### PR TITLE
Check for missing tx before block creation

### DIFF
--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -2428,7 +2428,6 @@ func (cs *State) tryCreateProposalBlock(ctx context.Context, height int64, round
 // Build a proposal block from mempool txs. If cs.config.GossipTransactionKeyOnly=true
 // proposals only contain txKeys so we rebuild the block using mempool txs
 func (cs *State) buildProposalBlock(height int64, header types.Header, lastCommit *types.Commit, evidence []types.Evidence, proposerAddress types.Address, txKeys []types.TxKey) *types.Block {
-	block := cs.state.MakeBlock(height, cs.blockExec.GetTxsForKeys(txKeys), lastCommit, evidence, proposerAddress)
 	missingTxs := cs.blockExec.GetMissingTxs(txKeys)
 	if len(missingTxs) > 0 {
 		cs.metrics.ProposalMissingTxs.Set(float64(len(missingTxs)))
@@ -2436,6 +2435,7 @@ func (cs *State) buildProposalBlock(height int64, header types.Header, lastCommi
 		return nil
 	}
 	txs := cs.blockExec.GetTxsForKeys(txKeys)
+	block := cs.state.MakeBlock(height, cs.blockExec.GetTxsForKeys(txKeys), lastCommit, evidence, proposerAddress)
 	block.Version = header.Version
 	block.Data.Txs = txs
 	block.DataHash = block.Data.Hash(true)


### PR DESCRIPTION
## Describe your changes and provide context
We run into nil pointers if we try to create a block without ensuring that the tx exists in the mempool. We should do a check beforehand.
## Testing performed to validate your change
Ran local docker cluster and sent tx. made sure it worked:
```
tendermint # curl localhost:26657/tx?hash=88D4266FD4E6338D13B845FCF289579D209C897823B9217DA3E161936F031589
{"hash":"88D4266FD4E6338D13B845FCF289579D209C897823B9217DA3E161936F031589","height":"20","index":0,"tx_result":{"events":[{"type":"app","attributes":[{"key":"creator","value":"Cosmoshi Netowoko","index":true},{"key":"key","value":"abcd","index":true},{"key":"index_key","value":"index is working","index":true},{"key":"noindex_key","value":"index is working","index":false}]}]},"tx":"YWJjZA==","proof":{"root_hash":"","data":null,"proof":{"total":"0","index":"0","leaf_hash":null,"aunts":null}}}/tendermint #
```
