### PR TITLE
Fix open connection race condition

### DIFF
--- a/internal/blocksync/reactor_test.go
+++ b/internal/blocksync/reactor_test.go
@@ -149,7 +149,6 @@ func makeReactor(
 		blockExec,
 		blockStore,
 		nil,
-		channelCreator,
 		peerEvents,
 		true,
 		consensus.NopMetrics(),

--- a/internal/consensus/reactor_test.go
+++ b/internal/consensus/reactor_test.go
@@ -85,23 +85,6 @@ func setup(
 	ctx, cancel := context.WithCancel(ctx)
 	t.Cleanup(cancel)
 
-	chCreator := func(nodeID types.NodeID) p2p.ChannelCreator {
-		return func(ctx context.Context, desc *p2p.ChannelDescriptor) (*p2p.Channel, error) {
-			switch desc.ID {
-			case StateChannel:
-				return rts.stateChannels[nodeID], nil
-			case DataChannel:
-				return rts.dataChannels[nodeID], nil
-			case VoteChannel:
-				return rts.voteChannels[nodeID], nil
-			case VoteSetBitsChannel:
-				return rts.voteSetBitsChannels[nodeID], nil
-			default:
-				return nil, fmt.Errorf("invalid channel; %v", desc.ID)
-			}
-		}
-	}
-
 	i := 0
 	for nodeID, node := range rts.network.Nodes {
 		state := states[i]
@@ -109,7 +92,6 @@ func setup(
 		reactor := NewReactor(
 			state.logger.With("node", nodeID),
 			state,
-			chCreator(nodeID),
 			func(ctx context.Context) *p2p.PeerUpdates { return node.MakePeerUpdates(ctx, t) },
 			state.eventBus,
 			true,
@@ -695,7 +677,6 @@ func TestSwitchToConsensusVoteExtensions(t *testing.T) {
 			reactor := NewReactor(
 				log.NewNopLogger(),
 				cs,
-				nil,
 				nil,
 				cs.eventBus,
 				true,

--- a/internal/evidence/reactor_test.go
+++ b/internal/evidence/reactor_test.go
@@ -96,13 +96,8 @@ func setup(ctx context.Context, t *testing.T, stateStores []sm.Store) *reactorTe
 		rts.network.Nodes[nodeID].PeerManager.Register(ctx, pu)
 		rts.nodes = append(rts.nodes, rts.network.Nodes[nodeID])
 
-		chCreator := func(ctx context.Context, chdesc *p2p.ChannelDescriptor) (*p2p.Channel, error) {
-			return rts.evidenceChannels[nodeID], nil
-		}
-
 		rts.reactors[nodeID] = evidence.NewReactor(
 			logger,
-			chCreator,
 			func(ctx context.Context) *p2p.PeerUpdates { return pu },
 			rts.pools[nodeID])
 

--- a/internal/mempool/reactor_test.go
+++ b/internal/mempool/reactor_test.go
@@ -58,7 +58,7 @@ func setupReactors(ctx context.Context, t *testing.T, logger log.Logger, numNode
 		peerUpdates:     make(map[types.NodeID]*p2p.PeerUpdates, numNodes),
 	}
 
-	chDesc := getChannelDescriptor(cfg.Mempool)
+	chDesc := GetChannelDescriptor(cfg.Mempool)
 	rts.mempoolChannels = rts.network.MakeChannelsNoCleanup(ctx, t, chDesc)
 
 	for nodeID := range rts.network.Nodes {
@@ -75,15 +75,10 @@ func setupReactors(ctx context.Context, t *testing.T, logger log.Logger, numNode
 		rts.peerUpdates[nodeID] = p2p.NewPeerUpdates(rts.peerChans[nodeID], 1)
 		rts.network.Nodes[nodeID].PeerManager.Register(ctx, rts.peerUpdates[nodeID])
 
-		chCreator := func(ctx context.Context, chDesc *p2p.ChannelDescriptor) (*p2p.Channel, error) {
-			return rts.mempoolChannels[nodeID], nil
-		}
-
 		rts.reactors[nodeID] = NewReactor(
 			rts.logger.With("nodeID", nodeID),
 			cfg.Mempool,
 			mempool,
-			chCreator,
 			func(ctx context.Context) *p2p.PeerUpdates { return rts.peerUpdates[nodeID] },
 		)
 		rts.nodes = append(rts.nodes, nodeID)

--- a/internal/p2p/router.go
+++ b/internal/p2p/router.go
@@ -112,33 +112,33 @@ func (o *RouterOptions) Validate() error {
 //
 // On startup, three main goroutines are spawned to maintain peer connections:
 //
-//   dialPeers(): in a loop, calls PeerManager.DialNext() to get the next peer
-//   address to dial and spawns a goroutine that dials the peer, handshakes
-//   with it, and begins to route messages if successful.
+//	dialPeers(): in a loop, calls PeerManager.DialNext() to get the next peer
+//	address to dial and spawns a goroutine that dials the peer, handshakes
+//	with it, and begins to route messages if successful.
 //
-//   acceptPeers(): in a loop, waits for an inbound connection via
-//   Transport.Accept() and spawns a goroutine that handshakes with it and
-//   begins to route messages if successful.
+//	acceptPeers(): in a loop, waits for an inbound connection via
+//	Transport.Accept() and spawns a goroutine that handshakes with it and
+//	begins to route messages if successful.
 //
-//   evictPeers(): in a loop, calls PeerManager.EvictNext() to get the next
-//   peer to evict, and disconnects it by closing its message queue.
+//	evictPeers(): in a loop, calls PeerManager.EvictNext() to get the next
+//	peer to evict, and disconnects it by closing its message queue.
 //
 // When a peer is connected, an outbound peer message queue is registered in
 // peerQueues, and routePeer() is called to spawn off two additional goroutines:
 //
-//   sendPeer(): waits for an outbound message from the peerQueues queue,
-//   marshals it, and passes it to the peer transport which delivers it.
+//	sendPeer(): waits for an outbound message from the peerQueues queue,
+//	marshals it, and passes it to the peer transport which delivers it.
 //
-//   receivePeer(): waits for an inbound message from the peer transport,
-//   unmarshals it, and passes it to the appropriate inbound channel queue
-//   in channelQueues.
+//	receivePeer(): waits for an inbound message from the peer transport,
+//	unmarshals it, and passes it to the appropriate inbound channel queue
+//	in channelQueues.
 //
 // When a reactor opens a channel via OpenChannel, an inbound channel message
 // queue is registered in channelQueues, and a channel goroutine is spawned:
 //
-//   routeChannel(): waits for an outbound message from the channel, looks
-//   up the recipient peer's outbound message queue in peerQueues, and submits
-//   the message to it.
+//	routeChannel(): waits for an outbound message from the channel, looks
+//	up the recipient peer's outbound message queue in peerQueues, and submits
+//	the message to it.
 //
 // All channel sends in the router are blocking. It is the responsibility of the
 // queue interface in peerQueues and channelQueues to prioritize and drop
@@ -172,6 +172,13 @@ type Router struct {
 	channelMtx      sync.RWMutex
 	channelQueues   map[ChannelID]queue // inbound messages from all peers to a single channel
 	channelMessages map[ChannelID]proto.Message
+
+	chDescsToBeAdded []chDescAdderWithCallback
+}
+
+type chDescAdderWithCallback struct {
+	chDesc *ChannelDescriptor
+	cb     func(*Channel)
 }
 
 // NewRouter creates a new Router. The given Transports must already be
@@ -946,6 +953,13 @@ func (r *Router) setupQueueFactory(ctx context.Context) error {
 	return nil
 }
 
+func (r *Router) AddChDescToBeAdded(chDesc *ChannelDescriptor, callback func(*Channel)) {
+	r.chDescsToBeAdded = append(r.chDescsToBeAdded, chDescAdderWithCallback{
+		chDesc: chDesc,
+		cb:     callback,
+	})
+}
+
 // OnStart implements service.Service.
 func (r *Router) OnStart(ctx context.Context) error {
 	if err := r.setupQueueFactory(ctx); err != nil {
@@ -954,6 +968,14 @@ func (r *Router) OnStart(ctx context.Context) error {
 
 	if err := r.transport.Listen(r.endpoint); err != nil {
 		return err
+	}
+
+	for _, chDescWithCb := range r.chDescsToBeAdded {
+		if ch, err := r.OpenChannel(ctx, chDescWithCb.chDesc); err != nil {
+			return err
+		} else {
+			chDescWithCb.cb(ch)
+		}
 	}
 
 	go r.dialPeers(ctx)

--- a/internal/statesync/reactor_test.go
+++ b/internal/statesync/reactor_test.go
@@ -133,21 +133,6 @@ func setup(
 
 	cfg := config.DefaultStateSyncConfig()
 
-	chCreator := func(ctx context.Context, desc *p2p.ChannelDescriptor) (*p2p.Channel, error) {
-		switch desc.ID {
-		case SnapshotChannel:
-			return rts.snapshotChannel, nil
-		case ChunkChannel:
-			return rts.chunkChannel, nil
-		case LightBlockChannel:
-			return rts.blockChannel, nil
-		case ParamsChannel:
-			return rts.paramsChannel, nil
-		default:
-			return nil, fmt.Errorf("invalid channel; %v", desc.ID)
-		}
-	}
-
 	logger := log.NewNopLogger()
 
 	rts.reactor = NewReactor(
@@ -156,7 +141,6 @@ func setup(
 		*cfg,
 		logger.With("component", "reactor"),
 		conn,
-		chCreator,
 		func(context.Context) *p2p.PeerUpdates { return rts.peerUpdates },
 		rts.stateStore,
 		rts.blockStore,

--- a/node/seed.go
+++ b/node/seed.go
@@ -81,6 +81,7 @@ func makeSeedNode(
 			closer)
 	}
 
+	pexReactor := pex.NewReactor(logger, peerManager, peerManager.Subscribe)
 	node := &seedNodeImpl{
 		config:     cfg,
 		logger:     logger,
@@ -92,8 +93,9 @@ func makeSeedNode(
 
 		shutdownOps: closer,
 
-		pexReactor: pex.NewReactor(logger, peerManager, router.OpenChannel, peerManager.Subscribe),
+		pexReactor: pexReactor,
 	}
+	node.router.AddChDescToBeAdded(pex.ChannelDescriptor(), pexReactor.SetChannel)
 	node.BaseService = *service.NewBaseService(logger, "SeedNode", node)
 
 	return node, nil

--- a/node/setup.go
+++ b/node/setup.go
@@ -27,7 +27,6 @@ import (
 	"github.com/tendermint/tendermint/internal/store"
 	"github.com/tendermint/tendermint/libs/log"
 	tmnet "github.com/tendermint/tendermint/libs/net"
-	"github.com/tendermint/tendermint/libs/service"
 	tmstrings "github.com/tendermint/tendermint/libs/strings"
 	"github.com/tendermint/tendermint/privval"
 	tmgrpc "github.com/tendermint/tendermint/privval/grpc"
@@ -146,8 +145,7 @@ func createMempoolReactor(
 	store sm.Store,
 	memplMetrics *mempool.Metrics,
 	peerEvents p2p.PeerEventSubscriber,
-	chCreator p2p.ChannelCreator,
-) (service.Service, mempool.Mempool) {
+) (*mempool.Reactor, mempool.Mempool) {
 	logger = logger.With("module", "mempool")
 
 	mp := mempool.NewTxMempool(
@@ -163,7 +161,6 @@ func createMempoolReactor(
 		logger,
 		cfg.Mempool,
 		mp,
-		chCreator,
 		peerEvents,
 	)
 
@@ -181,7 +178,6 @@ func createEvidenceReactor(
 	store sm.Store,
 	blockStore *store.BlockStore,
 	peerEvents p2p.PeerEventSubscriber,
-	chCreator p2p.ChannelCreator,
 	metrics *evidence.Metrics,
 	eventBus *eventbus.EventBus,
 ) (*evidence.Reactor, *evidence.Pool, closer, error) {
@@ -193,7 +189,7 @@ func createEvidenceReactor(
 	logger = logger.With("module", "evidence")
 
 	evidencePool := evidence.NewPool(logger, evidenceDB, store, blockStore, metrics, eventBus)
-	evidenceReactor := evidence.NewReactor(logger, chCreator, peerEvents, evidencePool)
+	evidenceReactor := evidence.NewReactor(logger, peerEvents, evidencePool)
 
 	return evidenceReactor, evidencePool, evidenceDB.Close, nil
 }


### PR DESCRIPTION
Previously it's possible for peer connections established without having all descriptors registered. This PR waits synchronously for descriptor registration before proceeding to establish peer connections.