### PR TITLE
Bump default max gas to 6 million

### DIFF
--- a/types/params.go
+++ b/types/params.go
@@ -132,7 +132,7 @@ func DefaultBlockParams() BlockParams {
 		MaxBytes: 22020096, // 21MB
 		// Default, can be increased and tuned as needed
 		// match sei-devnet-3 and atlantic-2 current values
-		MaxGas:   600000,
+		MaxGas:   6000000,
 	}
 }
 


### PR DESCRIPTION
## Describe your changes and provide context
Bump default max gas to 6M for easier local testing 

## Testing performed to validate your change

