### PR TITLE
[State Sync] Add backfill configurations for state sync

### DIFF
--- a/internal/statesync/reactor.go
+++ b/internal/statesync/reactor.go
@@ -419,9 +419,8 @@ func (r *Reactor) Sync(ctx context.Context) (sm.State, error) {
 // and time that is less or equal to the stopHeight and stopTime. The
 // trustedBlockID should be of the header at startHeight.
 func (r *Reactor) Backfill(ctx context.Context, state sm.State) error {
-	params := state.ConsensusParams.Evidence
-	stopHeight := state.LastBlockHeight - params.MaxAgeNumBlocks
-	stopTime := state.LastBlockTime.Add(-params.MaxAgeDuration)
+	stopHeight := state.LastBlockHeight - r.cfg.BackfillBlocks
+	stopTime := state.LastBlockTime.Add(-r.cfg.BackfillDuration)
 	// ensure that stop height doesn't go below the initial height
 	if stopHeight < state.InitialHeight {
 		stopHeight = state.InitialHeight


### PR DESCRIPTION
## Describe your changes and provide context
**Problem**:
The current issue is that tendermint enforce backfill until number of blocks reach max_age_num_blocks as well as backfill until 48 hours ago, controlled by max_age_duration. This means to complete the state sync, it will need to spend couple of hours doing backfill, this is not acceptable to fast bootstrap a RPC node.

Although this is configurable now, we do not want to change the genesis configuration in order to change the backfill behavior, because this config is also used in other places for different purposes, e.g. pruning.

**Solution**:
Ideally, we want a separate set of configurations to configure the backfill history for RPC node (Most RPC nodes doesn't need backfill at all)

This PR introduced two new startup configurations:

- backfill-blocks (maximum number of blocks to backfill)
- backfill-duration (backfill till the block time that is for this duration long ago)

## Testing performed to validate your change
Tested in set-devnet-2

