### PR TITLE
Restart node if no statesync peer is available 

### DIFF
--- a/internal/statesync/reactor.go
+++ b/internal/statesync/reactor.go
@@ -72,7 +72,7 @@ const (
 	maxLightBlockRequestRetries = 20
 
 	// How long to wait when there's no available epers to restart the router
-	restartNoAvailablePeersWindow = 1 * time.Minute
+	restartNoAvailablePeersWindow = 10 * time.Minute
 )
 
 func GetSnapshotChannelDescriptor() *p2p.ChannelDescriptor {
@@ -970,8 +970,6 @@ func (r *Reactor) processChannels(ctx context.Context, chanTable map[p2p.Channel
 func (r *Reactor) processPeerUpdate(ctx context.Context, peerUpdate p2p.PeerUpdate) {
 	r.logger.Info("received peer update", "peer", peerUpdate.NodeID, "status", peerUpdate.Status)
 
-	r.lastNoAvailablePeers = time.Now()
-
 	switch peerUpdate.Status {
 	case p2p.PeerStatusUp:
 		if peerUpdate.Channels.Contains(SnapshotChannel) &&
@@ -991,7 +989,7 @@ func (r *Reactor) processPeerUpdate(ctx context.Context, peerUpdate p2p.PeerUpda
 	r.mtx.Lock()
 	defer r.mtx.Unlock()
 
-	if r.peers.Len() > 0 {
+	if r.peers.Len() == 0 {
 		r.logger.Error("no available peers left for statesync (restarting router)")
 		if r.lastNoAvailablePeers.IsZero() {
 			r.lastNoAvailablePeers = time.Now()

--- a/internal/statesync/reactor.go
+++ b/internal/statesync/reactor.go
@@ -970,6 +970,7 @@ func (r *Reactor) processPeerUpdate(ctx context.Context, peerUpdate p2p.PeerUpda
 			r.peers.Append(peerUpdate.NodeID)
 
 		} else {
+			r.peers.Remove(peerUpdate.NodeID)
 			r.logger.Error("could not use peer for statesync", "peer", peerUpdate.NodeID)
 		}
 

--- a/internal/statesync/reactor.go
+++ b/internal/statesync/reactor.go
@@ -226,6 +226,7 @@ func NewReactor(
 		eventBus:       eventBus,
 		postSyncHook:   postSyncHook,
 		needsStateSync: needsStateSync,
+		lastNoAvailablePeers: time.Time{},
 		restartCh:		restartCh,
 	}
 
@@ -996,6 +997,9 @@ func (r *Reactor) processPeerUpdate(ctx context.Context, peerUpdate p2p.PeerUpda
 			r.logger.Error("no available peers left for statesync (restarting router)")
 			r.restartCh <- struct{}{}
 		}
+	} else {
+		// Reset
+		r.lastNoAvailablePeers = time.Time{}
 	}
 
 	if r.syncer == nil {

--- a/internal/statesync/reactor.go
+++ b/internal/statesync/reactor.go
@@ -990,10 +990,10 @@ func (r *Reactor) processPeerUpdate(ctx context.Context, peerUpdate p2p.PeerUpda
 	defer r.mtx.Unlock()
 
 	if r.peers.Len() == 0 {
-		r.logger.Error("no available peers left for statesync (restarting router)")
 		if r.lastNoAvailablePeers.IsZero() {
 			r.lastNoAvailablePeers = time.Now()
 		} else if time.Since(r.lastNoAvailablePeers) > restartNoAvailablePeersWindow {
+			r.logger.Error("no available peers left for statesync (restarting router)")
 			r.restartCh <- struct{}{}
 		}
 	}

--- a/internal/statesync/reactor.go
+++ b/internal/statesync/reactor.go
@@ -969,6 +969,9 @@ func (r *Reactor) processChannels(ctx context.Context, chanTable map[p2p.Channel
 // handle the PeerUpdate or if a panic is recovered.
 func (r *Reactor) processPeerUpdate(ctx context.Context, peerUpdate p2p.PeerUpdate) {
 	r.logger.Info("received peer update", "peer", peerUpdate.NodeID, "status", peerUpdate.Status)
+
+	r.lastNoAvailablePeers = time.Now()
+
 	switch peerUpdate.Status {
 	case p2p.PeerStatusUp:
 		if peerUpdate.Channels.Contains(SnapshotChannel) &&
@@ -988,7 +991,7 @@ func (r *Reactor) processPeerUpdate(ctx context.Context, peerUpdate p2p.PeerUpda
 	r.mtx.Lock()
 	defer r.mtx.Unlock()
 
-	if r.peers.Len() == 0 {
+	if r.peers.Len() > 0 {
 		r.logger.Error("no available peers left for statesync (restarting router)")
 		if r.lastNoAvailablePeers.IsZero() {
 			r.lastNoAvailablePeers = time.Now()

--- a/internal/statesync/reactor.go
+++ b/internal/statesync/reactor.go
@@ -968,8 +968,8 @@ func (r *Reactor) processPeerUpdate(ctx context.Context, peerUpdate p2p.PeerUpda
 			peerUpdate.Channels.Contains(ParamsChannel) {
 
 			r.peers.Append(peerUpdate.NodeID)
-
 		} else {
+			// TODO::(bweng) send signal to reset channel if there's no more peers
 			r.peers.Remove(peerUpdate.NodeID)
 			r.logger.Error("could not use peer for statesync", "peer", peerUpdate.NodeID)
 		}

--- a/internal/statesync/reactor_test.go
+++ b/internal/statesync/reactor_test.go
@@ -149,6 +149,7 @@ func setup(
 		nil,   // eventbus can be nil
 		nil,   // post-sync-hook
 		false, // run Sync during Start()
+		make(chan struct{}),
 	)
 	rts.reactor.SetSnapshotChannel(rts.snapshotChannel)
 	rts.reactor.SetChunkChannel(rts.chunkChannel)

--- a/node/node.go
+++ b/node/node.go
@@ -402,6 +402,7 @@ func makeNode(
 			return nil
 		},
 		stateSync,
+		restartCh,
 	)
 	node.shouldStateSync = stateSync
 	node.services = append(node.services, ssReactor)


### PR DESCRIPTION
## Describe your changes and provide context
Remove peer if it's not available for state sync and restart if there's no peers available. 

This is to restart the node in the case where doesn't have any good peers 

## Testing performed to validate your change
Tested on a LT node and saw that it restarted (forcefully injected code to have it go down to no peers after a minute)

Local setup still works fine (single node) 

