### PR TITLE
Enrich net-info endpoint

### DIFF
--- a/internal/rpc/core/env.go
+++ b/internal/rpc/core/env.go
@@ -59,10 +59,12 @@ type consensusState interface {
 
 type peerManager interface {
 	Peers() []types.NodeID
+	Score(types.NodeID) int
+	State(types.NodeID) string
 	Addresses(types.NodeID) []p2p.NodeAddress
 }
 
-//----------------------------------------------
+// ----------------------------------------------
 // Environment contains objects and interfaces used by the RPC. It is expected
 // to be setup once during startup.
 type Environment struct {

--- a/internal/rpc/core/net.go
+++ b/internal/rpc/core/net.go
@@ -14,6 +14,7 @@ func (env *Environment) NetInfo(ctx context.Context) (*coretypes.ResultNetInfo, 
 	peerList := env.PeerManager.Peers()
 
 	peers := make([]coretypes.Peer, 0, len(peerList))
+	peerConnections := make([]coretypes.PeerConnection, 0, len(peerList))
 	for _, peer := range peerList {
 		addrs := env.PeerManager.Addresses(peer)
 		if len(addrs) == 0 {
@@ -24,13 +25,19 @@ func (env *Environment) NetInfo(ctx context.Context) (*coretypes.ResultNetInfo, 
 			ID:  peer,
 			URL: addrs[0].String(),
 		})
+		peerConnections = append(peerConnections, coretypes.PeerConnection{
+			ID:    peer,
+			State: env.PeerManager.State(peer),
+			Score: env.PeerManager.Score(peer),
+		})
 	}
 
 	return &coretypes.ResultNetInfo{
-		Listening: env.IsListening,
-		Listeners: env.Listeners,
-		NPeers:    len(peers),
-		Peers:     peers,
+		Listening:       env.IsListening,
+		Listeners:       env.Listeners,
+		NPeers:          len(peers),
+		Peers:           peers,
+		PeerConnections: peerConnections,
 	}, nil
 }
 

--- a/rpc/coretypes/responses.go
+++ b/rpc/coretypes/responses.go
@@ -174,10 +174,11 @@ func (s *ResultStatus) TxIndexEnabled() bool {
 
 // Info about peer connections
 type ResultNetInfo struct {
-	Listening bool     `json:"listening"`
-	Listeners []string `json:"listeners"`
-	NPeers    int      `json:"n_peers,string"`
-	Peers     []Peer   `json:"peers"`
+	Listening       bool             `json:"listening"`
+	Listeners       []string         `json:"listeners"`
+	NPeers          int              `json:"n_peers,string"`
+	Peers           []Peer           `json:"peers"`
+	PeerConnections []PeerConnection `json:"peer_connections"`
 }
 
 // Log from dialing seeds
@@ -194,6 +195,13 @@ type ResultDialPeers struct {
 type Peer struct {
 	ID  types.NodeID `json:"node_id"`
 	URL string       `json:"url"`
+}
+
+// A peer connection
+type PeerConnection struct {
+	ID    types.NodeID `json:"node_id"`
+	State string       `json:"state"`
+	Score int          `json:"score,string"`
 }
 
 // Validators for a height.


### PR DESCRIPTION
## Describe your changes and provide context
Show both state and score for peers in net-info responses. Added as new fields instead of mutating existing ones.

## Testing performed to validate your change
loadtest cluster

