### PR TITLE
[0 Gas] add counter for CheckTx failures

### DIFF
--- a/internal/mempool/mempool_test.go
+++ b/internal/mempool/mempool_test.go
@@ -636,3 +636,36 @@ func TestTxMempool_CheckTxPostCheckError(t *testing.T) {
 		})
 	}
 }
+
+func TestTxMempool_FailedCheckTxCount(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	client := abciclient.NewLocalClient(log.NewNopLogger(), &application{Application: kvstore.NewApplication()})
+	if err := client.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(client.Wait)
+
+	postCheckFn := func(_ types.Tx, _ *abci.ResponseCheckTx) error {
+		return nil
+	}
+	txmp := setup(t, client, 0, WithPostCheck(postCheckFn))
+	tx := []byte("bad tx")
+
+	callback := func(res *abci.ResponseCheckTx) {
+		require.Equal(t, nil, txmp.postCheck(tx, res))
+	}
+	// bad tx
+	require.NoError(t, txmp.CheckTx(ctx, tx, callback, TxInfo{SenderID: 0, SenderNodeID: "sender"}))
+	require.Equal(t, uint64(1), txmp.GetPeerFailedCheckTxCount("sender"))
+
+	// bad tx again
+	require.NoError(t, txmp.CheckTx(ctx, tx, callback, TxInfo{SenderID: 0, SenderNodeID: "sender"}))
+	require.Equal(t, uint64(2), txmp.GetPeerFailedCheckTxCount("sender"))
+
+	tx = []byte("sender=key=1")
+	// good tx
+	require.NoError(t, txmp.CheckTx(ctx, tx, callback, TxInfo{SenderID: 0, SenderNodeID: "sender"}))
+	require.Equal(t, uint64(2), txmp.GetPeerFailedCheckTxCount("sender"))
+}

--- a/internal/mempool/mempool_test.go
+++ b/internal/mempool/mempool_test.go
@@ -656,6 +656,7 @@ func TestTxMempool_FailedCheckTxCount(t *testing.T) {
 	callback := func(res *abci.ResponseCheckTx) {
 		require.Equal(t, nil, txmp.postCheck(tx, res))
 	}
+	require.Equal(t, uint64(0), txmp.GetPeerFailedCheckTxCount("sender"))
 	// bad tx
 	require.NoError(t, txmp.CheckTx(ctx, tx, callback, TxInfo{SenderID: 0, SenderNodeID: "sender"}))
 	require.Equal(t, uint64(1), txmp.GetPeerFailedCheckTxCount("sender"))


### PR DESCRIPTION
## Describe your changes and provide context
Keep track of CheckTx failures per peer with a map + a mutex. The scope of the newly introduce mutex doesn't overlap with any existing mutex so there would be no deadlock. Also exposed a method for objects outside mempool to query CheckTx failures.

## Testing performed to validate your change
unit test

