### PR TITLE
Default to validator mode on genesis 

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -44,7 +44,7 @@ var (
 	defaultConfigFileName  = "config.toml"
 	defaultGenesisJSONName = "genesis.json"
 
-	defaultMode             = ModeFull
+	defaultMode             = ModeValidator
 	defaultPrivValKeyName   = "priv_validator_key.json"
 	defaultPrivValStateName = "priv_validator_state.json"
 

--- a/config/config.go
+++ b/config/config.go
@@ -44,6 +44,8 @@ var (
 	defaultConfigFileName  = "config.toml"
 	defaultGenesisJSONName = "genesis.json"
 
+	// Default to Validator mode users must change config.toml to
+	// full or seed if they are bringing up other types of nodes
 	defaultMode             = ModeValidator
 	defaultPrivValKeyName   = "priv_validator_key.json"
 	defaultPrivValStateName = "priv_validator_state.json"


### PR DESCRIPTION
## Describe your changes and provide context
There was a lot of confusion around the default mode and validators all had to manually set the mode to the validator 

## Testing performed to validate your change

