### PR TITLE
Error if there's dupe connections

### DIFF
--- a/internal/p2p/peermanager.go
+++ b/internal/p2p/peermanager.go
@@ -576,7 +576,6 @@ func (m *PeerManager) Dialed(address NodeAddress) error {
 	}
 	if m.connected[address.NodeID] {
 		dupeConnectionErr := fmt.Errorf("cant dial, peer=%q is already connected", address.NodeID)
-		m.evictPeer(address.NodeID, dupeConnectionErr)
 		return dupeConnectionErr
 	}
 	if m.options.MaxConnected > 0 && len(m.connected) >= int(m.options.MaxConnected) {
@@ -645,7 +644,6 @@ func (m *PeerManager) Accepted(peerID types.NodeID) error {
 	}
 	if m.connected[peerID] {
 		dupeConnectionErr := fmt.Errorf("can't accept, peer=%q is already connected", peerID)
-		m.evictPeer(peerID, dupeConnectionErr)
 		return dupeConnectionErr
 	}
 	if m.options.MaxConnected > 0 &&
@@ -796,10 +794,6 @@ func (m *PeerManager) Errored(peerID types.NodeID, err error) {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
 
-	m.evictPeer(peerID, err)
-}
-
-func (m *PeerManager) evictPeer(peerID types.NodeID, err error) {
 	if m.connected[peerID] {
 		m.evict[peerID] = true
 	}

--- a/internal/p2p/peermanager.go
+++ b/internal/p2p/peermanager.go
@@ -576,8 +576,8 @@ func (m *PeerManager) Dialed(address NodeAddress) error {
 	}
 	if m.connected[address.NodeID] {
 		dupeConnectionErr := fmt.Errorf("peer %q is already connected", address.NodeID)
-		m.Errored(address.NodeID, dupeConnectionErr)
-		return fmt.Errorf("peer %v is already connected", address.NodeID)
+		go m.Errored(address.NodeID, dupeConnectionErr)
+		return dupeConnectionErr
 	}
 	if m.options.MaxConnected > 0 && len(m.connected) >= int(m.options.MaxConnected) {
 		if upgradeFromPeer == "" || len(m.connected) >=
@@ -645,7 +645,7 @@ func (m *PeerManager) Accepted(peerID types.NodeID) error {
 	}
 	if m.connected[peerID] {
 		dupeConnectionErr := fmt.Errorf("peer %q is already connected", peerID)
-		m.Errored(peerID, dupeConnectionErr)
+		go m.Errored(peerID, dupeConnectionErr)
 		return dupeConnectionErr
 	}
 	if m.options.MaxConnected > 0 &&

--- a/internal/p2p/peermanager.go
+++ b/internal/p2p/peermanager.go
@@ -575,6 +575,8 @@ func (m *PeerManager) Dialed(address NodeAddress) error {
 		return fmt.Errorf("rejecting connection to self (%v)", address.NodeID)
 	}
 	if m.connected[address.NodeID] {
+		dupeConnectionErr := fmt.Errorf("peer %q is already connected", address.NodeID)
+		m.Errored(address.NodeID, dupeConnectionErr)
 		return fmt.Errorf("peer %v is already connected", address.NodeID)
 	}
 	if m.options.MaxConnected > 0 && len(m.connected) >= int(m.options.MaxConnected) {
@@ -642,7 +644,9 @@ func (m *PeerManager) Accepted(peerID types.NodeID) error {
 		return fmt.Errorf("rejecting connection from self (%v)", peerID)
 	}
 	if m.connected[peerID] {
-		return fmt.Errorf("peer %q is already connected", peerID)
+		dupeConnectionErr := fmt.Errorf("peer %q is already connected", peerID)
+		m.Errored(peerID, dupeConnectionErr)
+		return dupeConnectionErr
 	}
 	if m.options.MaxConnected > 0 &&
 		len(m.connected) >= int(m.options.MaxConnected)+int(m.options.MaxConnectedUpgrade) {

--- a/internal/p2p/pex/reactor.go
+++ b/internal/p2p/pex/reactor.go
@@ -179,9 +179,6 @@ func (r *Reactor) processPexCh(ctx context.Context, pexCh *p2p.Channel) {
 				// channel just because of an error here?
 			}
 
-			// Note we do not update the poll timer upon making a request, only
-			// when we receive an update that updates our priors.
-
 		case envelope, ok := <-incoming:
 			if !ok {
 				return // channel closed
@@ -311,8 +308,7 @@ func (r *Reactor) sendRequestForPeers(ctx context.Context, pexCh *p2p.Channel) e
 	defer r.mtx.Unlock()
 	if len(r.availablePeers) == 0 {
 		// no peers are available
-		r.logger.Error("no available peers to send a PEX request to (retrying)")
-		return nil
+		panic("no available peers to send a PEX request to")
 	}
 
 	// Select an arbitrary peer from the available set.

--- a/internal/p2p/pex/reactor.go
+++ b/internal/p2p/pex/reactor.go
@@ -308,7 +308,8 @@ func (r *Reactor) sendRequestForPeers(ctx context.Context, pexCh *p2p.Channel) e
 	defer r.mtx.Unlock()
 	if len(r.availablePeers) == 0 {
 		// no peers are available
-		panic("no available peers to send a PEX request to")
+		r.logger.Error("no available peers to send a PEX request to (retrying)")
+		return nil
 	}
 
 	// Select an arbitrary peer from the available set.

--- a/internal/p2p/pex/reactor.go
+++ b/internal/p2p/pex/reactor.go
@@ -311,7 +311,7 @@ func (r *Reactor) sendRequestForPeers(ctx context.Context, pexCh *p2p.Channel) e
 	defer r.mtx.Unlock()
 	if len(r.availablePeers) == 0 {
 		// no peers are available
-		r.logger.Debug("no available peers to send a PEX request to (retrying)")
+		r.logger.Error("no available peers to send a PEX request to (retrying)")
 		return nil
 	}
 

--- a/internal/p2p/router.go
+++ b/internal/p2p/router.go
@@ -8,6 +8,7 @@ import (
 	"math/rand"
 	"net"
 	"runtime"
+	"strings"
 	"sync"
 	"time"
 
@@ -546,6 +547,10 @@ func (r *Router) openConnection(ctx context.Context, conn Connection) {
 	}
 
 	if err := r.runWithPeerMutex(func() error { return r.peerManager.Accepted(peerInfo.NodeID) }); err != nil {
+		// If peer is trying to reconnect, fail it and let it reconnect
+		if strings.Contains(err.Error(), "is already connected") {
+			r.peerManager.Errored(peerInfo.NodeID, err)
+		}
 		r.logger.Error("failed to accept connection",
 			"op", "incoming/accepted", "peer", peerInfo.NodeID, "err", err)
 		return
@@ -637,6 +642,11 @@ func (r *Router) connectPeer(ctx context.Context, address NodeAddress) {
 	}
 
 	if err := r.runWithPeerMutex(func() error { return r.peerManager.Dialed(address) }); err != nil {
+		// If peer is trying to reconnect, fail it and let it reconnect
+		if strings.Contains(err.Error(), "is already connected") {
+			r.peerManager.Disconnected(ctx, address.NodeID)
+		}
+
 		r.logger.Error("failed to dial peer",
 			"op", "outgoing/dialing", "peer", address.NodeID, "err", err)
 		conn.Close()

--- a/internal/p2p/router.go
+++ b/internal/p2p/router.go
@@ -547,7 +547,7 @@ func (r *Router) openConnection(ctx context.Context, conn Connection) {
 	}
 
 	if err := r.runWithPeerMutex(func() error { return r.peerManager.Accepted(peerInfo.NodeID) }); err != nil {
-		// If peer is trying to reconnect, fail it and let it reconnect
+		// If peer is trying to reconnect, error and let it reconnect
 		if strings.Contains(err.Error(), "is already connected") {
 			r.peerManager.Errored(peerInfo.NodeID, err)
 		}


### PR DESCRIPTION
## Describe your changes and provide context
The peers fall into an unrecoverable state if they already have a connection to another peer and they try to connect again. 

It seems like Peer A lost its connection to Peer B, but Peer B's mapping was not updated to be aware of this. So when Peer A tries to connect to peer B again, it fails. Therefore if we get a duplicate request where the peer is already connected, we should Error out the existing connection AND return error, this way if it retries it can successfully connect 

```
Dec 12 15:02:02 ip-172-31-33-167 seid[16502]: 3:02PM ERR failed to accept connection err="peer \"4b336938f10433839baf727999e78965dcbae4d5\" is already connected" module=p2p op=incoming/accepted peer=4b336938f10433839baf727999e78965dcbae4d5
Dec 12 15:02:02 ip-172-31-33-167 seid[16502]: 3:02PM INF stopping service module=p2p peer={"Hostname":"3.22.225.111","NodeID":"4b336938f10433839baf727999e78965dcbae4d5","Path":"","Port":58322,"Protocol":"mconn"} service=MConnection
Dec 12 15:02:03 ip-172-31-33-167 seid[16502]: 3:02PM INF starting service impl=MConnection module=p2p peer={"Hostname":"3.143.253.100","NodeID":"53dd9f3b8edf7e37ddd6ee152d0eec205181752b","Path":"","Port":26656,"Protocol":"mconn"} service=MConnection
Dec 12 15:02:03 ip-172-31-33-167 seid[16502]: 3:02PM INF peer connected endpoint={} module=p2p peer=53dd9f3b8edf7e37ddd6ee152d0eec205181752b
Dec 12 15:02:03 ip-172-31-33-167 seid[16502]: 3:02PM INF Connection is closed @ recvRoutine (likely by the other side) conn={} module=p2p peer={"Hostname":"3.143.253.100","NodeID":"53dd9f3b8edf7e37ddd6ee152d0eec205181752b","Path":"","Port":26656,"Protocol":"mconn"}
Dec 12 15:02:03 ip-172-31-33-167 seid[16502]: 3:02PM INF stopping service module=p2p peer={"Hostname":"3.143.253.100","NodeID":"53dd9f3b8edf7e37ddd6ee152d0eec205181752b","Path":"","Port":26656,"Protocol":"mconn"} service=MConnection
Dec 12 15:02:03 ip-172-31-33-167 seid[16502]: 3:02PM INF received peer update module=statesync peer=53dd9f3b8edf7e37ddd6ee152d0eec205181752b status=up
Dec 12 15:02:03 ip-172-31-33-167 seid[16502]: 3:02PM INF peer disconnected endpoint={} module=p2p peer=53dd9f3b8edf7e37ddd6ee152d0eec205181752b
Dec 12 15:02:03 ip-172-31-33-167 seid[16502]: 3:02PM INF received peer update module=statesync peer=53dd9f3b8edf7e37ddd6ee152d0eec205181752b status=down
Dec 12 15:02:03 ip-172-31-33-167 seid[16502]: 3:02PM INF starting service impl=MConnection module=p2p peer={"Hostname":"3.22.225.111","NodeID":"4b336938f10433839baf727999e78965dcbae4d5","Path":"","Port":58324,"Protocol":"mconn"} service=MConnection
Dec 12 15:02:03 ip-172-31-33-167 seid[16502]: 3:02PM ERR failed to accept connection err="peer \"4b336938f10433839baf727999e78965dcbae4d5\" is already connected" module=p2p op=incoming/accepted peer=4b336938f10433839baf727999e78965dcbae4d5
Dec 12 15:02:03 ip-172-31-33-167 seid[16502]: 3:02PM INF stopping service module=p2p peer={"Hostname":"3.22.225.111","NodeID":"4b336938f10433839baf727999e78965dcbae4d5","Path":"","Port":58324,"Protocol":"mconn"} service=MConnection
Dec 12 15:02:03 ip-172-31-33-167 seid[16502]: 3:02PM INF starting service impl=MConnection module=p2p peer={"Hostname":"3.143.253.100","NodeID":"53dd9f3b8edf7e37ddd6ee152d0eec205181752b","Path":"","Port":26656,"Protocol":"mconn"} service=MConnection
Dec 12 15:02:03 ip-172-31-33-167 seid[16502]: 3:02PM INF peer connected endpoint={} module=p2p peer=53dd9f3b8edf7e37ddd6ee152d0eec205181752b
Dec 12 15:02:03 ip-172-31-33-167 seid[16502]: 3:02PM INF Connection is closed @ recvRoutine (likely by the other side) conn={} module=p2p peer={"Hostname":"3.143.253.100","NodeID":"53dd9f3b8edf7e37ddd6ee152d0eec205181752b","Path":"","Port":26656,"Protocol":"mconn"}
Dec 12 15:02:03 ip-172-31-33-167 seid[16502]: 3:02PM INF stopping service module=p2p peer={"Hostname":"3.143.253.100","NodeID":"53dd9f3b8edf7e37ddd6ee152d0eec205181752b","Path":"","Port":26656,"Protocol":"mconn"} service=MConnection
Dec 12 15:02:03 ip-172-31-33-167 seid[16502]: 3:02PM INF received peer update module=statesync peer=53dd9f3b8edf7e37ddd6ee152d0eec205181752b status=up
Dec 12 15:02:03 ip-172-31-33-167 seid[16502]: 3:02PM INF peer disconnected endpoint={} module=p2p peer=53dd9f3b8edf7e37ddd6ee152d0eec205181752b
Dec 12 15:02:03 ip-172-31-33-167 seid[16502]: 3:02PM INF received peer update module=statesync peer=53dd9f3b8edf7e37ddd6ee152d0eec205181752b status=down
Dec 12 15:02:04 ip-172-31-33-167 seid[16502]: 3:02PM INF starting service impl=MConnection module=p2p peer={"Hostname":"3.22.225.111","NodeID":"4b336938f10433839baf727999e78965dcbae4d5","Path":"","Port":58326,"Protocol":"mconn"} service=MConnection
Dec 12 15:02:04 ip-172-31-33-167 seid[16502]: 3:02PM ERR failed to accept connection err="peer \"4b336938f10433839baf727999e78965dcbae4d5\" is already connected" module=p2p op=incoming/accepted peer=4b336938f10433839baf727999e78965dcbae4d5
Dec 12 15:02:04 ip-172-31-33-167 seid[16502]: 3:02PM INF stopping service module=p2p peer={"Hostname":"3.22.225.111","NodeID":"4b336938f10433839baf727999e78965dcbae4d5","Path":"","Port":58326,"Protocol":"mconn"} service=MConnection
Dec 12 15:02:05 ip-172-31-33-167 seid[16502]: 3:02PM INF starting service impl=MConnection module=p2p peer={"Hostname":"3.22.225.111","NodeID":"4b336938f10433839baf727999e78965dcbae4d5","Path":"","Port":58328,"Protocol":"mconn"} service=MConnection
Dec 12 15:02:05 ip-172-31-33-167 seid[16502]: 3:02PM ERR failed to accept connection err="peer \"4b336938f10433839baf727999e78965dcbae4d5\" is already connected" module=p2p op=incoming/accepted peer=4b336938f10433839baf727999e78965dcbae4d5
Dec 12 15:02:05 ip-172-31-33-167 seid[16502]: 3:02PM INF stopping service module=p2p peer={"Hostname":"3.22.225.111","NodeID":"4b336938f10433839baf727999e78965dcbae4d5","Path":"","Port":58328,"Protocol":"mconn"} service=MConnection
```

## Testing performed to validate your change
Deployed this in a test cluster and deployed to Peer B, and saw that the Peer A was then able to connect to Peer B again 
