### PR TITLE
[0 Gas] evict peer connection if they send too many transactions failing CheckTx

### DIFF
--- a/config/toml.go
+++ b/config/toml.go
@@ -398,6 +398,10 @@ ttl-num-blocks = {{ .Mempool.TTLNumBlocks }}
 
 tx-notify-threshold = {{ .Mempool.TxNotifyThreshold }}
 
+check-tx-error-blacklist-enabled = {{ .Mempool.CheckTxErrorBlacklistEnabled }}
+
+check-tx-error-threshold = {{ .Mempool.CheckTxErrorThreshold }}
+
 #######################################################
 ###         State Sync Configuration Options        ###
 #######################################################

--- a/internal/consensus/common_test.go
+++ b/internal/consensus/common_test.go
@@ -485,6 +485,7 @@ func newStateWithConfigAndBlockStore(
 		logger.With("module", "mempool"),
 		thisConfig.Mempool,
 		proxyAppConnMem,
+		nil,
 	)
 
 	if thisConfig.Consensus.WaitForTxs() {

--- a/internal/consensus/reactor_test.go
+++ b/internal/consensus/reactor_test.go
@@ -472,6 +472,7 @@ func TestReactorWithEvidence(t *testing.T) {
 			log.NewNopLogger().With("module", "mempool"),
 			thisConfig.Mempool,
 			proxyAppConnMem,
+			nil,
 		)
 
 		if thisConfig.Consensus.WaitForTxs() {

--- a/internal/mempool/types.go
+++ b/internal/mempool/types.go
@@ -151,3 +151,7 @@ func PostCheckMaxGas(maxGas int64) PostCheckFunc {
 		return nil
 	}
 }
+
+type PeerEvictor interface {
+	Errored(types.NodeID, error)
+}

--- a/node/node.go
+++ b/node/node.go
@@ -270,7 +270,7 @@ func makeNode(
 	node.evPool = evPool
 
 	mpReactor, mp := createMempoolReactor(logger, cfg, proxyApp, stateStore, nodeMetrics.mempool,
-		peerManager.Subscribe)
+		peerManager.Subscribe, peerManager)
 	node.router.AddChDescToBeAdded(mempool.GetChannelDescriptor(cfg.Mempool), mpReactor.SetChannel)
 	node.rpcEnv.Mempool = mp
 	node.services = append(node.services, mpReactor)

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -296,6 +296,7 @@ func TestCreateProposalBlock(t *testing.T) {
 		logger.With("module", "mempool"),
 		cfg.Mempool,
 		proxyApp,
+		nil,
 	)
 
 	// Make EvidencePool
@@ -398,6 +399,7 @@ func TestMaxTxsProposalBlockSize(t *testing.T) {
 		logger.With("module", "mempool"),
 		cfg.Mempool,
 		proxyApp,
+		nil,
 	)
 
 	// fill the mempool with one txs just below the maximum size
@@ -468,6 +470,7 @@ func TestMaxProposalBlockSize(t *testing.T) {
 		logger.With("module", "mempool"),
 		cfg.Mempool,
 		proxyApp,
+		nil,
 	)
 
 	// fill the mempool with one txs just below the maximum size

--- a/node/setup.go
+++ b/node/setup.go
@@ -145,6 +145,7 @@ func createMempoolReactor(
 	store sm.Store,
 	memplMetrics *mempool.Metrics,
 	peerEvents p2p.PeerEventSubscriber,
+	peerManager *p2p.PeerManager,
 ) (*mempool.Reactor, mempool.Mempool) {
 	logger = logger.With("module", "mempool")
 
@@ -152,6 +153,7 @@ func createMempoolReactor(
 		logger,
 		cfg.Mempool,
 		appClient,
+		peerManager,
 		mempool.WithMetrics(memplMetrics),
 		mempool.WithPreCheck(sm.TxPreCheckFromStore(store)),
 		mempool.WithPostCheck(sm.TxPostCheckFromStore(store)),


### PR DESCRIPTION
## Describe your changes and provide context
- Added two new mempool configs: one controls whether blacklisting feature is on and the other indicates the threshold (over which a peer sending too many CheckTx-failing txs will be blacklisted if the former config is on)
- Evict peer if above threshold. Note that TM will retry connection, which would fail because a blacklisted node will not have connection established

## Testing performed to validate your change
unit test

