### PR TITLE
Add Tx notification threshold

### DIFF
--- a/config/toml.go
+++ b/config/toml.go
@@ -396,6 +396,8 @@ ttl-duration = "{{ .Mempool.TTLDuration }}"
 # it's insertion time into the mempool is beyond ttl-duration.
 ttl-num-blocks = {{ .Mempool.TTLNumBlocks }}
 
+tx-notify-threshold = {{ .Mempool.TxNotifyThreshold }}
+
 #######################################################
 ###         State Sync Configuration Options        ###
 #######################################################

--- a/internal/mempool/mempool.go
+++ b/internal/mempool/mempool.go
@@ -837,6 +837,11 @@ func (txmp *TxMempool) notifyTxsAvailable() {
 		panic("attempt to notify txs available but mempool is empty!")
 	}
 
+	if txmp.Size() < txmp.config.TxNotifyThreshold {
+		// not reaching the threshold yet. Holding off from notification
+		return
+	}
+
 	if txmp.txsAvailable != nil && !txmp.notifiedTxsAvailable {
 		// channel cap is 1, so this will send once
 		txmp.notifiedTxsAvailable = true


### PR DESCRIPTION
Add a config that allows node to specify the minimum number of transactions needed for mempool to notify consensus state machine about transactions. For example, if this config is set as 10, then the node would not start to propose block unless the minimum threshold is met.