### PR TITLE
Bug Fix: recheck should not cause all future transactions to halt

### DIFF
--- a/internal/mempool/mempool.go
+++ b/internal/mempool/mempool.go
@@ -505,11 +505,12 @@ func (txmp *TxMempool) Update(
 // addNewTransaction is invoked for a new unique transaction after CheckTx
 // has been executed by the ABCI application for the first time on that transaction.
 // CheckTx can be called again for the same transaction later when re-checking;
-// however, this function will not be called.
+// however, this function will not be called. A recheck after a block is committed
+// goes to handleRecheckResult.
 //
-// initTxCallback runs after the ABCI application executes CheckTx.
+// addNewTransaction runs after the ABCI application executes CheckTx.
 // It runs the postCheck hook if one is defined on the mempool.
-// If the CheckTx response response code is not OK, or if the postCheck hook
+// If the CheckTx response code is not OK, or if the postCheck hook
 // reports an error, the transaction is rejected. Otherwise, we attempt to insert
 // the transaction into the mempool.
 //
@@ -630,14 +631,19 @@ func (txmp *TxMempool) addNewTransaction(wtx *WrappedTx, res *abci.ResponseCheck
 	return nil
 }
 
-// defaultTxCallback is the CheckTx application callback used when a
-// transaction is being re-checked (if re-checking is enabled). The
-// caller must hold a mempool write-lock (via Lock()) and when
+// handleRecheckResult handles the responses from ABCI CheckTx calls issued
+// during the recheck phase of a block Update.  It removes any transactions
+// invalidated by the application.
+//
+// The caller must hold a mempool write-lock (via Lock()) and when
 // executing Update(), if the mempool is non-empty and Recheck is
 // enabled, then all remaining transactions will be rechecked via
 // CheckTx. The order transactions are rechecked must be the same as
 // the order in which this callback is called.
-func (txmp *TxMempool) defaultTxCallback(tx types.Tx, res *abci.ResponseCheckTx) {
+//
+// This method is NOT executed for the initial CheckTx on a new transaction;
+// that case is handled by addNewTransaction instead.
+func (txmp *TxMempool) handleRecheckResult(tx types.Tx, res *abci.ResponseCheckTx) {
 	if txmp.recheckCursor == nil {
 		return
 	}
@@ -750,7 +756,7 @@ func (txmp *TxMempool) updateReCheckTxs(ctx context.Context) {
 				txmp.logger.Error("failed to execute CheckTx during rechecking", "err", err)
 				continue
 			}
-			txmp.defaultTxCallback(wtx.tx, res)
+			txmp.handleRecheckResult(wtx.tx, res)
 		}
 	}
 


### PR DESCRIPTION
## Describe your changes and provide context
**Problem:**
Currently in checkTx, if recheck cursor is not nil (means there's some remaining tx haven't finished recheck), it will return an error to the current transaction and will not accept any new transactions, and will not trigger the retry of existing rechecks, not even to remove them from the checklist or evict them when they expires. This logic is problematic, because whenever there's an transaction that failed the recheck, it will block all future transactions and can not self recover any more.

This failure could happen frequently for broadcastTx calls, because cosmos context will branch out the temporary state in the checkTx mode (https://docs.cosmos.network/v0.45/core/context.html#store-branching), this would case the account sequence number queried from the keeper of the memory pool inconsistent. The rechecks will be checking the branched out state store until a commit successfully executed. This branching out / snapshotted KVStore would cause account sequence mismatch happen frequently and thus -> lead to recheck failures -> halt

**Fix:**
This fix is simple, we just remove the check. We do not really care about recheck cursor is nil or not when handling a new transaction. Also there's no need to call recheck in each checkTx, it should be only called by Update after the transaction is committed.

## Testing performed to validate your change
Tested locally and tested in devnet-3
