### PR TITLE
Cherrypick p2p priority queue optimizations

### DIFF
--- a/internal/p2p/channel.go
+++ b/internal/p2p/channel.go
@@ -19,6 +19,10 @@ type Envelope struct {
 	ChannelID ChannelID
 }
 
+func (e Envelope) IsZero() bool {
+	return e.From == "" && e.To == "" && e.Message == nil
+}
+
 // Wrapper is a Protobuf message that can contain a variety of inner messages
 // (e.g. via oneof fields). If a Channel's message type implements Wrapper, the
 // Router will automatically wrap outbound messages and unwrap inbound messages,
@@ -142,11 +146,10 @@ func iteratorWorker(ctx context.Context, ch *Channel, pipe chan Envelope) {
 // it will never return true again.
 // in general, use Next, as in:
 //
-//     for iter.Next(ctx) {
-//          envelope := iter.Envelope()
-//          // ... do things ...
-//     }
-//
+//	for iter.Next(ctx) {
+//	     envelope := iter.Envelope()
+//	     // ... do things ...
+//	}
 func (iter *ChannelIterator) Next(ctx context.Context) bool {
 	select {
 	case <-ctx.Done():

--- a/internal/p2p/rqueue.go
+++ b/internal/p2p/rqueue.go
@@ -1,0 +1,112 @@
+package p2p
+
+import (
+	"container/heap"
+	"context"
+	"sort"
+	"time"
+
+	"github.com/gogo/protobuf/proto"
+)
+
+type simpleQueue struct {
+	input   chan Envelope
+	output  chan Envelope
+	closeFn func()
+	closeCh <-chan struct{}
+
+	maxSize int
+	chDescs []*ChannelDescriptor
+}
+
+func newSimplePriorityQueue(ctx context.Context, size int, chDescs []*ChannelDescriptor) *simpleQueue {
+	if size%2 != 0 {
+		size++
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	q := &simpleQueue{
+		input:   make(chan Envelope, size*2),
+		output:  make(chan Envelope, size/2),
+		maxSize: size * size,
+		closeCh: ctx.Done(),
+		closeFn: cancel,
+	}
+
+	go q.run(ctx)
+	return q
+}
+
+func (q *simpleQueue) enqueue() chan<- Envelope { return q.input }
+func (q *simpleQueue) dequeue() <-chan Envelope { return q.output }
+func (q *simpleQueue) close()                   { q.closeFn() }
+func (q *simpleQueue) closed() <-chan struct{}  { return q.closeCh }
+
+func (q *simpleQueue) run(ctx context.Context) {
+	defer q.closeFn()
+
+	var chPriorities = make(map[ChannelID]uint, len(q.chDescs))
+	for _, chDesc := range q.chDescs {
+		chID := chDesc.ID
+		chPriorities[chID] = uint(chDesc.Priority)
+	}
+
+	pq := make(priorityQueue, 0, q.maxSize)
+	heap.Init(&pq)
+	ticker := time.NewTicker(10 * time.Millisecond)
+	// must have a buffer of exactly one because both sides of
+	// this channel are used in this loop, and simply signals adds
+	// to the heap
+	signal := make(chan struct{}, 1)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-q.closeCh:
+			return
+		case e := <-q.input:
+			// enqueue the incoming Envelope
+			heap.Push(&pq, &pqEnvelope{
+				envelope:  e,
+				size:      uint(proto.Size(e.Message)),
+				priority:  chPriorities[e.ChannelID],
+				timestamp: time.Now().UTC(),
+			})
+
+			select {
+			case signal <- struct{}{}:
+			default:
+				if len(pq) > q.maxSize {
+					sort.Sort(pq)
+					pq = pq[:q.maxSize]
+				}
+			}
+
+		case <-ticker.C:
+			if len(pq) > q.maxSize {
+				sort.Sort(pq)
+				pq = pq[:q.maxSize]
+			}
+			if len(pq) > 0 {
+				select {
+				case signal <- struct{}{}:
+				default:
+				}
+			}
+		case <-signal:
+		SEND:
+			for len(pq) > 0 {
+				select {
+				case <-ctx.Done():
+					return
+				case <-q.closeCh:
+					return
+				case q.output <- heap.Pop(&pq).(*pqEnvelope).envelope:
+					continue SEND
+				default:
+					break SEND
+				}
+			}
+		}
+	}
+}

--- a/internal/p2p/rqueue_test.go
+++ b/internal/p2p/rqueue_test.go
@@ -1,0 +1,47 @@
+package p2p
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestSimpleQueue(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// set up a small queue with very small buffers so we can
+	// watch it shed load, then send a bunch of messages to the
+	// queue, most of which we'll watch it drop.
+	sq := newSimplePriorityQueue(ctx, 1, nil)
+	for i := 0; i < 100; i++ {
+		sq.enqueue() <- Envelope{From: "merlin"}
+	}
+
+	seen := 0
+
+RETRY:
+	for seen <= 2 {
+		select {
+		case e := <-sq.dequeue():
+			if e.From != "merlin" {
+				continue
+			}
+			seen++
+		case <-time.After(10 * time.Millisecond):
+			break RETRY
+		}
+	}
+	// if we don't see any messages, then it's just broken.
+	if seen == 0 {
+		t.Errorf("seen %d messages, should have seen more than one", seen)
+	}
+	// ensure that load shedding happens: there can be at most 3
+	// messages that we get out of this, one that was buffered
+	// plus 2 that were under the cap, everything else gets
+	// dropped.
+	if seen > 3 {
+		t.Errorf("saw %d messages, should have seen 5 or fewer", seen)
+	}
+
+}


### PR DESCRIPTION
## Describe your changes and provide context
This PR cherrypicks changes from https://github.com/tendermint/tendermint/pull/8929 which fixes the issue described in https://github.com/tendermint/tendermint/issues/8903

TLDR:
The issue is that the 0.35 priority queue impl uses bounded channels which causes unwanted blocking under certain scenarios. The main difference of the "simple" pqueue is that it added an additional time-based signal that fires every 10ms to make sure things are always moving.

The queue type can be configured under `P2P.queue-type`

## Testing performed to validate your change
unit test & test on load cluster

