### PR TITLE
Bump max gas to 100m

### DIFF
--- a/types/params.go
+++ b/types/params.go
@@ -132,7 +132,7 @@ func DefaultBlockParams() BlockParams {
 		MaxBytes: 22020096, // 21MB
 		// Default, can be increased and tuned as needed
 		// match sei-devnet-3 and atlantic-2 current values
-		MaxGas:   6000000,
+		MaxGas:   100000000,
 	}
 }
 


### PR DESCRIPTION
## Describe your changes and provide context
We're bumping it to 100m in sei-devnet-3 and atlantic-2, just updating default here too 

## Testing performed to validate your change

