### PR TITLE
Improve recheckTx logs

### DIFF
--- a/internal/mempool/mempool.go
+++ b/internal/mempool/mempool.go
@@ -737,6 +737,11 @@ func (txmp *TxMempool) updateReCheckTxs(ctx context.Context) {
 	if txmp.Size() == 0 {
 		panic("attempted to update re-CheckTx txs when mempool is empty")
 	}
+	txmp.logger.Debug(
+		"executing re-CheckTx for all remaining transactions",
+		"num_txs", txmp.Size(),
+		"height", txmp.height,
+	)
 
 	txmp.recheckCursor = txmp.gossipIndex.Front()
 	txmp.recheckEnd = txmp.gossipIndex.Back()
@@ -753,7 +758,7 @@ func (txmp *TxMempool) updateReCheckTxs(ctx context.Context) {
 			})
 			if err != nil {
 				// no need in retrying since the tx will be rechecked after the next block
-				txmp.logger.Error("failed to execute CheckTx during rechecking", "err", err)
+				txmp.logger.Error("failed to execute CheckTx during recheck", "err", err, "hash", fmt.Sprintf("%x", wtx.tx.Hash()))
 				continue
 			}
 			txmp.handleRecheckResult(wtx.tx, res)


### PR DESCRIPTION
## Describe your changes and provide context
Seeing a lot of of check Tx logs 

The caller is suppose to have the write lock but it doesn't seem to be true: 
https://github.com/sei-protocol/sei-tendermint/blob/main/internal/mempool/mempool.go#L735

Output the TX hash to see if we're running into race condition issues in the mempool or running into a callback deadlock 
![image](https://user-images.githubusercontent.com/18161326/216097804-0a64fb78-f29e-4213-a587-a90bb26623d2.png)

## Testing performed to validate your change
Copied these from oss repo 
