### PR TITLE
[client] Fix https / wss conversion

### DIFF
--- a/rpc/jsonrpc/client/ws_client.go
+++ b/rpc/jsonrpc/client/ws_client.go
@@ -88,8 +88,10 @@ func NewWS(remoteAddr, endpoint string) (*WSClient, error) {
 	if err != nil {
 		return nil, err
 	}
-	// default to ws protocol, unless wss is explicitly specified
-	if parsedURL.Scheme != protoWSS {
+	// default to ws protocol, unless wss or https is specified
+	if parsedURL.Scheme == protoHTTPS {
+		parsedURL.Scheme = protoWSS
+	} else if parsedURL.Scheme != protoWSS {
 		parsedURL.Scheme = protoWS
 	}
 


### PR DESCRIPTION
## Describe your changes and provide context
This fixes the issue where https addr isn't converted to wss for websocket
found the issue here: https://github.com/sei-protocol/sei-tendermint/blob/46d0a598a7f5c67cbdefea37c8da18df2c25d184/rpc/jsonrpc/client/ws_client.go#L92 

tendermint repo does this fix: https://github.com/tendermint/tendermint/blob/64747b2b184184ecba4f4bffc54ffbcb47cfbcb0/rpc/jsonrpc/client/ws_client.go#L93 


## Testing performed to validate your change

