### PR TITLE
[config] set override unsafeTimeoutOverride to false by default

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1050,8 +1050,6 @@ type ConsensusConfig struct {
 	DeprecatedSkipTimeoutCommit     *interface{} `mapstructure:"skip-timeout-commit"`
 }
 
-var UnsafeBypassCommitTimeoutOverride = false
-
 // DefaultConsensusConfig returns a default configuration for the consensus service
 func DefaultConsensusConfig() *ConsensusConfig {
 	return &ConsensusConfig{
@@ -1063,7 +1061,6 @@ func DefaultConsensusConfig() *ConsensusConfig {
 		DoubleSignCheckHeight:       int64(0),
 		// Sei Configurations
 		GossipTransactionKeyOnly:          true,
-		UnsafeBypassCommitTimeoutOverride: &UnsafeBypassCommitTimeoutOverride,
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -1050,7 +1050,7 @@ type ConsensusConfig struct {
 	DeprecatedSkipTimeoutCommit     *interface{} `mapstructure:"skip-timeout-commit"`
 }
 
-var UnsafeBypassCommitTimeoutOverride = true
+var UnsafeBypassCommitTimeoutOverride = false
 
 // DefaultConsensusConfig returns a default configuration for the consensus service
 func DefaultConsensusConfig() *ConsensusConfig {

--- a/config/config.go
+++ b/config/config.go
@@ -1050,7 +1050,7 @@ type ConsensusConfig struct {
 	DeprecatedSkipTimeoutCommit     *interface{} `mapstructure:"skip-timeout-commit"`
 }
 
-var UnsafeBypassCommitTimeoutOverride = false
+var UnsafeBypassCommitTimeoutOverride = true
 
 // DefaultConsensusConfig returns a default configuration for the consensus service
 func DefaultConsensusConfig() *ConsensusConfig {

--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -1009,7 +1009,7 @@ func (cs *State) receiveRoutine(ctx context.Context, maxSteps int) {
 func (cs *State) fsyncAndCompleteProposal(ctx context.Context, fsyncUponCompletion bool, height int64, span otrace.Span) {
 	if fsyncUponCompletion {
 		if err := cs.wal.FlushAndSync(); err != nil { // fsync
-			panic("error flushing wal after receiving all block parts")
+			panic(fmt.Sprintf("error flushing wal after receiving all block parts error=%s", err))
 		}
 	}
 	cs.handleCompleteProposal(ctx, height, span)


### PR DESCRIPTION
## Describe your changes and provide context
e.g https://github.com/sei-protocol/sei-cosmos/pull/153

Based on the logs, the data race is between QueryContext and the Finalizeblock for app.checkState.ctx.

I narrowed it cause and it seems like with UnsafeBypassCommitTimeoutOverride=true on by default, the single node consensus is much faster as it doesn't need to wait for timeout, all the datarace failures are happening in the query cli unit tests so i suspect that the queries and the async network are handled in different gorountines and thus have async access to checkState.Ctx (one is updating through finalizeBlock while the unit test is querying it)

Its fine to set to false, since it's mainly exposing the behavior that CLI queries do not have a freshness guarantee, which is expected as the data is constantly changing 
## Testing performed to validate your change

Tag has this change to set to false, will tag from main after this merges
https://github.com/sei-protocol/sei-cosmos/pull/152 
