### PR TITLE
Revert grpc breaking change

### DIFF
--- a/abci/client/grpc_client.go
+++ b/abci/client/grpc_client.go
@@ -8,13 +8,11 @@ import (
 	"sync"
 	"time"
 
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
-
 	"github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/libs/log"
 	tmnet "github.com/tendermint/tendermint/libs/net"
 	"github.com/tendermint/tendermint/libs/service"
+	"google.golang.org/grpc"
 )
 
 // A gRPC client.
@@ -58,7 +56,7 @@ func (cli *grpcClient) OnStart(ctx context.Context) error {
 RETRY_LOOP:
 	for {
 		conn, err := grpc.Dial(cli.addr,
-			grpc.WithTransportCredentials(insecure.NewCredentials()),
+			grpc.WithInsecure(),
 			grpc.WithContextDialer(dialerFunc),
 		)
 		if err != nil {


### PR DESCRIPTION
## Describe your changes and provide context
Due to protobuf <> grpc incompatibility, we need to continue using an older version of grpc in cosmos that doesn't have the new insecure function, see: https://github.com/sei-protocol/sei-cosmos/blob/main/go.mod#L150
## Testing performed to validate your change
Ensure that it builds and runs
