### PR TITLE
Minor log tunings to make debugging state sync p2p issue easier

### DIFF
--- a/internal/p2p/conn/connection.go
+++ b/internal/p2p/conn/connection.go
@@ -515,7 +515,7 @@ FOR_LOOP:
 
 			if c.IsRunning() {
 				if err == io.EOF {
-					c.logger.Info("Connection is closed @ recvRoutine (likely by the other side)", "conn", c)
+					c.logger.Debug("Connection is closed @ recvRoutine (likely by the other side)", "conn", c)
 				} else {
 					c.logger.Debug("Connection failed @ recvRoutine (reading byte)", "conn", c, "err", err)
 				}

--- a/internal/p2p/router.go
+++ b/internal/p2p/router.go
@@ -731,7 +731,7 @@ func (r *Router) dialPeer(ctx context.Context, address NodeAddress) (Connection,
 		// Internet can't and needs a different public address.
 		conn, err := r.transport.Dial(dialCtx, endpoint)
 		if err != nil {
-			r.logger.Error("failed to dial endpoint", "peer", address.NodeID, "endpoint", endpoint, "err", err)
+			r.logger.Debug("failed to dial endpoint", "peer", address.NodeID, "endpoint", endpoint, "err", err)
 		} else {
 			r.logger.Debug("dialed peer", "peer", address.NodeID, "endpoint", endpoint)
 			return conn, nil

--- a/internal/p2p/router.go
+++ b/internal/p2p/router.go
@@ -816,7 +816,7 @@ func (r *Router) routePeer(ctx context.Context, peerID types.NodeID, conn Connec
 		r.metrics.Peers.Add(-1)
 	}()
 
-	r.logger.Info("peer connected", "peer", peerID, "endpoint", conn, "connected peers", r.peerManager.connected)
+	r.logger.Info("peer connected", "peer", peerID, "endpoint", conn, "number of connected peers", len(r.peerManager.connected), "connected peers", r.peerManager.connected)
 
 	errCh := make(chan error, 2)
 

--- a/internal/p2p/router.go
+++ b/internal/p2p/router.go
@@ -816,7 +816,7 @@ func (r *Router) routePeer(ctx context.Context, peerID types.NodeID, conn Connec
 		r.metrics.Peers.Add(-1)
 	}()
 
-	r.logger.Info("peer connected", "peer", peerID, "endpoint", conn, "number of connected peers", len(r.peerManager.connected), "connected peers", r.peerManager.connected)
+	r.logger.Info("peer connected", "peer", peerID, "endpoint", conn, "connected peers", r.peerManager.connected)
 
 	errCh := make(chan error, 2)
 

--- a/internal/p2p/transport_mconn.go
+++ b/internal/p2p/transport_mconn.go
@@ -376,6 +376,8 @@ func (c *mConnConnection) handshake(
 		return nil, types.NodeInfo{}, nil, err
 	}
 
+	c.logger.Info(fmt.Sprintf("Creating a new MConnection with peerId %s, moniker %s, listenAddr %s", peerInfo.NodeID, peerInfo.Moniker, peerInfo.ListenAddr))
+
 	mconn := conn.NewMConnection(
 		c.logger.With("peer", c.RemoteEndpoint().NodeAddress(peerInfo.NodeID)),
 		secretConn,

--- a/internal/statesync/reactor.go
+++ b/internal/statesync/reactor.go
@@ -969,7 +969,7 @@ func (r *Reactor) processChannels(ctx context.Context, chanTable map[p2p.Channel
 // processPeerUpdate processes a PeerUpdate, returning an error upon failing to
 // handle the PeerUpdate or if a panic is recovered.
 func (r *Reactor) processPeerUpdate(ctx context.Context, peerUpdate p2p.PeerUpdate) {
-	r.logger.Info("received peer update", "peer", peerUpdate.NodeID, "status", peerUpdate.Status)
+	r.logger.Debug("received peer update", "peer", peerUpdate.NodeID, "status", peerUpdate.Status)
 
 	switch peerUpdate.Status {
 	case p2p.PeerStatusUp:
@@ -1026,7 +1026,7 @@ func (r *Reactor) processPeerUpdate(ctx context.Context, peerUpdate p2p.PeerUpda
 		delete(r.providers, peerUpdate.NodeID)
 		r.syncer.RemovePeer(peerUpdate.NodeID)
 	}
-	r.logger.Info("processed peer update", "peer", peerUpdate.NodeID, "status", peerUpdate.Status)
+	r.logger.Debug("processed peer update", "peer", peerUpdate.NodeID, "status", peerUpdate.Status)
 }
 
 // processPeerUpdates initiates a blocking process where we listen for and handle

--- a/internal/statesync/reactor.go
+++ b/internal/statesync/reactor.go
@@ -71,7 +71,7 @@ const (
 	// the backfill process aborts
 	maxLightBlockRequestRetries = 20
 
-	// How long to wait when there's no available epers to restart the router
+	// How long to wait when there's no available peers to restart the router
 	restartNoAvailablePeersWindow = 10 * time.Minute
 )
 
@@ -211,23 +211,23 @@ func NewReactor(
 	restartCh chan struct{},
 ) *Reactor {
 	r := &Reactor{
-		logger:         logger,
-		chainID:        chainID,
-		initialHeight:  initialHeight,
-		cfg:            cfg,
-		conn:           conn,
-		peerEvents:     peerEvents,
-		tempDir:        tempDir,
-		stateStore:     stateStore,
-		blockStore:     blockStore,
-		peers:          newPeerList(),
-		providers:      make(map[types.NodeID]*BlockProvider),
-		metrics:        ssMetrics,
-		eventBus:       eventBus,
-		postSyncHook:   postSyncHook,
-		needsStateSync: needsStateSync,
+		logger:               logger,
+		chainID:              chainID,
+		initialHeight:        initialHeight,
+		cfg:                  cfg,
+		conn:                 conn,
+		peerEvents:           peerEvents,
+		tempDir:              tempDir,
+		stateStore:           stateStore,
+		blockStore:           blockStore,
+		peers:                newPeerList(),
+		providers:            make(map[types.NodeID]*BlockProvider),
+		metrics:              ssMetrics,
+		eventBus:             eventBus,
+		postSyncHook:         postSyncHook,
+		needsStateSync:       needsStateSync,
 		lastNoAvailablePeers: time.Time{},
-		restartCh:		restartCh,
+		restartCh:            restartCh,
 	}
 
 	r.BaseService = *service.NewBaseService(logger, "StateSync", r)

--- a/internal/statesync/syncer.go
+++ b/internal/statesync/syncer.go
@@ -111,7 +111,7 @@ func (s *syncer) AddSnapshot(peerID types.NodeID, snapshot *snapshot) (bool, err
 // AddPeer adds a peer to the pool. For now we just keep it simple and send a
 // single request to discover snapshots, later we may want to do retries and stuff.
 func (s *syncer) AddPeer(ctx context.Context, peerID types.NodeID) error {
-	s.logger.Debug("Requesting snapshots from peer", "peer", peerID)
+	s.logger.Info("Requesting snapshots from peer", "peer", peerID)
 
 	return s.snapshotCh.Send(ctx, p2p.Envelope{
 		To:      peerID,

--- a/node/setup.go
+++ b/node/setup.go
@@ -229,8 +229,8 @@ func createPeerManager(
 		MaxConnectedUpgrade:    maxUpgradeConns,
 		MaxPeers:               maxUpgradeConns + 2*maxConns,
 		MinRetryTime:           250 * time.Millisecond,
-		MaxRetryTime:           5 * time.Minute,
-		MaxRetryTimePersistent: 5 * time.Minute,
+		MaxRetryTime:           2 * time.Minute,
+		MaxRetryTimePersistent: 2 * time.Minute,
 		RetryTimeJitter:        5 * time.Second,
 		PrivatePeers:           privatePeerIDs,
 	}


### PR DESCRIPTION
## Describe your changes and provide context
1. Add some more useful logs and remove some noisy and useless logs
2. Tune the timeout config for connecting to bad peers
## Testing performed to validate your change
Tested in RPC nodes

