### PR TITLE
Update Encoding for Genesis file and node key

### DIFF
--- a/types/genesis.go
+++ b/types/genesis.go
@@ -11,7 +11,6 @@ import (
 	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/internal/jsontypes"
 	tmbytes "github.com/tendermint/tendermint/libs/bytes"
-	tmjson "github.com/tendermint/tendermint/libs/json"
 	tmtime "github.com/tendermint/tendermint/libs/time"
 )
 
@@ -78,7 +77,7 @@ type GenesisDoc struct {
 
 // SaveAs is a utility method for saving GenensisDoc as a JSON file.
 func (genDoc *GenesisDoc) SaveAs(file string) error {
-	genDocBytes, err := tmjson.MarshalIndent(genDoc, "", "  ")
+	genDocBytes, err := json.MarshalIndent(genDoc, "", "  ")
 	if err != nil {
 		return err
 	}
@@ -146,7 +145,7 @@ func (genDoc *GenesisDoc) ValidateAndComplete() error {
 // GenesisDocFromJSON unmarshalls JSON data into a GenesisDoc.
 func GenesisDocFromJSON(jsonBlob []byte) (*GenesisDoc, error) {
 	genDoc := GenesisDoc{}
-	err := tmjson.Unmarshal(jsonBlob, &genDoc)
+	err := json.Unmarshal(jsonBlob, &genDoc)
 	if err != nil {
 		return nil, err
 	}

--- a/types/genesis_test.go
+++ b/types/genesis_test.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"encoding/json"
 	"os"
 	"testing"
 
@@ -8,7 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/tendermint/tendermint/crypto/ed25519"
-	tmjson "github.com/tendermint/tendermint/libs/json"
 	tmtime "github.com/tendermint/tendermint/libs/time"
 )
 
@@ -95,7 +95,7 @@ func TestBasicGenesisDoc(t *testing.T) {
 		ChainID:    "abc",
 		Validators: []GenesisValidator{{pubkey.Address(), pubkey, 10, "myval"}},
 	}
-	genDocBytes, err = tmjson.Marshal(baseGenDoc)
+	genDocBytes, err = json.Marshal(baseGenDoc)
 	assert.NoError(t, err, "error marshaling genDoc")
 
 	// test base gendoc and check consensus params were filled
@@ -107,14 +107,14 @@ func TestBasicGenesisDoc(t *testing.T) {
 	assert.NotNil(t, genDoc.Validators[0].Address, "expected validator's address to be filled in")
 
 	// create json with consensus params filled
-	genDocBytes, err = tmjson.Marshal(genDoc)
+	genDocBytes, err = json.Marshal(genDoc)
 	assert.NoError(t, err, "error marshaling genDoc")
 	genDoc, err = GenesisDocFromJSON(genDocBytes)
 	require.NoError(t, err, "expected no error for valid genDoc json")
 
 	// test with invalid consensus params
 	genDoc.ConsensusParams.Block.MaxBytes = 0
-	genDocBytes, err = tmjson.Marshal(genDoc)
+	genDocBytes, err = json.Marshal(genDoc)
 	assert.NoError(t, err, "error marshaling genDoc")
 	_, err = GenesisDocFromJSON(genDocBytes)
 	assert.Error(t, err, "expected error for genDoc json with block size of 0")

--- a/types/node_key.go
+++ b/types/node_key.go
@@ -7,7 +7,6 @@ import (
 	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/crypto/ed25519"
 	"github.com/tendermint/tendermint/internal/jsontypes"
-	tmjson "github.com/tendermint/tendermint/libs/json"
 	tmos "github.com/tendermint/tendermint/libs/os"
 )
 
@@ -59,7 +58,7 @@ func (nk NodeKey) PubKey() crypto.PubKey {
 
 // SaveAs persists the NodeKey to filePath.
 func (nk NodeKey) SaveAs(filePath string) error {
-	jsonBytes, err := tmjson.Marshal(nk)
+	jsonBytes, err := json.Marshal(nk)
 	if err != nil {
 		return err
 	}
@@ -102,7 +101,7 @@ func LoadNodeKey(filePath string) (NodeKey, error) {
 		return NodeKey{}, err
 	}
 	nodeKey := NodeKey{}
-	err = tmjson.Unmarshal(jsonBytes, &nodeKey)
+	err = json.Unmarshal(jsonBytes, &nodeKey)
 	if err != nil {
 		return NodeKey{}, err
 	}


### PR DESCRIPTION
## Describe your changes and provide context
- Updates the encoding / decoding from `tmjson` to `encoding/json` for genesis file and node key
- This reverts the changes for those files in https://github.com/sei-protocol/sei-tendermint/pull/98 as we were seeing issues during an upgrade 

## Testing performed to validate your change
- Spun up a local chain
