### PR TITLE
Cherrypick unconditional peers

### DIFF
--- a/cmd/tendermint/commands/run_node.go
+++ b/cmd/tendermint/commands/run_node.go
@@ -67,6 +67,8 @@ func AddNodeFlags(cmd *cobra.Command, conf *cfg.Config) {
 	cmd.Flags().Bool("p2p.upnp", conf.P2P.UPNP, "enable/disable UPNP port forwarding")
 	cmd.Flags().Bool("p2p.pex", conf.P2P.PexReactor, "enable/disable Peer-Exchange")
 	cmd.Flags().String("p2p.private-peer-ids", conf.P2P.PrivatePeerIDs, "comma-delimited private peer IDs")
+	cmd.Flags().String("p2p.unconditional_peer_ids",
+		conf.P2P.UnconditionalPeerIDs, "comma-delimited IDs of unconditional peers")
 
 	// consensus flags
 	cmd.Flags().Bool(

--- a/config/config.go
+++ b/config/config.go
@@ -665,6 +665,9 @@ type P2PConfig struct { //nolint: maligned
 	// layer uses. Options are: "fifo" and "priority",
 	// with the default being "priority".
 	QueueType string `mapstructure:"queue-type"`
+
+	// List of node IDs, to which a connection will be (re)established ignoring any existing limits
+	UnconditionalPeerIDs string `mapstructure:"unconditional-peer-ids"`
 }
 
 // DefaultP2PConfig returns a default configuration for the peer-to-peer layer

--- a/config/toml.go
+++ b/config/toml.go
@@ -342,6 +342,9 @@ send-rate = {{ .P2P.SendRate }}
 # TODO: Remove once MConnConnection is removed.
 recv-rate = {{ .P2P.RecvRate }}
 
+# List of node IDs, to which a connection will be (re)established ignoring any existing limits
+unconditional-peer-ids = "{{ .P2P.UnconditionalPeerIDs }}"
+
 
 #######################################################
 ###          Mempool Configuration Option          ###

--- a/node/setup.go
+++ b/node/setup.go
@@ -254,6 +254,10 @@ func createPeerManager(
 		peers = append(peers, address)
 	}
 
+	for _, p := range tmstrings.SplitAndTrimEmpty(cfg.P2P.UnconditionalPeerIDs, ",", " ") {
+		options.UnconditionalPeers = append(options.UnconditionalPeers, types.NodeID(p))
+	}
+
 	peerDB, err := dbProvider(&config.DBContext{ID: "peerstore", Config: cfg})
 	if err != nil {
 		return nil, func() error { return nil }, fmt.Errorf("unable to initialize peer store: %w", err)


### PR DESCRIPTION
## Describe your changes and provide context
Added unconditional peer based on v0.37.0-rc1 implementation, with the following differences:
- config field name is in `-` instead of `_` (if we want to change to `_` we might want to do it for all configs in a separate PR)
- implemented unconditional peer logics in `peermanager` instead of `switch` which was removed in the tendermint version we originally forked from

## Testing performed to validate your change
unit tests
