### PR TITLE
revert breaking changes

### DIFF
--- a/abci/client/grpc_client.go
+++ b/abci/client/grpc_client.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/libs/log"
@@ -57,7 +58,7 @@ func (cli *grpcClient) OnStart(ctx context.Context) error {
 RETRY_LOOP:
 	for {
 		conn, err := grpc.Dial(cli.addr,
-			grpc.WithInsecure,
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
 			grpc.WithContextDialer(dialerFunc),
 		)
 		if err != nil {

--- a/abci/client/grpc_client.go
+++ b/abci/client/grpc_client.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"google.golang.org/grpc/credentials/insecure"
 	"net"
 	"sync"
 	"time"
@@ -58,7 +57,7 @@ func (cli *grpcClient) OnStart(ctx context.Context) error {
 RETRY_LOOP:
 	for {
 		conn, err := grpc.Dial(cli.addr,
-			grpc.WithTransportCredentials(insecure.NewCredentials()),
+			grpc.WithInsecure,
 			grpc.WithContextDialer(dialerFunc),
 		)
 		if err != nil {

--- a/state/store.go
+++ b/state/store.go
@@ -1,0 +1,10 @@
+package state
+
+import (
+	tmstate "github.com/tendermint/tendermint/proto/tendermint/state"
+	"github.com/tendermint/tendermint/types"
+)
+
+func ABCIResponsesResultsHash(ar *tmstate.ABCIResponses) []byte {
+	return types.NewResults(ar.DeliverTxs).Hash()
+}


### PR DESCRIPTION
## Describe your changes and provide context
When building sei-chain with the latest sei-tendermint main branch we got
```
go: finding module for package github.com/tendermint/tendermint/state
go: finding module for package google.golang.org/grpc/credentials/insecure
github.com/sei-protocol/sei-chain/app imports
	github.com/cosmos/ibc-go/v3/modules/apps/transfer/types tested by
	github.com/cosmos/ibc-go/v3/modules/apps/transfer/types.test imports
	github.com/tendermint/tendermint/state: module github.com/tendermint/tendermint@latest found (v0.35.9, replaced by github.com/sei-protocol/sei-tendermint@v0.1.178-tonytest), but does not contain package github.com/tendermint/tendermint/state
github.com/sei-protocol/sei-chain/cmd/seid/cmd imports
	github.com/cosmos/cosmos-sdk/server imports
	github.com/tendermint/tendermint/abci/client imports
	google.golang.org/grpc/credentials/insecure: module google.golang.org/grpc@latest found (v1.53.0, replaced by google.golang.org/grpc@v1.33.2), but does not contain package google.golang.org/grpc/credentials/insecure
```
Reverting some recent changes fixed it
## Testing performed to validate your change
local build
