### PR TITLE
cherrypick unsafe-reset-all

### DIFF
--- a/cmd/tendermint/commands/reset.go
+++ b/cmd/tendermint/commands/reset.go
@@ -180,3 +180,23 @@ func ResetPeerStore(dbDir string) error {
 	}
 	return nil
 }
+
+func MakeUnsafeResetAllCommand(conf *config.Config, logger log.Logger) *cobra.Command {
+	var keyType string
+
+	resetAllCmd := &cobra.Command{
+		Use:   "unsafe-reset-all",
+		Short: "Removes all tendermint data including signing state",
+		Long: `Removes all tendermint data including signing state.
+Only use in testing. This can cause the node to double sign`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return ResetAll(conf.DBDir(), conf.PrivValidator.KeyFile(),
+				conf.PrivValidator.StateFile(), logger, keyType)
+		},
+	}
+
+	resetAllCmd.Flags().StringVar(&keyType, "key", types.ABCIPubKeyTypeEd25519,
+		"Signer key type. Options: ed25519, secp256k1")
+
+	return resetAllCmd
+}

--- a/cmd/tendermint/commands/reset_test.go
+++ b/cmd/tendermint/commands/reset_test.go
@@ -60,3 +60,27 @@ func Test_ResetState(t *testing.T) {
 	// private validator state should still be in tact.
 	require.Equal(t, int64(10), pv.LastSignState.Height)
 }
+
+func Test_UnsafeResetAll(t *testing.T) {
+	config := cfg.TestConfig()
+	dir := t.TempDir()
+	config.SetRoot(dir)
+	logger := log.NewNopLogger()
+	cfg.EnsureRoot(dir)
+	require.NoError(t, initFilesWithConfig(context.Background(), config, logger, types.ABCIPubKeyTypeEd25519))
+	pv, err := privval.LoadFilePV(config.PrivValidator.KeyFile(), config.PrivValidator.StateFile())
+	require.NoError(t, err)
+	pv.LastSignState.Height = 10
+	require.NoError(t, pv.Save())
+	require.NoError(t, ResetAll(config.DBDir(), config.PrivValidator.KeyFile(),
+		config.PrivValidator.StateFile(), logger, types.ABCIPubKeyTypeEd25519))
+	require.DirExists(t, config.DBDir())
+	require.NoFileExists(t, filepath.Join(config.DBDir(), "block.db"))
+	require.NoFileExists(t, filepath.Join(config.DBDir(), "state.db"))
+	require.NoFileExists(t, filepath.Join(config.DBDir(), "evidence.db"))
+	require.NoFileExists(t, filepath.Join(config.DBDir(), "tx_index.db"))
+	require.FileExists(t, config.PrivValidator.StateFile())
+	pv, err = privval.LoadFilePV(config.PrivValidator.KeyFile(), config.PrivValidator.StateFile())
+	require.NoError(t, err)
+	require.Equal(t, int64(0), pv.LastSignState.Height)
+}

--- a/cmd/tendermint/main.go
+++ b/cmd/tendermint/main.go
@@ -34,6 +34,7 @@ func main() {
 		commands.MakeReplayCommand(conf, logger),
 		commands.MakeReplayConsoleCommand(conf, logger),
 		commands.MakeResetCommand(conf, logger),
+		commands.MakeUnsafeResetAllCommand(conf, logger),
 		commands.MakeShowValidatorCommand(conf, logger),
 		commands.MakeTestnetFilesCommand(conf, logger),
 		commands.MakeShowNodeIDCommand(conf),


### PR DESCRIPTION
## Describe your changes and provide context
Cherrypick unsafe-reset-all based on https://github.com/tendermint/tendermint/blob/v0.37.0-rc1/cmd/tendermint/commands/reset.go#L16

Note that our tendermint version no longer uses an `AddrBook`, so it's not part of the reset

## Testing performed to validate your change
unit test
