### PR TITLE
move around state checks

### DIFF
--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -1036,11 +1036,6 @@ func (cs *State) handleMsg(ctx context.Context, mi msgInfo, fsyncUponCompletion 
 		// once proposal is set, we can receive block parts
 		err = cs.setProposal(msg.Proposal, mi.ReceiveTime)
 
-		// See if it's possible to be nil
-		if cs.privValidatorPubKey == nil {
-			cs.logger.Info("cs.privValidatorPubKey is nil")
-		}
-
 		// See if we can try creating the proposal block if keys exist
 		if cs.config.GossipTransactionKeyOnly && cs.privValidatorPubKey != nil {
 			isProposer := cs.isProposer(cs.privValidatorPubKey.Address())

--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -1036,10 +1036,13 @@ func (cs *State) handleMsg(ctx context.Context, mi msgInfo, fsyncUponCompletion 
 		// once proposal is set, we can receive block parts
 		err = cs.setProposal(msg.Proposal, mi.ReceiveTime)
 		// See if we can try creating the proposal block if keys exist
-		if cs.config.GossipTransactionKeyOnly && !cs.isProposer(cs.privValidatorPubKey.Address()) && cs.ProposalBlock == nil {
-			created := cs.tryCreateProposalBlock(spanCtx, msg.Proposal.Height, msg.Proposal.Round, msg.Proposal.Header, msg.Proposal.LastCommit, msg.Proposal.Evidence, msg.Proposal.ProposerAddress)
-			if created {
-				cs.fsyncAndCompleteProposal(ctx, fsyncUponCompletion, msg.Proposal.Height, span)
+		if cs.config.GossipTransactionKeyOnly {
+			isProposer := cs.isProposer(cs.privValidatorPubKey.Address())
+			if !isProposer && cs.ProposalBlock == nil {
+				created := cs.tryCreateProposalBlock(spanCtx, msg.Proposal.Height, msg.Proposal.Round, msg.Proposal.Header, msg.Proposal.LastCommit, msg.Proposal.Evidence, msg.Proposal.ProposerAddress)
+				if created {
+					cs.fsyncAndCompleteProposal(ctx, fsyncUponCompletion, msg.Proposal.Height, span)
+				}
 			}
 		}
 

--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -1035,8 +1035,14 @@ func (cs *State) handleMsg(ctx context.Context, mi msgInfo, fsyncUponCompletion 
 		// will not cause transition.
 		// once proposal is set, we can receive block parts
 		err = cs.setProposal(msg.Proposal, mi.ReceiveTime)
+
+		// See if it's possible to be nil
+		if cs.privValidatorPubKey == nil {
+			cs.logger.Info("cs.privValidatorPubKey is nil")
+		}
+
 		// See if we can try creating the proposal block if keys exist
-		if cs.config.GossipTransactionKeyOnly {
+		if cs.config.GossipTransactionKeyOnly && cs.privValidatorPubKey != nil {
 			isProposer := cs.isProposer(cs.privValidatorPubKey.Address())
 			if !isProposer && cs.ProposalBlock == nil {
 				created := cs.tryCreateProposalBlock(spanCtx, msg.Proposal.Height, msg.Proposal.Round, msg.Proposal.Header, msg.Proposal.LastCommit, msg.Proposal.Evidence, msg.Proposal.ProposerAddress)


### PR DESCRIPTION
## Describe your changes and provide context
Should check if its nil before using it, other places also do the something

Right now if the proposal is nil, it'll fall behind on consensus error then when you restart, it'll catch up but then fall behind again. This is only possible for non-val nodes as this field will be nil 
## Testing performed to validate your change

![image](https://user-images.githubusercontent.com/18161326/212437863-fd51e4a0-4ee9-43b2-ba9d-5fb471289982.png)
