### PR TITLE
Add node ID filtering for peers blacklisted due to CheckTx failures

### DIFF
--- a/internal/p2p/p2ptest/network.go
+++ b/internal/p2p/p2ptest/network.go
@@ -268,6 +268,7 @@ func (n *Network) MakeNode(ctx context.Context, t *testing.T, opts NodeOptions) 
 		func() *types.NodeInfo { return &nodeInfo },
 		transport,
 		ep,
+		nil,
 		p2p.RouterOptions{DialSleep: func(_ context.Context) {}},
 	)
 

--- a/internal/p2p/router_init_test.go
+++ b/internal/p2p/router_init_test.go
@@ -23,7 +23,7 @@ func TestRouter_ConstructQueueFactory(t *testing.T) {
 	t.Run("Default", func(t *testing.T) {
 		require.Zero(t, os.Getenv("TM_P2P_QUEUE"))
 		opts := RouterOptions{}
-		r, err := NewRouter(log.NewNopLogger(), nil, nil, nil, func() *types.NodeInfo { return &types.NodeInfo{} }, nil, nil, opts)
+		r, err := NewRouter(log.NewNopLogger(), nil, nil, nil, func() *types.NodeInfo { return &types.NodeInfo{} }, nil, nil, nil, opts)
 		require.NoError(t, err)
 		require.NoError(t, r.setupQueueFactory(ctx))
 
@@ -32,7 +32,7 @@ func TestRouter_ConstructQueueFactory(t *testing.T) {
 	})
 	t.Run("Fifo", func(t *testing.T) {
 		opts := RouterOptions{QueueType: queueTypeFifo}
-		r, err := NewRouter(log.NewNopLogger(), nil, nil, nil, func() *types.NodeInfo { return &types.NodeInfo{} }, nil, nil, opts)
+		r, err := NewRouter(log.NewNopLogger(), nil, nil, nil, func() *types.NodeInfo { return &types.NodeInfo{} }, nil, nil, nil, opts)
 		require.NoError(t, err)
 		require.NoError(t, r.setupQueueFactory(ctx))
 
@@ -41,7 +41,7 @@ func TestRouter_ConstructQueueFactory(t *testing.T) {
 	})
 	t.Run("Priority", func(t *testing.T) {
 		opts := RouterOptions{QueueType: queueTypePriority}
-		r, err := NewRouter(log.NewNopLogger(), nil, nil, nil, func() *types.NodeInfo { return &types.NodeInfo{} }, nil, nil, opts)
+		r, err := NewRouter(log.NewNopLogger(), nil, nil, nil, func() *types.NodeInfo { return &types.NodeInfo{} }, nil, nil, nil, opts)
 		require.NoError(t, err)
 		require.NoError(t, r.setupQueueFactory(ctx))
 
@@ -51,7 +51,7 @@ func TestRouter_ConstructQueueFactory(t *testing.T) {
 	})
 	t.Run("NonExistant", func(t *testing.T) {
 		opts := RouterOptions{QueueType: "fast"}
-		_, err := NewRouter(log.NewNopLogger(), nil, nil, nil, func() *types.NodeInfo { return &types.NodeInfo{} }, nil, nil, opts)
+		_, err := NewRouter(log.NewNopLogger(), nil, nil, nil, func() *types.NodeInfo { return &types.NodeInfo{} }, nil, nil, nil, opts)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "fast")
 	})

--- a/node/setup.go
+++ b/node/setup.go
@@ -308,6 +308,7 @@ func createRouter(
 		nodeInfoProducer,
 		transport,
 		ep,
+		nil, // TODO: replace with mempool CheckTx failure based filterer
 		getRouterConfig(cfg, appClient),
 	)
 }


### PR DESCRIPTION
## Describe your changes and provide context
This PR allows registering a dynamic node ID filterer on the p2p router. The dynamic filterer can be based on mempool CheckTx failure counts.

The stages of  adding a peer look like:
1. the process is notified of a connection request. Nothing about the sender is known at this point.
2. the process "Accept()" the request. At this point the IP of the sender is known.
3. the process "handshake()" the request (not TCP handshake but an application concept). At this point the node ID is known.
4. the process registers the node ID and starts to process its messages.

The filtering in this PR happens between 3 and 4. Alternatively it's also possible to filter (by IP) between 2 and 3. However this requires maintaining a mapping between IP and node ID, which could be an additional bug surface area whereas doesn't give us significant gain.

## Testing performed to validate your change
unit tests

