### PR TITLE
Bump block part size and delay fsync

### DIFF
--- a/internal/consensus/replay.go
+++ b/internal/consensus/replay.go
@@ -82,7 +82,7 @@ func (cs *State) readReplayMessage(ctx context.Context, msg *TimedWALMessage, ne
 				"blockID", v.BlockID, "peer", peerID)
 		}
 
-		cs.handleMsg(ctx, m)
+		cs.handleMsg(ctx, m, false)
 	case timeoutInfo:
 		cs.logger.Info("Replay: Timeout", "height", m.Height, "round", m.Round, "step", m.Step, "dur", m.Duration)
 		cs.handleTimeout(ctx, m, cs.RoundState)

--- a/types/params.go
+++ b/types/params.go
@@ -18,7 +18,7 @@ const (
 	MaxBlockSizeBytes = 104857600 // 100MB
 
 	// BlockPartSizeBytes is the size of one block part.
-	BlockPartSizeBytes uint32 = 65536 // 64kB
+	BlockPartSizeBytes uint32 = 1048576 // 1MB
 
 	// MaxBlockPartsCount is the maximum number of block parts.
 	MaxBlockPartsCount = (MaxBlockSizeBytes / BlockPartSizeBytes) + 1


### PR DESCRIPTION
- Bump block part size to 1MB
- Only fsync if the proposer has received all block parts