### PR TITLE
Delete peer on max retry 

### DIFF
--- a/internal/p2p/p2ptest/network.go
+++ b/internal/p2p/p2ptest/network.go
@@ -38,6 +38,7 @@ type NetworkOptions struct {
 type NodeOptions struct {
 	MaxPeers     uint16
 	MaxConnected uint16
+	MaxRetryTime time.Duration
 }
 
 func (opts *NetworkOptions) setDefaults() {
@@ -251,9 +252,14 @@ func (n *Network) MakeNode(ctx context.Context, t *testing.T, opts NodeOptions) 
 	require.NoError(t, err)
 	require.NotNil(t, ep, "transport not listening an endpoint")
 
+	maxRetryTime := 500 * time.Millisecond
+	if opts.MaxRetryTime > 0 {
+		maxRetryTime = opts.MaxRetryTime
+	}
+
 	peerManager, err := p2p.NewPeerManager(nodeID, dbm.NewMemDB(), p2p.PeerManagerOptions{
 		MinRetryTime:    10 * time.Millisecond,
-		MaxRetryTime:    500 * time.Millisecond,
+		MaxRetryTime:    maxRetryTime,
 		RetryTimeJitter: time.Millisecond,
 		MaxPeers:        opts.MaxPeers,
 		MaxConnected:    opts.MaxConnected,

--- a/internal/p2p/p2ptest/network.go
+++ b/internal/p2p/p2ptest/network.go
@@ -253,7 +253,7 @@ func (n *Network) MakeNode(ctx context.Context, t *testing.T, opts NodeOptions) 
 
 	peerManager, err := p2p.NewPeerManager(nodeID, dbm.NewMemDB(), p2p.PeerManagerOptions{
 		MinRetryTime:    10 * time.Millisecond,
-		MaxRetryTime:    100 * time.Millisecond,
+		MaxRetryTime:    500 * time.Millisecond,
 		RetryTimeJitter: time.Millisecond,
 		MaxPeers:        opts.MaxPeers,
 		MaxConnected:    opts.MaxConnected,

--- a/internal/p2p/peermanager.go
+++ b/internal/p2p/peermanager.go
@@ -563,7 +563,6 @@ func (m *PeerManager) DialFailed(ctx context.Context, address NodeAddress) error
 			if err := m.store.Delete(address.NodeID); err != nil {
 				return err
 			}
-			fmt.Printf("dialing failed %d times will not retry for address=%s, deleting peer\n", addressInfo.DialFailures, address.NodeID)
 			return fmt.Errorf("dialing failed %d times will not retry for address=%s, deleting peer", addressInfo.DialFailures, address.NodeID)
 		}
 		go func() {

--- a/internal/p2p/peermanager.go
+++ b/internal/p2p/peermanager.go
@@ -563,6 +563,7 @@ func (m *PeerManager) DialFailed(ctx context.Context, address NodeAddress) error
 			if err := m.store.Delete(address.NodeID); err != nil {
 				return err
 			}
+			fmt.Printf("dialing failed %d times will not retry for address=%s, deleting peer\n", addressInfo.DialFailures, address.NodeID)
 			return fmt.Errorf("dialing failed %d times will not retry for address=%s, deleting peer", addressInfo.DialFailures, address.NodeID)
 		}
 		go func() {
@@ -1100,7 +1101,7 @@ func (m *PeerManager) retryDelay(failures uint32, persistent bool) time.Duration
 		maxDelay = m.options.MaxRetryTimePersistent
 	}
 
-	delay := m.options.MinRetryTime * time.Duration(failures)
+	delay := m.options.MinRetryTime * (time.Duration(math.Pow(2, float64(failures))))
 	if m.options.RetryTimeJitter > 0 {
 		delay += time.Duration(m.rand.Int63n(int64(m.options.RetryTimeJitter)))
 	}

--- a/internal/p2p/peermanager.go
+++ b/internal/p2p/peermanager.go
@@ -528,8 +528,6 @@ func (m *PeerManager) TryDialNext() (NodeAddress, error) {
 
 // DialFailed reports a failed dial attempt. This will make the peer available
 // for dialing again when appropriate (possibly after a retry timeout).
-//
-// FIXME: This should probably delete or mark bad addresses/peers after some time.
 func (m *PeerManager) DialFailed(ctx context.Context, address NodeAddress) error {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()

--- a/internal/p2p/peermanager_test.go
+++ b/internal/p2p/peermanager_test.go
@@ -378,7 +378,7 @@ func TestPeerManager_DialNext_Retry(t *testing.T) {
 	ctx, cancel = context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
-	for i := 0; i <= 6; i++ {
+	for i := 0; i < 4; i++ {
 		start := time.Now()
 		dial, err := peerManager.DialNext(ctx)
 		require.NoError(t, err)
@@ -395,8 +395,6 @@ func TestPeerManager_DialNext_Retry(t *testing.T) {
 			require.GreaterOrEqual(t, elapsed, 2*options.MinRetryTime)
 		case 3:
 			require.GreaterOrEqual(t, elapsed, 3*options.MinRetryTime)
-		case 4, 5, 6:
-			require.GreaterOrEqual(t, elapsed, 4*options.MinRetryTime)
 		default:
 			t.Fatal("unexpected retry")
 		}
@@ -404,30 +402,58 @@ func TestPeerManager_DialNext_Retry(t *testing.T) {
 	}
 }
 
-func TestPeerManager_DialNext_WakeOnAdd(t *testing.T) {
+func TestPeerManagerDeleteOnMaxRetries(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	a := p2p.NodeAddress{Protocol: "memory", NodeID: types.NodeID(strings.Repeat("a", 40))}
 
-	peerManager, err := p2p.NewPeerManager(selfID, dbm.NewMemDB(), p2p.PeerManagerOptions{})
+	options := p2p.PeerManagerOptions{
+		MinRetryTime: 100 * time.Millisecond,
+		MaxRetryTime: 500 * time.Millisecond,
+	}
+	peerManager, err := p2p.NewPeerManager(selfID, dbm.NewMemDB(), options)
 	require.NoError(t, err)
 
-	// Spawn a goroutine to add a peer after a delay.
-	go func() {
-		time.Sleep(200 * time.Millisecond)
-		added, err := peerManager.Add(a)
-		require.NoError(t, err)
-		require.True(t, added)
-	}()
+	added, err := peerManager.Add(a)
+	require.NoError(t, err)
+	require.True(t, added)
 
-	// This will block until peer is added above.
-	ctx, cancel = context.WithTimeout(ctx, 3*time.Second)
+	// Do five dial retries (six dials total). The retry time should double for
+	// each failure. At the forth retry, MaxRetryTime should kick in.
+	ctx, cancel = context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
-	dial, err := peerManager.DialNext(ctx)
-	require.NoError(t, err)
-	require.Equal(t, a, dial)
+
+	for i := 0; i < 5; i++ {
+		start := time.Now()
+		dial, err := peerManager.DialNext(ctx)
+		require.NoError(t, err)
+		require.Equal(t, a, dial)
+		elapsed := time.Since(start).Round(time.Millisecond)
+
+		fmt.Println(elapsed, options.MinRetryTime)
+		switch i {
+		case 0:
+			require.LessOrEqual(t, elapsed, options.MinRetryTime)
+		case 1:
+			require.GreaterOrEqual(t, elapsed, options.MinRetryTime)
+		case 2:
+			require.GreaterOrEqual(t, elapsed, 2*options.MinRetryTime)
+		case 3:
+			require.GreaterOrEqual(t, elapsed, 3*options.MinRetryTime)
+		case 4:
+			require.GreaterOrEqual(t, elapsed, 4*options.MinRetryTime)
+		default:
+			t.Fatal("unexpected retry")
+		}
+
+		if i == 4 {
+			require.ErrorContains(t, peerManager.DialFailed(ctx, a), "dialing failed 5 times")
+		}
+		require.NoError(t, peerManager.DialFailed(ctx, a))
+	}
 }
+
 
 func TestPeerManager_DialNext_WakeOnDialFailed(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/p2p/pex/reactor_test.go
+++ b/internal/p2p/pex/reactor_test.go
@@ -202,6 +202,7 @@ func TestReactorSmallPeerStoreInALargeNetwork(t *testing.T) {
 		MaxPeers:     4,
 		MaxConnected: 3,
 		BufferSize:   8,
+		MaxRetryTime: 5 * time.Minute,
 	})
 	testNet.connectN(ctx, t, 1)
 	testNet.start(ctx, t)
@@ -225,6 +226,7 @@ func TestReactorLargePeerStoreInASmallNetwork(t *testing.T) {
 		MaxPeers:     25,
 		MaxConnected: 25,
 		BufferSize:   5,
+		MaxRetryTime: 5 * time.Minute,
 	})
 	testNet.connectN(ctx, t, 1)
 	testNet.start(ctx, t)
@@ -343,6 +345,7 @@ type testOptions struct {
 	BufferSize   int
 	MaxPeers     uint16
 	MaxConnected uint16
+	MaxRetryTime time.Duration
 }
 
 // setup setups a test suite with a network of nodes. Mocknodes represent the
@@ -360,6 +363,7 @@ func setupNetwork(ctx context.Context, t *testing.T, opts testOptions) *reactorT
 		NodeOpts: p2ptest.NodeOptions{
 			MaxPeers:     opts.MaxPeers,
 			MaxConnected: opts.MaxConnected,
+			MaxRetryTime: opts.MaxRetryTime,
 		},
 	}
 	chBuf := opts.BufferSize
@@ -439,6 +443,7 @@ func (r *reactorTestSuite) addNodes(ctx context.Context, t *testing.T, nodes int
 		node := r.network.MakeNode(ctx, t, p2ptest.NodeOptions{
 			MaxPeers:     r.opts.MaxPeers,
 			MaxConnected: r.opts.MaxConnected,
+			MaxRetryTime: r.opts.MaxRetryTime,
 		})
 		r.network.Nodes[node.NodeID] = node
 		nodeID := node.NodeID

--- a/internal/p2p/router.go
+++ b/internal/p2p/router.go
@@ -706,6 +706,9 @@ func (r *Router) dialPeer(ctx context.Context, address NodeAddress) (Connection,
 	endpoints, err := address.Resolve(resolveCtx)
 	switch {
 	case err != nil:
+		// Mark the peer as private so it's not broadcasted to other peers.
+		// This is reset upon restart of the node.
+		r.peerManager.options.PrivatePeers[address.NodeID] = struct{}{}
 		return nil, fmt.Errorf("failed to resolve address %q: %w", address, err)
 	case len(endpoints) == 0:
 		return nil, fmt.Errorf("address %q did not resolve to any endpoints", address)

--- a/node/setup.go
+++ b/node/setup.go
@@ -229,7 +229,7 @@ func createPeerManager(
 		MaxConnectedUpgrade:    maxUpgradeConns,
 		MaxPeers:               maxUpgradeConns + 2*maxConns,
 		MinRetryTime:           250 * time.Millisecond,
-		MaxRetryTime:           30 * time.Minute,
+		MaxRetryTime:           5 * time.Minute,
 		MaxRetryTimePersistent: 5 * time.Minute,
 		RetryTimeJitter:        5 * time.Second,
 		PrivatePeers:           privatePeerIDs,

--- a/node/setup.go
+++ b/node/setup.go
@@ -229,7 +229,7 @@ func createPeerManager(
 		MaxConnectedUpgrade:    maxUpgradeConns,
 		MaxPeers:               maxUpgradeConns + 2*maxConns,
 		MinRetryTime:           250 * time.Millisecond,
-		MaxRetryTime:           5 * time.Minute,
+		MaxRetryTime:           1 * time.Minute,
 		MaxRetryTimePersistent: 5 * time.Minute,
 		RetryTimeJitter:        5 * time.Second,
 		PrivatePeers:           privatePeerIDs,

--- a/node/setup.go
+++ b/node/setup.go
@@ -229,7 +229,7 @@ func createPeerManager(
 		MaxConnectedUpgrade:    maxUpgradeConns,
 		MaxPeers:               maxUpgradeConns + 2*maxConns,
 		MinRetryTime:           250 * time.Millisecond,
-		MaxRetryTime:           1 * time.Minute,
+		MaxRetryTime:           5 * time.Minute,
 		MaxRetryTimePersistent: 5 * time.Minute,
 		RetryTimeJitter:        5 * time.Second,
 		PrivatePeers:           privatePeerIDs,


### PR DESCRIPTION
## Describe your changes and provide context
* Delete the peer if we hit max retries 
* If we can't resolve the address then mark it as a private address and dont broadcast it to other nodes (propagating the failure) 

## Testing performed to validate your change
Unit tests, will spin up a LT cluster with this change too, but I don't think it's too risky internally 
