### PR TITLE
CheckTx for txs from peer proposal

### DIFF
--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -1648,7 +1648,7 @@ func (cs *State) defaultDoPrevote(ctx context.Context, height int64, round int32
 				return
 			}
 			if block == nil {
-				logger.Debug("prevote step: ProposalBlock is nil")
+				logger.Error("prevote step: ProposalBlock is nil")
 				cs.signAddVote(ctx, tmproto.PrevoteType, nil, types.PartSetHeader{})
 				return
 			}
@@ -1673,17 +1673,10 @@ func (cs *State) defaultDoPrevote(ctx context.Context, height int64, round int32
 		// if there is still any missing tx, it means CheckTx failed on application level for some txs, and
 		// we should not vote for this block
 		if len(missingTxKeys) > 0 {
-			logger.Debug("prevote step: CheckTx failed for some txs")
+			logger.Error("prevote step: CheckTx failed for some txs")
 			cs.signAddVote(ctx, tmproto.PrevoteType, nil, types.PartSetHeader{})
 			return
 		}
-	}
-
-	// If ProposalBlock is still nil, prevote nil.
-	if cs.ProposalBlock == nil {
-		logger.Debug("prevote step: ProposalBlock is nil")
-		cs.signAddVote(ctx, tmproto.PrevoteType, nil, types.PartSetHeader{})
-		return
 	}
 
 	if !cs.Proposal.Timestamp.Equal(cs.ProposalBlock.Header.Time) {

--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -1620,22 +1620,61 @@ func (cs *State) defaultDoPrevote(ctx context.Context, height int64, round int32
 		return
 	}
 
-	// If we're not the proposer, we need to build the block
-	if cs.config.GossipTransactionKeyOnly && cs.Proposal != nil && cs.ProposalBlock == nil {
-		txKeys := cs.Proposal.TxKeys
-		if cs.ProposalBlockParts.IsComplete() {
+	if cs.config.GossipTransactionKeyOnly {
+		if cs.ProposalBlock == nil {
+			// If we're not the proposer, we need to build the block
+			txKeys := cs.Proposal.TxKeys
+			if cs.ProposalBlockParts.IsComplete() {
+				block, err := cs.getBlockFromBlockParts()
+				if err != nil {
+					cs.logger.Error("Encountered error building block from parts", "block parts", cs.ProposalBlockParts)
+					return
+				}
+				// We have full proposal block and txs. Build proposal block with txKeys
+				proposalBlock := cs.buildProposalBlock(height, block.Header, block.LastCommit, block.Evidence, block.ProposerAddress, txKeys)
+				if proposalBlock == nil {
+					return
+				}
+				cs.ProposalBlock = proposalBlock
+			} else {
+				return
+			}
+		}
+	} else {
+		if cs.ProposalBlock == nil {
 			block, err := cs.getBlockFromBlockParts()
 			if err != nil {
 				cs.logger.Error("Encountered error building block from parts", "block parts", cs.ProposalBlockParts)
 				return
 			}
-			// We have full proposal block and txs. Build proposal block with txKeys
-			proposalBlock := cs.buildProposalBlock(height, block.Header, block.LastCommit, block.Evidence, block.ProposerAddress, txKeys)
-			if proposalBlock == nil {
+			if block == nil {
+				logger.Debug("prevote step: ProposalBlock is nil")
+				cs.signAddVote(ctx, tmproto.PrevoteType, nil, types.PartSetHeader{})
 				return
 			}
-			cs.ProposalBlock = proposalBlock
-		} else {
+			cs.ProposalBlock = block
+		}
+		txKeys := cs.Proposal.TxKeys
+		// add missing tx keys to the mempool for CheckTx
+		missingTxKeys := cs.blockExec.GetMissingTxs(txKeys)
+		blockTxKeyToTx := map[types.TxKey]types.Tx{}
+		for _, tx := range cs.ProposalBlock.Txs {
+			blockTxKeyToTx[tx.Key()] = tx
+		}
+		for _, missingTxKey := range missingTxKeys {
+			if tx, ok := blockTxKeyToTx[missingTxKey]; !ok {
+				cs.logger.Error("Mismatch between cs.Proposal.TxKeys and cs.ProposalBlock.Txs")
+				return
+			} else {
+				cs.blockExec.CheckTxFromPeerProposal(ctx, tx)
+			}
+		}
+		missingTxKeys = cs.blockExec.GetMissingTxs(txKeys)
+		// if there is still any missing tx, it means CheckTx failed on application level for some txs, and
+		// we should not vote for this block
+		if len(missingTxKeys) > 0 {
+			logger.Debug("prevote step: CheckTx failed for some txs")
+			cs.signAddVote(ctx, tmproto.PrevoteType, nil, types.PartSetHeader{})
 			return
 		}
 	}
@@ -1643,7 +1682,7 @@ func (cs *State) defaultDoPrevote(ctx context.Context, height int64, round int32
 	// If ProposalBlock is still nil, prevote nil.
 	if cs.ProposalBlock == nil {
 		logger.Debug("prevote step: ProposalBlock is nil")
-		cs.signAddVote(ctx,tmproto.PrevoteType, nil, types.PartSetHeader{})
+		cs.signAddVote(ctx, tmproto.PrevoteType, nil, types.PartSetHeader{})
 		return
 	}
 


### PR DESCRIPTION
## Describe your changes and provide context
At the moment, if a tx is all of the following:
- proposal by tx key is not turned on
- received as part of a block proposal from other peers
- not received via gossip on mempool level
then `CheckTx` won't be run for it, which could cause problems with ante handlers that are CheckTx-only (e.g. min gas config check).

This PR makes it such that for txs from peer proposal that are not already in the local mempool, the validator will run `CheckTx` for them before prevoting the proposed block. Note that `CheckTx` will also insert the tx into the local mempool if the application check passes.

## Testing performed to validate your change
tested with local chain
**will test with multiple nodes with mempool gossiping turned off once merged and released**
