### PR TITLE
Vote nil if proposal block is nil

### DIFF
--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -1624,7 +1624,6 @@ func (cs *State) defaultDoPrevote(ctx context.Context, height int64, round int32
 	if cs.config.GossipTransactionKeyOnly && cs.Proposal != nil && cs.ProposalBlock == nil {
 		txKeys := cs.Proposal.TxKeys
 		if cs.ProposalBlockParts.IsComplete() {
-			logger.Info("gossip done")
 			block, err := cs.getBlockFromBlockParts()
 			if err != nil {
 				cs.logger.Error("Encountered error building block from parts", "block parts", cs.ProposalBlockParts)
@@ -1637,14 +1636,14 @@ func (cs *State) defaultDoPrevote(ctx context.Context, height int64, round int32
 			}
 			cs.ProposalBlock = proposalBlock
 		}
-		logger.Info("gossipsss")
 	}
 
-	logger.Info(fmt.Sprintf("cs.Proposal: %s", cs.Proposal))
-	logger.Info(fmt.Sprintf("cs.Proposal.Timestamp: %s", cs.Proposal.Timestamp))
-	logger.Info(fmt.Sprintf("cs.ProposalBlock: %s", cs.ProposalBlock))
-	logger.Info(fmt.Sprintf("cs.ProposalBlock.Header.ChainID: %s", cs.ProposalBlock.Header.ChainID))
-	logger.Info(fmt.Sprintf("cs.ProposalBlock.Header.Time: %s", cs.ProposalBlock.Header.Time))
+	// If ProposalBlock is still nil, prevote nil.
+	if cs.ProposalBlock == nil {
+		logger.Debug("prevote step: ProposalBlock is nil")
+		cs.signAddVote(ctx,tmproto.PrevoteType, nil, types.PartSetHeader{})
+		return
+	}
 
 	if !cs.Proposal.Timestamp.Equal(cs.ProposalBlock.Header.Time) {
 		logger.Info("prevote step: proposal timestamp not equal; prevoting nil")

--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -1624,6 +1624,7 @@ func (cs *State) defaultDoPrevote(ctx context.Context, height int64, round int32
 	if cs.config.GossipTransactionKeyOnly && cs.Proposal != nil && cs.ProposalBlock == nil {
 		txKeys := cs.Proposal.TxKeys
 		if cs.ProposalBlockParts.IsComplete() {
+			logger.Info("gossip done")
 			block, err := cs.getBlockFromBlockParts()
 			if err != nil {
 				cs.logger.Error("Encountered error building block from parts", "block parts", cs.ProposalBlockParts)
@@ -1636,7 +1637,14 @@ func (cs *State) defaultDoPrevote(ctx context.Context, height int64, round int32
 			}
 			cs.ProposalBlock = proposalBlock
 		}
+		logger.Info("gossipsss")
 	}
+
+	logger.Info(fmt.Sprintf("cs.Proposal: %s", cs.Proposal))
+	logger.Info(fmt.Sprintf("cs.Proposal.Timestamp: %s", cs.Proposal.Timestamp))
+	logger.Info(fmt.Sprintf("cs.ProposalBlock: %s", cs.ProposalBlock))
+	logger.Info(fmt.Sprintf("cs.ProposalBlock.Header.ChainID: %s", cs.ProposalBlock.Header.ChainID))
+	logger.Info(fmt.Sprintf("cs.ProposalBlock.Header.Time: %s", cs.ProposalBlock.Header.Time))
 
 	if !cs.Proposal.Timestamp.Equal(cs.ProposalBlock.Header.Time) {
 		logger.Info("prevote step: proposal timestamp not equal; prevoting nil")


### PR DESCRIPTION
## Describe your changes and provide context
two of the loadtest cluster nodes got stuck as it kept panicking due to a nil proposal block 
```
Nov 18 03:14:53 ip-172-31-36-34 seid[2631731]: 3:14AM INF Replay: Timeout dur=3000 height=676073 module=consensus round=0 step=3
Nov 18 03:14:53 ip-172-31-36-34 seid[2631731]: 3:14AM INF entering prevote step current=676073/0/RoundStepPropose height=676073 module=consensus round=0
Nov 18 03:14:53 ip-172-31-36-34 seid[2631731]: panic: runtime error: invalid memory address or nil pointer dereference [recovered]
Nov 18 03:14:53 ip-172-31-36-34 seid[2631731]:         panic: runtime error: invalid memory address or nil pointer dereference
Nov 18 03:14:53 ip-172-31-36-34 seid[2631731]: [signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0x1095cf8]
Nov 18 03:14:53 ip-172-31-36-34 seid[2631731]: goroutine 245 [running]:
Nov 18 03:14:53 ip-172-31-36-34 seid[2631731]: go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End.func1()
Nov 18 03:14:53 ip-172-31-36-34 seid[2631731]:         /root/go/pkg/mod/go.opentelemetry.io/otel/sdk@v1.9.0/trace/span.go:363 +0x2a
Nov 18 03:14:53 ip-172-31-36-34 seid[2631731]: go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End(0xc0009c5980, {0x0, 0x0, 0xc0008fe480?})
Nov 18 03:14:53 ip-172-31-36-34 seid[2631731]:         /root/go/pkg/mod/go.opentelemetry.io/otel/sdk@v1.9.0/trace/span.go:402 +0x8ee
Nov 18 03:14:53 ip-172-31-36-34 seid[2631731]: panic({0x1c69a80, 0x376c820})
Nov 18 03:14:53 ip-172-31-36-34 seid[2631731]:         /usr/lib/go-1.19/src/runtime/panic.go:884 +0x212
Nov 18 03:14:53 ip-172-31-36-34 seid[2631731]: github.com/tendermint/tendermint/internal/consensus.(*State).defaultDoPrevote(0xc0008fe480, {0x28817e8, 0xc000702cc0}, 0x1?, 0x0?)
Nov 18 03:14:53 ip-172-31-36-34 seid[2631731]:         /root/go/pkg/mod/github.com/sei-protocol/sei-tendermint@v0.1.59/internal/consensus/state.go:1641 +0x3b8
Nov 18 03:14:53 ip-172-31-36-34 seid[2631731]: github.com/tendermint/tendermint/internal/consensus.(*State).enterPrevote(0xc0008fe480, {0x28817e8, 0xc000702cc0}, 0xa50e9, 0x0, {0x1eea0cf, 0x7})
Nov 18 03:14:53 ip-172-31-36-34 seid[2631731]:         /root/go/pkg/mod/github.com/sei-protocol/sei-tendermint@v0.1.59/internal/consensus/state.go:1597 +0xaaa
Nov 18 03:14:53 ip-172-31-36-34 seid[2631731]: github.com/tendermint/tendermint/internal/consensus.(*State).handleTimeout(0xc0008fe480, {0x28817e8, 0xc000702cc0}, {0x1cc1c60?, _, _, _}, {0xa50e9, 0x0, 0x3, ...})
Nov 18 03:14:53 ip-172-31-36-34 seid[2631731]:         /root/go/pkg/mod/github.com/sei-protocol/sei-tendermint@v0.1.59/internal/consensus/state.go:1175 +0x69f
Nov 18 03:14:53 ip-172-31-36-34 seid[2631731]: github.com/tendermint/tendermint/internal/consensus.(*State).readReplayMessage(0xc0008fe480, {0x28817e8, 0xc000702cc0}, 0xc00449de40?, {0x0?, 0x0?})
Nov 18 03:14:53 ip-172-31-36-34 seid[2631731]:         /root/go/pkg/mod/github.com/sei-protocol/sei-tendermint@v0.1.59/internal/consensus/replay.go:88 +0x1309
Nov 18 03:14:53 ip-172-31-36-34 seid[2631731]: github.com/tendermint/tendermint/internal/consensus.(*State).catchupReplay(0xc0008fe480, {0x28817e8, 0xc000702cc0}, 0xa50e9)
Nov 18 03:14:53 ip-172-31-36-34 seid[2631731]:         /root/go/pkg/mod/github.com/sei-protocol/sei-tendermint@v0.1.59/internal/consensus/replay.go:164 +0x74e
Nov 18 03:14:53 ip-172-31-36-34 seid[2631731]: github.com/tendermint/tendermint/internal/consensus.(*State).OnStart(0xc0008fe480, {0x28817e8?, 0xc000702cc0})
Nov 18 03:14:53 ip-172-31-36-34 seid[2631731]:         /root/go/pkg/mod/github.com/sei-protocol/sei-tendermint@v0.1.59/internal/consensus/state.go:443 +0x206
Nov 18 03:14:53 ip-172-31-36-34 seid[2631731]: github.com/tendermint/tendermint/libs/service.(*BaseService).Start(0xc0008fe480, {0x28817e8?, 0xc000702cc0})
Nov 18 03:14:53 ip-172-31-36-34 seid[2631731]:         /root/go/pkg/mod/github.com/sei-protocol/sei-tendermint@v0.1.59/libs/service/service.go:114 +0x227
Nov 18 03:14:53 ip-172-31-36-34 seid[2631731]: github.com/tendermint/tendermint/internal/consensus.(*Reactor).SwitchToConsensus(_, {_, _}, {{{0xb, 0x0}, {0xc0002ac4e0, 0x11}}, {0xc0002ac4f8, 0x14}, 0x1, ...}, ...)
Nov 18 03:14:53 ip-172-31-36-34 seid[2631731]:         /root/go/pkg/mod/github.com/sei-protocol/sei-tendermint@v0.1.59/internal/consensus/reactor.go:264 +0x11b
Nov 18 03:14:53 ip-172-31-36-34 seid[2631731]: github.com/tendermint/tendermint/internal/blocksync.(*Reactor).poolRoutine(0xc000a64000, {0x28817e8, 0xc000702cc0}, 0x0, 0xc000c06270?)
Nov 18 03:14:53 ip-172-31-36-34 seid[2631731]:         /root/go/pkg/mod/github.com/sei-protocol/sei-tendermint@v0.1.59/internal/blocksync/reactor.go:520 +0xfa2
Nov 18 03:14:53 ip-172-31-36-34 seid[2631731]: created by github.com/tendermint/tendermint/internal/blocksync.(*Reactor).OnStart
Nov 18 03:14:53 ip-172-31-36-34 seid[2631731]:         /root/go/pkg/mod/github.com/sei-protocol/sei-tendermint@v0.1.59/internal/blocksync/reactor.go:162 +0x5df
Nov 18 03:14:53 ip-172-31-36-34 systemd[1]: seid.service: Main process exited, code=exited, status=2/INVALIDARGUMENT
Nov 18 03:14:53 ip-172-31-36-34 systemd[1]: seid.service: Failed with result 'exit-code'.
Nov 18 03:14:53 ip-172-31-36-34 systemd[1]: seid.service: Scheduled restart job, restart counter is at 189277.
```


This logic was changed when we made the gossip proposal change, it should just be an if statement I believe

discord link: https://discord.com/channels/973057323805311026/1042955400535867443/1043001719069605928

## Testing performed to validate your change
Pushed changes to one of the nodes and see that it no longer panics and is able to proceed

<img width="783" alt="image" src="https://user-images.githubusercontent.com/18161326/202624432-ad98018b-ea61-4c8d-ac28-442fd110a3d8.png">

