### PR TITLE
[Bug Fix] Revert PR "Don't allow duplicates for light client providers #7781"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/creachadair/taskgroup v0.3.2
 	github.com/golangci/golangci-lint v1.46.0
 	github.com/google/go-cmp v0.5.8
-	github.com/vektra/mockery/v2 v2.12.3
+	github.com/vektra/mockery/v2 v2.14.0
 	gotest.tools v2.2.0+incompatible
 )
 

--- a/light/client.go
+++ b/light/client.go
@@ -175,6 +175,11 @@ func NewClient(
 		)
 	}
 
+	// Validate the number of witnesses.
+	if len(witnesses) < 1 {
+		return nil, ErrNoWitnesses
+	}
+
 	// Validate trust options
 	if err := trustOptions.ValidateBasic(); err != nil {
 		return nil, fmt.Errorf("invalid TrustOptions: %w", err)
@@ -1073,7 +1078,7 @@ func (c *Client) compareFirstHeaderWithWitnesses(ctx context.Context, h *types.S
 	defer c.providerMutex.Unlock()
 
 	if len(c.witnesses) < 1 {
-		return nil
+		return ErrNoWitnesses
 	}
 
 	errc := make(chan error, len(c.witnesses))

--- a/light/client.go
+++ b/light/client.go
@@ -142,20 +142,6 @@ type Client struct {
 	logger log.Logger
 }
 
-func validatePrimaryAndWitnesses(primary provider.Provider, witnesses []provider.Provider) error {
-	witnessMap := make(map[string]struct{})
-	for _, w := range witnesses {
-		if w.ID() == primary.ID() {
-			return fmt.Errorf("primary (%s) cannot be also configured as witness", primary.ID())
-		}
-		if _, duplicate := witnessMap[w.ID()]; duplicate {
-			return fmt.Errorf("witness list must not contain duplicates; duplicate found: %s", w.ID())
-		}
-		witnessMap[w.ID()] = struct{}{}
-	}
-	return nil
-}
-
 // NewClient returns a new light client. It returns an error if it fails to
 // obtain the light block from the primary, or they are invalid (e.g. trust
 // hash does not match with the one from the headers).
@@ -187,11 +173,6 @@ func NewClient(
 		return NewClientFromTrustedStore(
 			chainID, trustOptions.Period, primary, witnesses, trustedStore, options...,
 		)
-	}
-
-	// Check that the witness list does not include duplicates or the primary
-	if err := validatePrimaryAndWitnesses(primary, witnesses); err != nil {
-		return nil, err
 	}
 
 	// Validate trust options
@@ -240,11 +221,6 @@ func NewClientFromTrustedStore(
 	witnesses []provider.Provider,
 	trustedStore store.Store,
 	options ...Option) (*Client, error) {
-
-	// Check that the witness list does not include duplicates or the primary
-	if err := validatePrimaryAndWitnesses(primary, witnesses); err != nil {
-		return nil, err
-	}
 
 	c := &Client{
 		chainID:          chainID,
@@ -331,10 +307,10 @@ func (c *Client) initializeWithTrustOptions(ctx context.Context, options TrustOp
 // TrustedLightBlock returns a trusted light block at the given height (0 - the latest).
 //
 // It returns an error if:
-//  - there are some issues with the trusted store, although that should not
-//  happen normally;
-//  - negative height is passed;
-//  - header has not been verified yet and is therefore not in the store
+//   - there are some issues with the trusted store, although that should not
+//     happen normally;
+//   - negative height is passed;
+//   - header has not been verified yet and is therefore not in the store
 //
 // Safe for concurrent use by multiple goroutines.
 func (c *Client) TrustedLightBlock(height int64) (*types.LightBlock, error) {
@@ -448,8 +424,9 @@ func (c *Client) VerifyLightBlockAtHeight(ctx context.Context, height int64, now
 //
 // If the header, which is older than the currently trusted header, is
 // requested and the light client does not have it, VerifyHeader will perform:
-//		a) verifySkipping verification if nearest trusted header is found & not expired
-//		b) backwards verification in all other cases
+//
+//	a) verifySkipping verification if nearest trusted header is found & not expired
+//	b) backwards verification in all other cases
 //
 // It returns ErrOldHeaderExpired if the latest trusted header expired.
 //
@@ -930,12 +907,12 @@ func (c *Client) backwards(
 // lightBlockFromPrimary retrieves the lightBlock from the primary provider
 // at the specified height. This method also handles provider behavior as follows:
 //
-// 1. If the provider does not respond or does not have the block, it tries again
-//    with a different provider
-// 2. If all providers return the same error, the light client forwards the error to
-//    where the initial request came from
-// 3. If the provider provides an invalid light block, is deemed unreliable or returns
-//    any other error, the primary is permanently dropped and is replaced by a witness.
+//  1. If the provider does not respond or does not have the block, it tries again
+//     with a different provider
+//  2. If all providers return the same error, the light client forwards the error to
+//     where the initial request came from
+//  3. If the provider provides an invalid light block, is deemed unreliable or returns
+//     any other error, the primary is permanently dropped and is replaced by a witness.
 func (c *Client) lightBlockFromPrimary(ctx context.Context, height int64) (*types.LightBlock, error) {
 	c.providerMutex.Lock()
 	l, err := c.getLightBlock(ctx, c.primary, height)

--- a/light/client_benchmark_test.go
+++ b/light/client_benchmark_test.go
@@ -84,7 +84,7 @@ func BenchmarkSequence(b *testing.B) {
 			Hash:   genesisBlock.Hash(),
 		},
 		benchmarkFullNode,
-		nil,
+		[]provider.Provider{benchmarkFullNode},
 		dbs.New(dbm.NewMemDB()),
 		light.Logger(logger),
 		light.SequentialVerification(),
@@ -121,7 +121,7 @@ func BenchmarkBisection(b *testing.B) {
 			Hash:   genesisBlock.Hash(),
 		},
 		benchmarkFullNode,
-		nil,
+		[]provider.Provider{benchmarkFullNode},
 		dbs.New(dbm.NewMemDB()),
 		light.Logger(logger),
 	)
@@ -157,7 +157,7 @@ func BenchmarkBackwards(b *testing.B) {
 			Hash:   trustedBlock.Hash(),
 		},
 		benchmarkFullNode,
-		nil,
+		[]provider.Provider{benchmarkFullNode},
 		dbs.New(dbm.NewMemDB()),
 		light.Logger(logger),
 	)

--- a/light/detector.go
+++ b/light/detector.go
@@ -26,11 +26,6 @@ import (
 // If there are no conflictinge headers, the light client deems the verified target header
 // trusted and saves it to the trusted store.
 func (c *Client) detectDivergence(ctx context.Context, primaryTrace []*types.LightBlock, now time.Time) error {
-	c.providerMutex.Lock()
-	defer c.providerMutex.Unlock()
-	if len(c.witnesses) < 1 {
-		return nil
-	}
 	if primaryTrace == nil || len(primaryTrace) < 2 {
 		return errors.New("nil or single block primary trace")
 	}
@@ -41,6 +36,12 @@ func (c *Client) detectDivergence(ctx context.Context, primaryTrace []*types.Lig
 	)
 	c.logger.Debug("running detector against trace", "finalizeBlockHeight", lastVerifiedHeader.Height,
 		"finalizeBlockHash", lastVerifiedHeader.Hash, "length", len(primaryTrace))
+	c.providerMutex.Lock()
+	defer c.providerMutex.Unlock()
+
+	if len(c.witnesses) == 0 {
+		return ErrNoWitnesses
+	}
 
 	// launch one goroutine per witness to retrieve the light block of the target height
 	// and compare it with the header from the primary
@@ -103,7 +104,9 @@ func (c *Client) detectDivergence(ctx context.Context, primaryTrace []*types.Lig
 //
 // 1: errConflictingHeaders -> there may have been an attack on this light client
 // 2: errBadWitness -> the witness has either not responded, doesn't have the header or has given us an invalid one
-//    Note: In the case of an invalid header we remove the witness
+//
+//	Note: In the case of an invalid header we remove the witness
+//
 // 3: nil -> the hashes of the two headers match
 func (c *Client) compareNewHeaderWithWitness(ctx context.Context, errc chan error, h *types.SignedHeader,
 	witness provider.Provider, witnessIndex int) {
@@ -273,16 +276,16 @@ func (c *Client) handleConflictingHeaders(
 // it has received from another and preforms verifySkipping at the heights of each of the intermediate
 // headers in the trace until it reaches the divergentHeader. 1 of 2 things can happen.
 //
-// 1. The light client verifies a header that is different to the intermediate header in the trace. This
-//    is the bifurcation point and the light client can create evidence from it
-// 2. The source stops responding, doesn't have the block or sends an invalid header in which case we
-//    return the error and remove the witness
+//  1. The light client verifies a header that is different to the intermediate header in the trace. This
+//     is the bifurcation point and the light client can create evidence from it
+//  2. The source stops responding, doesn't have the block or sends an invalid header in which case we
+//     return the error and remove the witness
 //
 // CONTRACT:
-// 1. Trace can not be empty len(trace) > 0
-// 2. The last block in the trace can not be of a lower height than the target block
-//    trace[len(trace)-1].Height >= targetBlock.Height
-// 3. The
+//  1. Trace can not be empty len(trace) > 0
+//  2. The last block in the trace can not be of a lower height than the target block
+//     trace[len(trace)-1].Height >= targetBlock.Height
+//  3. The
 func (c *Client) examineConflictingHeaderAgainstTrace(
 	ctx context.Context,
 	trace []*types.LightBlock,

--- a/light/detector_test.go
+++ b/light/detector_test.go
@@ -3,6 +3,7 @@ package light_test
 import (
 	"bytes"
 	"context"
+	provider_mocks "github.com/tendermint/tendermint/light/provider/mocks"
 	"testing"
 	"time"
 
@@ -15,7 +16,6 @@ import (
 	"github.com/tendermint/tendermint/libs/log"
 	"github.com/tendermint/tendermint/light"
 	"github.com/tendermint/tendermint/light/provider"
-	provider_mocks "github.com/tendermint/tendermint/light/provider/mocks"
 	dbs "github.com/tendermint/tendermint/light/store/db"
 	"github.com/tendermint/tendermint/types"
 )
@@ -56,7 +56,7 @@ func TestLightClientAttackEvidence_Lunatic(t *testing.T) {
 	delete(primaryHeaders, 2)
 
 	mockWitness := mockNodeFromHeadersAndVals(witnessHeaders, witnessValidators)
-	mockWitness.On("ID").Return("mockWitness")
+	mockPrimary := mockNodeFromHeadersAndVals(primaryHeaders, primaryValidators)
 	mockWitness.On("ReportEvidence", mock.Anything, mock.MatchedBy(func(evidence types.Evidence) bool {
 		evAgainstPrimary := &types.LightClientAttackEvidence{
 			// after the divergence height the valset doesn't change so we expect the evidence to be for the latest height
@@ -69,8 +69,6 @@ func TestLightClientAttackEvidence_Lunatic(t *testing.T) {
 		return bytes.Equal(evidence.Hash(), evAgainstPrimary.Hash())
 	})).Return(nil)
 
-	mockPrimary := mockNodeFromHeadersAndVals(primaryHeaders, primaryValidators)
-	mockPrimary.On("ID").Return("mockPrimary")
 	mockPrimary.On("ReportEvidence", mock.Anything, mock.MatchedBy(func(evidence types.Evidence) bool {
 		evAgainstWitness := &types.LightClientAttackEvidence{
 			// when forming evidence against witness we learn that the canonical chain continued to change validator sets
@@ -174,13 +172,11 @@ func TestLightClientAttackEvidence_Equivocation(t *testing.T) {
 				delete(witnessHeaders, height)
 			}
 			mockWitness := mockNodeFromHeadersAndVals(witnessHeaders, witnessValidators)
-			mockWitness.On("ID").Return("mockWitness")
 
 			for _, height := range testCase.unusedPrimaryBlockHeights {
 				delete(primaryHeaders, height)
 			}
 			mockPrimary := mockNodeFromHeadersAndVals(primaryHeaders, primaryValidators)
-			mockPrimary.On("ID").Return("mockPrimary")
 
 			// Check evidence was sent to both full nodes.
 			// Common height should be set to the height of the divergent header in the instance
@@ -285,7 +281,6 @@ func TestLightClientAttackEvidence_ForwardLunatic(t *testing.T) {
 	mockPrimary.On("LightBlock", mock.Anything, mock.Anything).Return(nil, provider.ErrLightBlockNotFound)
 
 	mockWitness := mockNodeFromHeadersAndVals(witnessHeaders, witnessValidators)
-	mockWitness.On("ID").Return("mockWitness")
 	lastBlock, _ = mockWitness.LightBlock(ctx, latestHeight)
 	mockWitness.On("LightBlock", mock.Anything, int64(0)).Return(lastBlock, nil).Once()
 	mockWitness.On("LightBlock", mock.Anything, int64(12)).Return(nil, provider.ErrHeightTooHigh)
@@ -304,11 +299,7 @@ func TestLightClientAttackEvidence_ForwardLunatic(t *testing.T) {
 
 	// In order to perform the attack, the primary needs at least one accomplice as a witness to also
 	// send the forged block
-	accomplice := mockNodeFromHeadersAndVals(primaryHeaders, primaryValidators)
-	accomplice.On("ID").Return("accomplice")
-	lastBlock, _ = accomplice.LightBlock(ctx, forgedHeight)
-	accomplice.On("LightBlock", mock.Anything, int64(0)).Return(lastBlock, nil)
-	accomplice.On("LightBlock", mock.Anything, mock.Anything).Return(nil, provider.ErrLightBlockNotFound)
+	accomplice := mockPrimary
 
 	c, err := light.NewClient(
 		ctx,
@@ -367,7 +358,6 @@ func TestLightClientAttackEvidence_ForwardLunatic(t *testing.T) {
 	// Lastly we test the unfortunate case where the light clients supporting witness doesn't update
 	// in enough time
 	mockLaggingWitness := mockNodeFromHeadersAndVals(witnessHeaders, witnessValidators)
-	mockLaggingWitness.On("ID").Return("mockLaggingWitness")
 	mockLaggingWitness.On("LightBlock", mock.Anything, int64(12)).Return(nil, provider.ErrHeightTooHigh)
 	lastBlock, _ = mockLaggingWitness.LightBlock(ctx, latestHeight)
 	mockLaggingWitness.On("LightBlock", mock.Anything, int64(0)).Return(lastBlock, nil)
@@ -403,13 +393,11 @@ func TestClientDivergentTraces1(t *testing.T) {
 
 	headers, vals, _ := genLightBlocksWithKeys(t, 1, 5, 2, bTime)
 	mockPrimary := mockNodeFromHeadersAndVals(headers, vals)
-	mockPrimary.On("ID").Return("mockPrimary")
 
 	firstBlock, err := mockPrimary.LightBlock(ctx, 1)
 	require.NoError(t, err)
 	headers, vals, _ = genLightBlocksWithKeys(t, 1, 5, 2, bTime)
 	mockWitness := mockNodeFromHeadersAndVals(headers, vals)
-	mockWitness.On("ID").Return("mockWitness")
 
 	logger := log.NewNopLogger()
 
@@ -441,19 +429,8 @@ func TestClientDivergentTraces2(t *testing.T) {
 
 	headers, vals, _ := genLightBlocksWithKeys(t, 2, 5, 2, bTime)
 	mockPrimaryNode := mockNodeFromHeadersAndVals(headers, vals)
-	mockPrimaryNode.On("ID").Return("mockPrimaryNode")
-
-	mockGoodWitness := mockNodeFromHeadersAndVals(headers, vals)
-	mockGoodWitness.On("ID").Return("mockGoodWitness")
-
-	mockDeadNode1 := &provider_mocks.Provider{}
-	mockDeadNode1.On("ID").Return("mockDeadNode1")
-	mockDeadNode1.On("LightBlock", mock.Anything, mock.Anything).Return(nil, provider.ErrNoResponse)
-
-	mockDeadNode2 := &provider_mocks.Provider{}
-	mockDeadNode2.On("ID").Return("mockDeadNode2")
-	mockDeadNode2.On("LightBlock", mock.Anything, mock.Anything).Return(nil, provider.ErrNoResponse)
-
+	mockDeadNode := &provider_mocks.Provider{}
+	mockDeadNode.On("LightBlock", mock.Anything, mock.Anything).Return(nil, provider.ErrNoResponse)
 	firstBlock, err := mockPrimaryNode.LightBlock(ctx, 1)
 	require.NoError(t, err)
 	c, err := light.NewClient(
@@ -465,7 +442,7 @@ func TestClientDivergentTraces2(t *testing.T) {
 			Period: 4 * time.Hour,
 		},
 		mockPrimaryNode,
-		[]provider.Provider{mockDeadNode1, mockDeadNode2, mockGoodWitness},
+		[]provider.Provider{mockDeadNode, mockDeadNode, mockPrimaryNode},
 		dbs.New(dbm.NewMemDB()),
 		light.Logger(logger),
 	)
@@ -474,20 +451,19 @@ func TestClientDivergentTraces2(t *testing.T) {
 	_, err = c.VerifyLightBlockAtHeight(ctx, 2, bTime.Add(1*time.Hour))
 	assert.NoError(t, err)
 	assert.Equal(t, 3, len(c.Witnesses()))
-	mockDeadNode1.AssertExpectations(t)
+	mockDeadNode.AssertExpectations(t)
 	mockPrimaryNode.AssertExpectations(t)
 }
 
 // 3. witness has the same first header, but different second header
 // => creation should succeed, but the verification should fail
-//nolint: dupl
+// nolint: dupl
 func TestClientDivergentTraces3(t *testing.T) {
 	logger := log.NewNopLogger()
 
 	//
 	primaryHeaders, primaryVals, _ := genLightBlocksWithKeys(t, 2, 5, 2, bTime)
 	mockPrimary := mockNodeFromHeadersAndVals(primaryHeaders, primaryVals)
-	mockPrimary.On("ID").Return("mockPrimary")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -499,7 +475,6 @@ func TestClientDivergentTraces3(t *testing.T) {
 	mockHeaders[1] = primaryHeaders[1]
 	mockVals[1] = primaryVals[1]
 	mockWitness := mockNodeFromHeadersAndVals(mockHeaders, mockVals)
-	mockWitness.On("ID").Return("mockWitness")
 
 	c, err := light.NewClient(
 		ctx,
@@ -525,14 +500,13 @@ func TestClientDivergentTraces3(t *testing.T) {
 
 // 4. Witness has a divergent header but can not produce a valid trace to back it up.
 // It should be ignored
-//nolint: dupl
+// nolint: dupl
 func TestClientDivergentTraces4(t *testing.T) {
 	logger := log.NewNopLogger()
 
 	//
 	primaryHeaders, primaryVals, _ := genLightBlocksWithKeys(t, 2, 5, 2, bTime)
 	mockPrimary := mockNodeFromHeadersAndVals(primaryHeaders, primaryVals)
-	mockPrimary.On("ID").Return("mockPrimary")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -544,7 +518,6 @@ func TestClientDivergentTraces4(t *testing.T) {
 	primaryHeaders[2] = witnessHeaders[2]
 	primaryVals[2] = witnessVals[2]
 	mockWitness := mockNodeFromHeadersAndVals(primaryHeaders, primaryVals)
-	mockWitness.On("ID").Return("mockWitness")
 
 	c, err := light.NewClient(
 		ctx,

--- a/light/detector_test.go
+++ b/light/detector_test.go
@@ -275,7 +275,6 @@ func TestLightClientAttackEvidence_ForwardLunatic(t *testing.T) {
 		0, len(forgedKeys),
 	)
 	mockPrimary := mockNodeFromHeadersAndVals(primaryHeaders, primaryValidators)
-	mockPrimary.On("ID").Return("mockPrimary")
 	lastBlock, _ := mockPrimary.LightBlock(ctx, forgedHeight)
 	mockPrimary.On("LightBlock", mock.Anything, int64(0)).Return(lastBlock, nil)
 	mockPrimary.On("LightBlock", mock.Anything, mock.Anything).Return(nil, provider.ErrLightBlockNotFound)
@@ -381,7 +380,6 @@ func TestLightClientAttackEvidence_ForwardLunatic(t *testing.T) {
 	_, err = c.Update(ctx, bTime.Add(time.Duration(forgedHeight)*time.Minute))
 	assert.NoError(t, err)
 	mockPrimary.AssertExpectations(t)
-	mockWitness.AssertExpectations(t)
 }
 
 // 1. Different nodes therefore a divergent header is produced.

--- a/light/example_test.go
+++ b/light/example_test.go
@@ -2,6 +2,7 @@ package light_test
 
 import (
 	"context"
+	"github.com/tendermint/tendermint/light/provider"
 	"testing"
 	"time"
 
@@ -67,7 +68,7 @@ func TestExampleClient(t *testing.T) {
 			Hash:   block.Hash(),
 		},
 		primary,
-		nil,
+		[]provider.Provider{primary},
 		dbs.New(db),
 		light.Logger(logger),
 	)

--- a/light/light_test.go
+++ b/light/light_test.go
@@ -2,6 +2,7 @@ package light_test
 
 import (
 	"context"
+	"os"
 	"testing"
 	"time"
 
@@ -42,6 +43,9 @@ func TestClientIntegration_Update(t *testing.T) {
 	time.Sleep(5 * time.Second)
 
 	dbDir := t.TempDir()
+	require.NoError(t, err)
+	defer os.RemoveAll(dbDir)
+
 	chainID := conf.ChainID()
 
 	primary, err := httpp.New(chainID, conf.RPC.ListenAddress)
@@ -63,7 +67,7 @@ func TestClientIntegration_Update(t *testing.T) {
 			Hash:   block.Hash(),
 		},
 		primary,
-		nil,
+		[]provider.Provider{primary},
 		dbs.New(db),
 		light.Logger(logger),
 	)
@@ -120,7 +124,7 @@ func TestClientIntegration_VerifyLightBlockAtHeight(t *testing.T) {
 			Hash:   block.Hash(),
 		},
 		primary,
-		nil,
+		[]provider.Provider{primary},
 		dbs.New(db),
 		light.Logger(logger),
 	)
@@ -187,9 +191,9 @@ func TestClientStatusRPC(t *testing.T) {
 	db, err := dbm.NewGoLevelDB("light-client-db", dbDir)
 	require.NoError(t, err)
 
-	// In order to not create a full testnet we create the light client with no witnesses
-	// and only verify the primary IP address.
-	witnesses := []provider.Provider{}
+	// In order to not create a full testnet to verify whether we get the correct IPs
+	// if we have more than one witness, we add the primary multiple times
+	witnesses := []provider.Provider{primary, primary, primary}
 
 	c, err := light.NewClient(ctx,
 		chainID,


### PR DESCRIPTION
## Describe your changes and provide context
This original PR https://github.com/tendermint/tendermint/pull/7781 was introduced in Feb 2022, however it was later reverted and doesn't exist in latest master of open source. 

This change enforce us to use two different RPC DNS name for primary and witness address, which we believe is not necessary at this point given open source has already reverted.

## Testing performed to validate your change
Tested state sync with the fix
