### PR TITLE
Default p2p with simple priority

### DIFF
--- a/abci/client/mocks/client.go
+++ b/abci/client/mocks/client.go
@@ -392,6 +392,11 @@ func (_m *Client) Start(_a0 context.Context) error {
 	return r0
 }
 
+// Stop provides a mock function with given fields:
+func (_m *Client) Stop() {
+	_m.Called()
+}
+
 // VerifyVoteExtension provides a mock function with given fields: _a0, _a1
 func (_m *Client) VerifyVoteExtension(_a0 context.Context, _a1 *types.RequestVerifyVoteExtension) (*types.ResponseVerifyVoteExtension, error) {
 	ret := _m.Called(_a0, _a1)

--- a/config/config.go
+++ b/config/config.go
@@ -696,7 +696,7 @@ func DefaultP2PConfig() *P2PConfig {
 		HandshakeTimeout:        20 * time.Second,
 		DialTimeout:             3 * time.Second,
 		TestDialFail:            false,
-		QueueType:               "priority",
+		QueueType:               "simple-priority",
 	}
 }
 

--- a/internal/p2p/pex/reactor_test.go
+++ b/internal/p2p/pex/reactor_test.go
@@ -299,7 +299,12 @@ func setupSingle(ctx context.Context, t *testing.T) *singleTestReactor {
 	peerManager, err := p2p.NewPeerManager(nodeID, dbm.NewMemDB(), p2p.PeerManagerOptions{})
 	require.NoError(t, err)
 
-	reactor := pex.NewReactor(log.NewNopLogger(), peerManager, func(_ context.Context) *p2p.PeerUpdates { return peerUpdates })
+	reactor := pex.NewReactor(
+		log.NewNopLogger(),
+		peerManager,
+		func(_ context.Context) *p2p.PeerUpdates { return peerUpdates },
+		make(chan struct{}),
+	)
 	reactor.SetChannel(pexCh)
 
 	require.NoError(t, reactor.Start(ctx))
@@ -393,6 +398,7 @@ func setupNetwork(ctx context.Context, t *testing.T, opts testOptions) *reactorT
 				rts.logger.With("nodeID", nodeID),
 				rts.network.Nodes[nodeID].PeerManager,
 				func(_ context.Context) *p2p.PeerUpdates { return rts.peerUpdates[nodeID] },
+				make(chan struct{}),
 			)
 			rts.reactors[nodeID].SetChannel(rts.pexChannels[nodeID])
 		}

--- a/internal/p2p/pex/reactor_test.go
+++ b/internal/p2p/pex/reactor_test.go
@@ -451,6 +451,7 @@ func (r *reactorTestSuite) addNodes(ctx context.Context, t *testing.T, nodes int
 			r.logger.With("nodeID", nodeID),
 			r.network.Nodes[nodeID].PeerManager,
 			func(_ context.Context) *p2p.PeerUpdates { return r.peerUpdates[nodeID] },
+			make(chan struct{}),
 		)
 		r.nodes = append(r.nodes, nodeID)
 		r.total++

--- a/internal/state/execution_test.go
+++ b/internal/state/execution_test.go
@@ -995,6 +995,7 @@ func TestPrepareProposalErrorOnPrepareProposalError(t *testing.T) {
 	cm.On("Error").Return(nil)
 	cm.On("Start", mock.Anything).Return(nil).Once()
 	cm.On("Wait").Return(nil).Once()
+	cm.On("Stop").Return(nil).Once()
 	cm.On("PrepareProposal", mock.Anything, mock.Anything).Return(nil, errors.New("an injected error")).Once()
 
 	proxyApp := proxy.New(cm, logger, proxy.NopMetrics())

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -50,7 +50,7 @@ func TestNodeStartStop(t *testing.T) {
 
 	logger := log.NewNopLogger()
 	// create & start node
-	ns, err := newDefaultNode(ctx, cfg, logger)
+	ns, err := newDefaultNode(ctx, cfg, logger, make(chan struct{}))
 	require.NoError(t, err)
 
 	n, ok := ns.(*nodeImpl)
@@ -87,7 +87,7 @@ func getTestNode(ctx context.Context, t *testing.T, conf *config.Config, logger 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	ns, err := newDefaultNode(ctx, conf, logger)
+	ns, err := newDefaultNode(ctx, conf, logger, make(chan struct{}))
 	require.NoError(t, err)
 
 	n, ok := ns.(*nodeImpl)
@@ -207,7 +207,7 @@ func TestPrivValidatorListenAddrNoProtocol(t *testing.T) {
 
 	logger := log.NewNopLogger()
 
-	n, err := newDefaultNode(ctx, cfg, logger)
+	n, err := newDefaultNode(ctx, cfg, logger, make(chan struct{}))
 
 	assert.Error(t, err)
 
@@ -604,6 +604,7 @@ func TestNodeNewSeedNode(t *testing.T) {
 		ctx,
 		logger,
 		cfg,
+		make(chan struct{}),
 		config.DefaultDBProvider,
 		nodeKey,
 		defaultGenesisDocProviderFunc(cfg),
@@ -683,7 +684,7 @@ func TestNodeSetEventSink(t *testing.T) {
 	assert.Equal(t, indexer.NULL, eventSinks[0].Type())
 
 	cfg.TxIndex.Indexer = []string{"kvv"}
-	ns, err := newDefaultNode(ctx, cfg, logger)
+	ns, err := newDefaultNode(ctx, cfg, logger, make(chan struct{}))
 	assert.Nil(t, ns)
 	assert.Contains(t, err.Error(), "unsupported event sink type")
 	t.Cleanup(cleanup(ns))
@@ -695,7 +696,7 @@ func TestNodeSetEventSink(t *testing.T) {
 	assert.Equal(t, indexer.NULL, eventSinks[0].Type())
 
 	cfg.TxIndex.Indexer = []string{"psql"}
-	ns, err = newDefaultNode(ctx, cfg, logger)
+	ns, err = newDefaultNode(ctx, cfg, logger, make(chan struct{}))
 	assert.Nil(t, ns)
 	assert.Contains(t, err.Error(), "the psql connection settings cannot be empty")
 	t.Cleanup(cleanup(ns))
@@ -705,13 +706,13 @@ func TestNodeSetEventSink(t *testing.T) {
 
 	var e = errors.New("found duplicated sinks, please check the tx-index section in the config.toml")
 	cfg.TxIndex.Indexer = []string{"null", "kv", "Kv"}
-	ns, err = newDefaultNode(ctx, cfg, logger)
+	ns, err = newDefaultNode(ctx, cfg, logger, make(chan struct{}))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), e.Error())
 	t.Cleanup(cleanup(ns))
 
 	cfg.TxIndex.Indexer = []string{"Null", "kV", "kv", "nUlL"}
-	ns, err = newDefaultNode(ctx, cfg, logger)
+	ns, err = newDefaultNode(ctx, cfg, logger, make(chan struct{}))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), e.Error())
 	t.Cleanup(cleanup(ns))


### PR DESCRIPTION
## Describe your changes and provide context
Per this comment: https://github.com/sei-protocol/sei-tendermint/pull/50#issuecomment-1411414817

We've done enough testing with multiple clusters, should be fine to set it to default now to reduce operational complexity for genesis 

![image](https://user-images.githubusercontent.com/18161326/217084185-699e47bc-53c8-45ac-be40-e427022f412a.png)


## Testing performed to validate your change

