### PR TITLE
Add unused prival pubKey back to node info

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -199,13 +199,13 @@ func makeNode(
 	}
 
 	var pubKey crypto.PubKey
-	if cfg.Mode == config.ModeValidator {
-		pubKey, err = privValidator.GetPubKey(ctx)
-		if err != nil {
-			return nil, combineCloseError(fmt.Errorf("can't get pubkey: %w", err),
-				makeCloser(closers))
+	pubKey, err = privValidator.GetPubKey(ctx)
+	if err != nil {
+		return nil, combineCloseError(fmt.Errorf("can't get pubkey: %w", err),
+			makeCloser(closers))
+	}
 
-		}
+	if cfg.Mode == config.ModeValidator {
 		if pubKey == nil {
 			return nil, combineCloseError(
 				errors.New("could not retrieve public key from private validator"),
@@ -415,8 +415,8 @@ func makeNode(
 		if privValidator != nil {
 			csState.SetPrivValidator(ctx, privValidator)
 		}
-		node.rpcEnv.PubKey = pubKey
 	}
+	node.rpcEnv.PubKey = pubKey
 
 	node.BaseService = *service.NewBaseService(logger, "Node", node)
 


### PR DESCRIPTION
## Describe your changes and provide context
TM 0.35 removes unused pubKey from `node.rpcEnv` and only validator nodes will return `validator_info` in the`/status` tm rpc endpoint. This update, however, breaks many auxiliary packages' interface as they cannot correctly serialize the default `validator_info.address`:

TM 0.34:
```
...
"validator_info":{
    "address":"E7996BE5125FBF866A3136F15072F2DAB31094FD",
    "pub_key":{
        "type":"tendermint/PubKeyEd25519",
        "value":"AC4vhXhevEYEFktkNQib6prIoSh6YDeZp7yn0kEqO1o="
    },
    "voting_power":"0"
}
```

TM 0.35:
```
...
"validator_info":{
    "address":"",
    "pub_key":null,
    "voting_power":"0"
}
```
=> ```ERROR failed to spawn chain runtime: relayer error: RPC error to endpoint http://:26657/: serde parse error: expected 40-character hex string, got "" at line 1 column 1298```

This PR reverts the change and add back the unused pubKey & address of **any** node type. 

Note that the other option to fix the interface incompatibility is to add a default dummy address (a 40 character hex string), but that may be confusing for any future reader / relevant issue or error.


## Testing performed to validate your change
- e2e test with IBC on sei-devnet-3 
- unit tests
