### PR TITLE
Fix tendermint state hard rollback logic

### DIFF
--- a/internal/state/rollback.go
+++ b/internal/state/rollback.go
@@ -98,13 +98,6 @@ func Rollback(bs BlockStore, ss Store, removeBlock bool, privValidatorConfig *co
 	rolledBackAppHash := latestBlock.Header.AppHash
 	rolledBackLastResultHash := latestBlock.Header.LastResultsHash
 
-	// When removing the latest block, the rolledback state should reflect the previous block instead
-	// of the block that's going to be removed
-	if removeBlock {
-		rolledBackAppHash = rollbackBlock.Header.AppHash
-		rolledBackLastResultHash = rollbackBlock.Header.LastResultsHash
-	}
-
 	fmt.Printf("Rollback block Height=%d, appHash=%X\n", rollbackBlock.Header.Height, rollbackBlock.Header.AppHash)
 	fmt.Printf("Latest block Height=%d, appHash=%X\n", latestBlock.Header.Height, latestBlock.Header.AppHash)
 


### PR DESCRIPTION
## Describe your changes and provide context

There are three heights: Block Height (BH), App Height (AH), State Height (SH). Those three are updated in this order so it's possible to have the following combinations:
H = BH = AH = SH
H = BH = AH = SH+1
H = BH = AH + 1 = SH + 1
With --hard, the desired output should be H-1 = BH = AH = SH all three scenarios.
Without --hard, the outputs should be
H = BH, H-1 = AH = SH
H-1 = BH = AH = SH
H-1 = BH = AH = SH

Regardless of whether --hard or not, SH is being rolled back to H-1, so its app hash should always be set as the hash in block H's header

## Testing performed to validate your change
tested on devnet-2

