### PR TITLE
fix unit test

### DIFF
--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -1009,7 +1009,7 @@ func (cs *State) receiveRoutine(ctx context.Context, maxSteps int) {
 func (cs *State) fsyncAndCompleteProposal(ctx context.Context, fsyncUponCompletion bool, height int64, span otrace.Span) {
 	if fsyncUponCompletion {
 		if err := cs.wal.FlushAndSync(); err != nil { // fsync
-			panic(fmt.Sprintf("error flushing wal after receiving all block parts error=%s", err))
+			cs.logger.Error("Error flushing wal after receiving all block parts", "error", err)
 		}
 	}
 	cs.handleCompleteProposal(ctx, height, span)


### PR DESCRIPTION
## Describe your changes and provide context
We don't need to panic if we're flushing the WAL which fixes unit tests that are failing due to
```
panic: error flushing wal after receiving all block parts error=write: autofile is closed [recovered]
	panic: error flushing wal after receiving all block parts error=write: autofile is closed [recovered]
	panic: error flushing wal after receiving all block parts error=write: autofile is closed
```
This also mimics OSS behavior https://github.com/sei-protocol/sei-tendermint/actions/runs/4115746669/jobs/7104875975
## Testing performed to validate your change
Unit tests pass
