### PR TITLE
Fix pubsub json encoding for IBC

### DIFF
--- a/internal/eventbus/event_bus_test.go
+++ b/internal/eventbus/event_bus_test.go
@@ -30,7 +30,7 @@ func TestEventBusPublishEventTx(t *testing.T) {
 	result := abci.ExecTxResult{
 		Data: []byte("bar"),
 		Events: []abci.Event{
-			{Type: "testType", Attributes: []abci.EventAttribute{{Key:[]byte( "baz"), Value: []byte("1")}}},
+			{Type: "testType", Attributes: []abci.EventAttribute{{Key: []byte("baz"), Value: []byte("1")}}},
 		},
 	}
 
@@ -109,7 +109,7 @@ func TestEventBusPublishEventNewBlock(t *testing.T) {
 		edt := msg.Data().(types.EventDataNewBlock)
 		assert.Equal(t, block, edt.Block)
 		assert.Equal(t, blockID, edt.BlockID)
-		assert.Equal(t, resultFinalizeBlock, edt.ResultFinalizeBlock)
+		assert.Equal(t, resultFinalizeBlock.Events, edt.ResultFinalizeBlock)
 	}()
 
 	err = eventBus.PublishEventNewBlock(types.EventDataNewBlock{

--- a/internal/eventbus/event_bus_test.go
+++ b/internal/eventbus/event_bus_test.go
@@ -109,7 +109,7 @@ func TestEventBusPublishEventNewBlock(t *testing.T) {
 		edt := msg.Data().(types.EventDataNewBlock)
 		assert.Equal(t, block, edt.Block)
 		assert.Equal(t, blockID, edt.BlockID)
-		assert.Equal(t, resultFinalizeBlock.Events, edt.ResultFinalizeBlock)
+		assert.Equal(t, resultFinalizeBlock, edt.ResultFinalizeBlock)
 	}()
 
 	err = eventBus.PublishEventNewBlock(types.EventDataNewBlock{

--- a/internal/eventlog/eventlog_test.go
+++ b/internal/eventlog/eventlog_test.go
@@ -34,6 +34,8 @@ type eventData string
 
 func (eventData) TypeTag() string { return "eventData" }
 
+func (e eventData) ToLegacy() types.LegacyEventData { return e }
+
 func TestNewError(t *testing.T) {
 	lg, err := eventlog.New(eventlog.LogSettings{})
 	if err == nil {

--- a/internal/pubsub/pubsub_test.go
+++ b/internal/pubsub/pubsub_test.go
@@ -26,6 +26,8 @@ type pubstring string
 
 func (pubstring) TypeTag() string { return "pubstring" }
 
+func (e pubstring) ToLegacy() types.LegacyEventData { return e }
+
 func TestSubscribeWithArgs(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/internal/pubsub/subscription.go
+++ b/internal/pubsub/subscription.go
@@ -86,5 +86,7 @@ func (msg Message) SubscriptionID() string { return msg.subID }
 // Data returns an original data published.
 func (msg Message) Data() types.EventData { return msg.data }
 
+func (msg Message) LegacyData() types.LegacyEventData { return msg.data.ToLegacy() }
+
 // Events returns events, which matched the client's query.
 func (msg Message) Events() []abci.Event { return msg.events }

--- a/internal/rpc/core/events.go
+++ b/internal/rpc/core/events.go
@@ -84,7 +84,7 @@ func (env *Environment) Subscribe(ctx context.Context, req *coretypes.RequestSub
 			// We have a message to deliver to the client.
 			resp := callInfo.RPCRequest.MakeResponse(&coretypes.ResultEvent{
 				Query:  req.Query,
-				Data:   msg.Data(),
+				Data:   msg.LegacyData(),
 				Events: msg.Events(),
 			})
 			wctx, cancel := context.WithTimeout(opctx, 10*time.Second)

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -192,7 +192,7 @@ func (store dbStore) save(state State, key []byte) error {
 	if err := batch.Set(key, stateBz); err != nil {
 		return err
 	}
-	fmt.Printf("Tendermint State Saved height=%d hash=%X lastResultHash=%X\n", state.LastBlockHeight, state.AppHash, state.LastResultsHash)
+	// fmt.Printf("Tendermint State Saved height=%d hash=%X lastResultHash=%X\n", state.LastBlockHeight, state.AppHash, state.LastResultsHash)
 	return batch.WriteSync()
 }
 

--- a/rpc/client/local/local.go
+++ b/rpc/client/local/local.go
@@ -269,7 +269,7 @@ func (c *Local) eventsRoutine(ctx context.Context, sub eventbus.Subscription, su
 		case outc <- coretypes.ResultEvent{
 			SubscriptionID: msg.SubscriptionID(),
 			Query:          qstr,
-			Data:           msg.Data(),
+			Data:           msg.LegacyData(),
 			Events:         msg.Events(),
 		}:
 		case <-ctx.Done():

--- a/rpc/client/rpc_test.go
+++ b/rpc/client/rpc_test.go
@@ -21,9 +21,9 @@ import (
 	"github.com/tendermint/tendermint/crypto/encoding"
 	"github.com/tendermint/tendermint/internal/mempool"
 	rpccore "github.com/tendermint/tendermint/internal/rpc/core"
+	tmjson "github.com/tendermint/tendermint/libs/json"
 	"github.com/tendermint/tendermint/libs/log"
 	tmmath "github.com/tendermint/tendermint/libs/math"
-	tmjson "github.com/tendermint/tendermint/libs/json"
 	"github.com/tendermint/tendermint/libs/service"
 	"github.com/tendermint/tendermint/privval"
 	"github.com/tendermint/tendermint/rpc/client"
@@ -494,7 +494,15 @@ func TestClientMethodCalls(t *testing.T) {
 					var firstBlockHeight int64
 					for i := int64(0); i < 3; i++ {
 						event := <-eventCh
-						blockEvent, ok := event.Data.(types.EventDataNewBlock)
+
+						blockEvent, ok := event.Data.(types.LegacyEventDataNewBlock)
+						if !ok {
+							blockEventPtr, okPtr := event.Data.(*types.LegacyEventDataNewBlock)
+							if okPtr {
+								blockEvent = *blockEventPtr
+							}
+							ok = okPtr
+						}
 						require.True(t, ok)
 
 						block := blockEvent.Block

--- a/rpc/coretypes/responses.go
+++ b/rpc/coretypes/responses.go
@@ -3,6 +3,8 @@ package coretypes
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
+	"strings"
 	"time"
 
 	abci "github.com/tendermint/tendermint/abci/types"
@@ -351,8 +353,7 @@ func (r *ResultEvent) UnmarshalJSON(data []byte) error {
 	}
 	r.SubscriptionID = res.SubscriptionID
 	r.Query = res.Query
-	// no way to de-compact events as information is lost during compaction
-	r.Events = []abci.Event{}
+	r.Events = decompactEvents(res.Events)
 	return nil
 }
 
@@ -367,6 +368,56 @@ func compactEvents(events []abci.Event) map[string][]string {
 			res[key] = append(res[key], string(a.Value))
 		}
 	}
+	return res
+}
+
+// best effort decompaction that group attributes with common
+// prefix into the same event
+func decompactEvents(compact map[string][]string) []abci.Event {
+	eventTypeToAttrs := map[string]map[string][]string{}
+	for longKey, vals := range compact {
+		splitted := strings.Split(longKey, ".")
+		if len(splitted) != 2 {
+			fmt.Printf("invalid compact event key: %s\n", longKey)
+			continue
+		}
+		if _, ok := eventTypeToAttrs[splitted[0]]; !ok {
+			eventTypeToAttrs[splitted[0]] = map[string][]string{}
+		}
+		if existing, ok := eventTypeToAttrs[splitted[0]][splitted[1]]; ok {
+			fmt.Printf("duplicate compact event key: %s\n", longKey)
+			eventTypeToAttrs[splitted[0]][splitted[1]] = append(existing, vals...)
+		} else {
+			eventTypeToAttrs[splitted[0]][splitted[1]] = vals
+		}
+	}
+	res := []abci.Event{}
+	for eventType, kvs := range eventTypeToAttrs {
+		// at most N events of this type where N is the count of the most common
+		// attribute key
+		eventNum := 0
+		for _, vals := range kvs {
+			if len(vals) > eventNum {
+				eventNum = len(vals)
+			}
+		}
+		for i := 0; i < eventNum; i++ {
+			attributes := []abci.EventAttribute{}
+			for key, vals := range kvs {
+				if i < len(vals) {
+					attributes = append(attributes, abci.EventAttribute{
+						Key:   []byte(key),
+						Value: []byte(vals[i]),
+					})
+				}
+			}
+			res = append(res, abci.Event{
+				Type:       eventType,
+				Attributes: attributes,
+			})
+		}
+	}
+
 	return res
 }
 

--- a/rpc/coretypes/responses.go
+++ b/rpc/coretypes/responses.go
@@ -322,9 +322,10 @@ type ResultEvent struct {
 }
 
 type resultEventJSON struct {
-	Query  string              `json:"query"`
-	Data   json.RawMessage     `json:"data"`
-	Events map[string][]string `json:"events"`
+	SubscriptionID string              `json:"subscription_id"`
+	Query          string              `json:"query"`
+	Data           json.RawMessage     `json:"data"`
+	Events         map[string][]string `json:"events"`
 }
 
 func (r ResultEvent) MarshalJSON() ([]byte, error) {
@@ -333,9 +334,10 @@ func (r ResultEvent) MarshalJSON() ([]byte, error) {
 		return nil, err
 	}
 	return json.Marshal(resultEventJSON{
-		Query:  r.Query,
-		Data:   evt,
-		Events: compactEvents(r.Events),
+		SubscriptionID: r.SubscriptionID,
+		Query:          r.Query,
+		Data:           evt,
+		Events:         compactEvents(r.Events),
 	})
 }
 
@@ -347,6 +349,7 @@ func (r *ResultEvent) UnmarshalJSON(data []byte) error {
 	if err := jsontypes.Unmarshal(res.Data, &r.Data); err != nil {
 		return err
 	}
+	r.SubscriptionID = res.SubscriptionID
 	r.Query = res.Query
 	// no way to de-compact events as information is lost during compaction
 	r.Events = []abci.Event{}

--- a/rpc/jsonrpc/types/types.go
+++ b/rpc/jsonrpc/types/types.go
@@ -11,8 +11,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/tendermint/tendermint/rpc/coretypes"
 	tmjson "github.com/tendermint/tendermint/libs/json"
+	"github.com/tendermint/tendermint/rpc/coretypes"
 )
 
 // ErrorCode is the type of JSON-RPC error codes.
@@ -302,7 +302,6 @@ func (ci *CallInfo) RemoteAddr() string {
 //----------------------------------------
 // SOCKETS
 
-//
 // Determine if its a unix or tcp socket.
 // If tcp, must specify the port; `0.0.0.0` will return incorrectly as "unix" since there's no port
 // TODO: deprecate

--- a/types/events.go
+++ b/types/events.go
@@ -120,6 +120,8 @@ func init() {
 	jsontypes.MustRegister(EventDataValidatorSetUpdates{})
 	jsontypes.MustRegister(EventDataVote{})
 	jsontypes.MustRegister(EventDataEvidenceValidated{})
+	jsontypes.MustRegister(LegacyEventDataNewBlock{})
+	jsontypes.MustRegister(LegacyEventDataTx{})
 	jsontypes.MustRegister(EventDataString(""))
 }
 
@@ -148,10 +150,10 @@ type LegacyEventDataNewBlock struct {
 	ResultEndBlock   LegacyResponseEndBlock  `json:"result_end_block"`
 }
 
-func (LegacyEventDataNewBlock) TypeTag() string { return "tendermint/event/NewBlock" }
+func (LegacyEventDataNewBlock) TypeTag() string { return "tendermint/event/NewBlock_legacy" }
 
 type LegacyEvidence struct {
-	Evidence []Evidence `json:"evidence"`
+	Evidence EvidenceList `json:"evidence"`
 }
 
 type LegacyBlock struct {
@@ -305,7 +307,7 @@ type LegacyResult struct {
 }
 
 func (LegacyEventDataTx) TypeTag() string {
-	return "tendermint/event/Tx"
+	return "tendermint/event/Tx_legacy"
 }
 
 func (e EventDataTx) ToLegacy() LegacyEventData {

--- a/types/events.go
+++ b/types/events.go
@@ -304,7 +304,9 @@ type LegacyResult struct {
 	Events    []abci.Event `json:"events,omitempty"`
 }
 
-func (LegacyEventDataTx) TypeTag() string { return "tendermint/event/Tx" }
+func (LegacyEventDataTx) TypeTag() string {
+	return "tendermint/event/Tx"
+}
 
 func (e EventDataTx) ToLegacy() LegacyEventData {
 	return LegacyEventDataTx{

--- a/types/events.go
+++ b/types/events.go
@@ -190,34 +190,48 @@ type LegacyVersionParams struct {
 }
 
 func (e EventDataNewBlock) ToLegacy() LegacyEventData {
-	return &LegacyEventDataNewBlock{
-		Block: &LegacyBlock{
+	block := &LegacyBlock{}
+	if e.Block != nil {
+		block = &LegacyBlock{
 			Header:     e.Block.Header,
 			Data:       e.Block.Data,
 			Evidence:   LegacyEvidence{Evidence: e.Block.Evidence},
 			LastCommit: e.Block.LastCommit,
-		},
+		}
+	}
+	consensusParamUpdates := &LegacyConsensusParams{}
+	if e.ResultFinalizeBlock.ConsensusParamUpdates != nil {
+		if e.ResultFinalizeBlock.ConsensusParamUpdates.Block != nil {
+			consensusParamUpdates.Block = &LegacyBlockParams{
+				MaxBytes: fmt.Sprintf("%d", e.ResultFinalizeBlock.ConsensusParamUpdates.Block.MaxBytes),
+				MaxGas:   fmt.Sprintf("%d", e.ResultFinalizeBlock.ConsensusParamUpdates.Block.MaxGas),
+			}
+		}
+		if e.ResultFinalizeBlock.ConsensusParamUpdates.Evidence != nil {
+			consensusParamUpdates.Evidence = &LegacyEvidenceParams{
+				MaxAgeNumBlocks: fmt.Sprintf("%d", e.ResultFinalizeBlock.ConsensusParamUpdates.Evidence.MaxAgeNumBlocks),
+				MaxAgeDuration:  fmt.Sprintf("%d", e.ResultFinalizeBlock.ConsensusParamUpdates.Evidence.MaxAgeDuration),
+				MaxBytes:        fmt.Sprintf("%d", e.ResultFinalizeBlock.ConsensusParamUpdates.Evidence.MaxBytes),
+			}
+		}
+		if e.ResultFinalizeBlock.ConsensusParamUpdates.Validator != nil {
+			consensusParamUpdates.Validator = &types.ValidatorParams{
+				PubKeyTypes: e.ResultFinalizeBlock.ConsensusParamUpdates.Validator.PubKeyTypes,
+			}
+		}
+		if e.ResultFinalizeBlock.ConsensusParamUpdates.Version != nil {
+			consensusParamUpdates.Version = &LegacyVersionParams{
+				AppVersion: fmt.Sprintf("%d", e.ResultFinalizeBlock.ConsensusParamUpdates.Version.AppVersion),
+			}
+		}
+	}
+	return &LegacyEventDataNewBlock{
+		Block:            block,
 		ResultBeginBlock: abci.ResponseBeginBlock{Events: e.ResultFinalizeBlock.Events},
 		ResultEndBlock: LegacyResponseEndBlock{
-			ValidatorUpdates: e.ResultFinalizeBlock.ValidatorUpdates,
-			Events:           []abci.Event{},
-			ConsensusParamUpdates: &LegacyConsensusParams{
-				Block: &LegacyBlockParams{
-					MaxBytes: fmt.Sprintf("%d", e.ResultFinalizeBlock.ConsensusParamUpdates.Block.MaxBytes),
-					MaxGas:   fmt.Sprintf("%d", e.ResultFinalizeBlock.ConsensusParamUpdates.Block.MaxGas),
-				},
-				Evidence: &LegacyEvidenceParams{
-					MaxAgeNumBlocks: fmt.Sprintf("%d", e.ResultFinalizeBlock.ConsensusParamUpdates.Evidence.MaxAgeNumBlocks),
-					MaxAgeDuration:  fmt.Sprintf("%d", e.ResultFinalizeBlock.ConsensusParamUpdates.Evidence.MaxAgeDuration),
-					MaxBytes:        fmt.Sprintf("%d", e.ResultFinalizeBlock.ConsensusParamUpdates.Evidence.MaxBytes),
-				},
-				Validator: &types.ValidatorParams{
-					PubKeyTypes: e.ResultFinalizeBlock.ConsensusParamUpdates.Validator.PubKeyTypes,
-				},
-				Version: &LegacyVersionParams{
-					AppVersion: fmt.Sprintf("%d", e.ResultFinalizeBlock.ConsensusParamUpdates.Version.AppVersion),
-				},
-			},
+			ValidatorUpdates:      e.ResultFinalizeBlock.ValidatorUpdates,
+			Events:                []abci.Event{},
+			ConsensusParamUpdates: consensusParamUpdates,
 		},
 	}
 }


### PR DESCRIPTION
## Describe your changes and provide context
IBC replayers (e.g. Hermes) are very particular about expected JSON encoding. This PR makes backward compatibility change so that sei's pubsub works with existing replayers

## Testing performed to validate your change
tested by doing a transfer from local sei to axelar testnet

