### PR TITLE
Ensure that defaultDoPrevote always signs a vote before returning

### DIFF
--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -959,7 +959,7 @@ func (cs *State) receiveRoutine(ctx context.Context, maxSteps int) {
 	for {
 		if maxSteps > 0 {
 			if cs.nSteps >= maxSteps {
-				cs.logger.Info("reached max steps; exiting receive routine")
+				cs.logger.Debug("reached max steps; exiting receive routine")
 				cs.nSteps = 0
 				return
 			}

--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -959,7 +959,7 @@ func (cs *State) receiveRoutine(ctx context.Context, maxSteps int) {
 	for {
 		if maxSteps > 0 {
 			if cs.nSteps >= maxSteps {
-				cs.logger.Debug("reached max steps; exiting receive routine")
+				cs.logger.Info("reached max steps; exiting receive routine")
 				cs.nSteps = 0
 				return
 			}
@@ -1612,6 +1612,7 @@ func (cs *State) proposalIsTimely() bool {
 func (cs *State) defaultDoPrevote(ctx context.Context, height int64, round int32) {
 	logger := cs.logger.With("height", height, "round", round)
 
+	logger.Info("[TMDEBUG] Entered defaultDoPrevote", "height", height, "round", round, "gossipTxKeyOnly config", cs.config.GossipTransactionKeyOnly, "proposal", cs.Proposal, "proposal block", cs.ProposalBlock)
 	// Check that a proposed block was not received within this round (and thus executing this from a timeout).
 	if !cs.config.GossipTransactionKeyOnly && cs.ProposalBlock == nil {
 		cs.signAddVote(ctx, tmproto.PrevoteType, nil, types.PartSetHeader{})
@@ -1628,19 +1629,24 @@ func (cs *State) defaultDoPrevote(ctx context.Context, height int64, round int32
 		if cs.ProposalBlock == nil {
 			// If we're not the proposer, we need to build the block
 			txKeys := cs.Proposal.TxKeys
+			logger.Info("[TMDEBUG] defaultDoPrevote ProposalBlockPartsIsComplete", cs.ProposalBlockParts.IsComplete())
 			if cs.ProposalBlockParts.IsComplete() {
 				block, err := cs.getBlockFromBlockParts()
 				if err != nil {
 					cs.logger.Error("Encountered error building block from parts", "block parts", cs.ProposalBlockParts)
+					//cs.signAddVote(ctx, tmproto.PrevoteType, nil, types.PartSetHeader{})
 					return
 				}
 				// We have full proposal block and txs. Build proposal block with txKeys
 				proposalBlock := cs.buildProposalBlock(height, block.Header, block.LastCommit, block.Evidence, block.ProposerAddress, txKeys)
 				if proposalBlock == nil {
+					cs.logger.Error("[TMDEBUG] Proposal block parts is complete but proposal block is nil, returning")
+					//cs.signAddVote(ctx, tmproto.PrevoteType, nil, types.PartSetHeader{})
 					return
 				}
 				cs.ProposalBlock = proposalBlock
 			} else {
+				//cs.signAddVote(ctx, tmproto.PrevoteType, nil, types.PartSetHeader{})
 				return
 			}
 		}
@@ -1649,6 +1655,7 @@ func (cs *State) defaultDoPrevote(ctx context.Context, height int64, round int32
 			block, err := cs.getBlockFromBlockParts()
 			if err != nil {
 				cs.logger.Error("Encountered error building block from parts", "block parts", cs.ProposalBlockParts)
+				//cs.signAddVote(ctx, tmproto.PrevoteType, nil, types.PartSetHeader{})
 				return
 			}
 			if block == nil {

--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -1629,7 +1629,7 @@ func (cs *State) defaultDoPrevote(ctx context.Context, height int64, round int32
 		if cs.ProposalBlock == nil {
 			// If we're not the proposer, we need to build the block
 			txKeys := cs.Proposal.TxKeys
-			logger.Info("[TMDEBUG] defaultDoPrevote ProposalBlockPartsIsComplete", cs.ProposalBlockParts.IsComplete())
+			logger.Info("[TMDEBUG] defaultDoPrevote ProposalBlockPartsIsComplete", "isComplete", cs.ProposalBlockParts.IsComplete())
 			if cs.ProposalBlockParts.IsComplete() {
 				block, err := cs.getBlockFromBlockParts()
 				if err != nil {
@@ -1646,7 +1646,7 @@ func (cs *State) defaultDoPrevote(ctx context.Context, height int64, round int32
 				}
 				cs.ProposalBlock = proposalBlock
 			} else {
-				//cs.signAddVote(ctx, tmproto.PrevoteType, nil, types.PartSetHeader{})
+				cs.signAddVote(ctx, tmproto.PrevoteType, nil, types.PartSetHeader{})
 				return
 			}
 		}

--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -1612,7 +1612,6 @@ func (cs *State) proposalIsTimely() bool {
 func (cs *State) defaultDoPrevote(ctx context.Context, height int64, round int32) {
 	logger := cs.logger.With("height", height, "round", round)
 
-	logger.Info("[TMDEBUG] Entered defaultDoPrevote", "height", height, "round", round, "gossipTxKeyOnly config", cs.config.GossipTransactionKeyOnly, "proposal", cs.Proposal, "proposal block", cs.ProposalBlock)
 	// Check that a proposed block was not received within this round (and thus executing this from a timeout).
 	if !cs.config.GossipTransactionKeyOnly && cs.ProposalBlock == nil {
 		cs.signAddVote(ctx, tmproto.PrevoteType, nil, types.PartSetHeader{})
@@ -1629,19 +1628,16 @@ func (cs *State) defaultDoPrevote(ctx context.Context, height int64, round int32
 		if cs.ProposalBlock == nil {
 			// If we're not the proposer, we need to build the block
 			txKeys := cs.Proposal.TxKeys
-			logger.Info("[TMDEBUG] defaultDoPrevote ProposalBlockPartsIsComplete", "isComplete", cs.ProposalBlockParts.IsComplete())
 			if cs.ProposalBlockParts.IsComplete() {
 				block, err := cs.getBlockFromBlockParts()
 				if err != nil {
-					cs.logger.Error("Encountered error building block from parts", "block parts", cs.ProposalBlockParts)
-					//cs.signAddVote(ctx, tmproto.PrevoteType, nil, types.PartSetHeader{})
+					cs.signAddVote(ctx, tmproto.PrevoteType, nil, types.PartSetHeader{})
 					return
 				}
 				// We have full proposal block and txs. Build proposal block with txKeys
 				proposalBlock := cs.buildProposalBlock(height, block.Header, block.LastCommit, block.Evidence, block.ProposerAddress, txKeys)
 				if proposalBlock == nil {
-					cs.logger.Error("[TMDEBUG] Proposal block parts is complete but proposal block is nil, returning")
-					//cs.signAddVote(ctx, tmproto.PrevoteType, nil, types.PartSetHeader{})
+					cs.signAddVote(ctx, tmproto.PrevoteType, nil, types.PartSetHeader{})
 					return
 				}
 				cs.ProposalBlock = proposalBlock
@@ -1655,7 +1651,7 @@ func (cs *State) defaultDoPrevote(ctx context.Context, height int64, round int32
 			block, err := cs.getBlockFromBlockParts()
 			if err != nil {
 				cs.logger.Error("Encountered error building block from parts", "block parts", cs.ProposalBlockParts)
-				//cs.signAddVote(ctx, tmproto.PrevoteType, nil, types.PartSetHeader{})
+				cs.signAddVote(ctx, tmproto.PrevoteType, nil, types.PartSetHeader{})
 				return
 			}
 			if block == nil {

--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -2865,7 +2865,7 @@ func (cs *State) signAddVote(
 		vote.StripExtension()
 	}
 	cs.sendInternalMessage(ctx, msgInfo{&VoteMessage{vote}, "", tmtime.Now()})
-	cs.logger.Debug("signed and pushed vote", "height", cs.Height, "round", cs.Round, "vote", vote)
+	cs.logger.Info("signed and pushed vote", "height", cs.Height, "round", cs.Round, "vote", vote)
 	return vote
 }
 


### PR DESCRIPTION
## Describe your changes and provide context
In the open source version of Tendermint, `defaultDoPrevote` always performs `signAddVote` before returning. However, after adding some of the gossip tx logic, we've noticed that nodes will occaisionally hang. The reason is that there are edge cases where we don't end up signing. As a result, consensus gets stuck since all the nodes wait for at least 2/3 voting before proceeding: https://sourcegraph.com/github.com/tendermint/tendermint@35581cf54ec436b8c37fabb43fdaa3f48339a170/-/blob/consensus/state.go?L2123
## Testing performed to validate your change
Ran loadtest cluster overnight:
<img width="709" alt="image" src="https://user-images.githubusercontent.com/3821073/217297443-8c0a0696-8e71-460e-bd35-d89bf20129f5.png">

