### PR TITLE
Increase sync timeout to 3min

### DIFF
--- a/internal/blocksync/reactor.go
+++ b/internal/blocksync/reactor.go
@@ -34,7 +34,7 @@ const (
 	switchToConsensusIntervalSeconds = 1
 
 	// switch to consensus after this duration of inactivity
-	syncTimeout = 60 * time.Second
+	syncTimeout = 180 * time.Second
 )
 
 func GetChannelDescriptor() *p2p.ChannelDescriptor {


### PR DESCRIPTION
## Describe your changes and provide context
Idea of increasing sync timeout is to give the node more time to discover and reconnect to peers. That is to prevent the node from switching to consensus mode due to timeout. 
## Testing performed to validate your change

