### PR TITLE
Add more gauges in the consensus flow

### DIFF
--- a/internal/consensus/metrics.gen.go
+++ b/internal/consensus/metrics.gen.go
@@ -264,7 +264,7 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 			Name:      "consensus_time",
 			Help:      "Number of seconds spent on consensus",
 		}, labels).With(labelsAndValues...),
-		CompleteProposalTime: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
+		CompleteProposalTime: prometheus.NewHistogramFrom(stdprometheus.HistogramOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "complete_proposal_time",
@@ -314,6 +314,6 @@ func NopMetrics() *Metrics {
 		ProposeLatency:                discard.NewHistogram(),
 		PrevoteLatency:                discard.NewHistogram(),
 		ConsensusTime:                 discard.NewHistogram(),
-		CompleteProposalTime:          discard.NewGauge(),
+		CompleteProposalTime:          discard.NewHistogram(),
 	}
 }

--- a/internal/consensus/metrics.gen.go
+++ b/internal/consensus/metrics.gen.go
@@ -264,6 +264,12 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 			Name:      "consensus_time",
 			Help:      "Number of seconds spent on consensus",
 		}, labels).With(labelsAndValues...),
+		CompleteProposalTime: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "complete_proposal_time",
+			Help:      "CompleteProposalTime measures how long it takes between receiving a proposal and finishing processing all of its parts. Note that this means it also includes network latency from block parts gossip",
+		}, labels).With(labelsAndValues...),
 	}
 }
 
@@ -308,5 +314,6 @@ func NopMetrics() *Metrics {
 		ProposeLatency:                discard.NewHistogram(),
 		PrevoteLatency:                discard.NewHistogram(),
 		ConsensusTime:                 discard.NewHistogram(),
+		CompleteProposalTime:          discard.NewGauge(),
 	}
 }

--- a/internal/consensus/metrics.go
+++ b/internal/consensus/metrics.go
@@ -169,7 +169,7 @@ type Metrics struct {
 	// CompleteProposalTime measures how long it takes between receiving a proposal and finishing
 	// processing all of its parts. Note that this means it also includes network latency from
 	// block parts gossip
-	CompleteProposalTime metrics.Gauge
+	CompleteProposalTime metrics.Histogram
 }
 
 // RecordConsMetrics uses for recording the block related metrics during fast-sync.

--- a/internal/consensus/metrics.go
+++ b/internal/consensus/metrics.go
@@ -86,13 +86,13 @@ type Metrics struct {
 	ProposalBlockCreatedOnPropose metrics.Counter `metrics_labels:"success"`
 
 	// Number of txs in a proposal.
-	ProposalTxs                   metrics.Gauge
+	ProposalTxs metrics.Gauge
 
 	// Number of missing txs when trying to create proposal.
-	ProposalMissingTxs            metrics.Gauge
+	ProposalMissingTxs metrics.Gauge
 
 	//Number of missing txs when a proposal is received
-	MissingTxs                    metrics.Gauge `metrics_labels:"proposer_address"`
+	MissingTxs metrics.Gauge `metrics_labels:"proposer_address"`
 
 	// QuroumPrevoteMessageDelay is the interval in seconds between the proposal
 	// timestamp and the timestamp of the earliest prevote that achieved a quorum
@@ -165,6 +165,11 @@ type Metrics struct {
 	// ConsensusTime the metric to track how long the consensus takes in each block
 	//metrics: Number of seconds spent on consensus
 	ConsensusTime metrics.Histogram
+
+	// CompleteProposalTime measures how long it takes between receiving a proposal and finishing
+	// processing all of its parts. Note that this means it also includes network latency from
+	// block parts gossip
+	CompleteProposalTime metrics.Gauge
 }
 
 // RecordConsMetrics uses for recording the block related metrics during fast-sync.

--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -1024,7 +1024,7 @@ func (cs *State) fsyncAndCompleteProposal(ctx context.Context, fsyncUponCompleti
 			cs.logger.Error("Error flushing wal after receiving all block parts", "error", err)
 		}
 	}
-	cs.metrics.CompleteProposalTime.Set(float64(time.Since(cs.roundState.ProposalReceiveTime())))
+	cs.metrics.CompleteProposalTime.Observe(float64(time.Since(cs.roundState.ProposalReceiveTime())))
 	cs.handleCompleteProposal(ctx, height, span)
 }
 

--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -1024,6 +1024,7 @@ func (cs *State) fsyncAndCompleteProposal(ctx context.Context, fsyncUponCompleti
 			cs.logger.Error("Error flushing wal after receiving all block parts", "error", err)
 		}
 	}
+	cs.metrics.CompleteProposalTime.Set(float64(time.Since(cs.roundState.ProposalReceiveTime())))
 	cs.handleCompleteProposal(ctx, height, span)
 }
 

--- a/internal/state/execution.go
+++ b/internal/state/execution.go
@@ -419,7 +419,7 @@ func (blockExec *BlockExecutor) Commit(
 		blockExec.logger.Error("client error during mempool.FlushAppConn", "err", err)
 		return 0, err
 	}
-	blockExec.metrics.FlushAppConnectionTime.Set(float64(time.Since(start)))
+	blockExec.metrics.FlushAppConnectionTime.Observe(float64(time.Since(start)))
 
 	// Commit block, get hash back
 	start = time.Now()
@@ -428,7 +428,7 @@ func (blockExec *BlockExecutor) Commit(
 		blockExec.logger.Error("client error during proxyAppConn.Commit", "err", err)
 		return 0, err
 	}
-	blockExec.metrics.ApplicationCommitTime.Set(float64(time.Since(start)))
+	blockExec.metrics.ApplicationCommitTime.Observe(float64(time.Since(start)))
 
 	// ResponseCommit has no error code - just data
 	blockExec.logger.Info(
@@ -450,7 +450,7 @@ func (blockExec *BlockExecutor) Commit(
 		TxPostCheckForState(state),
 		state.ConsensusParams.ABCI.RecheckTx,
 	)
-	blockExec.metrics.UpdateMempoolTime.Set(float64(time.Since(start)))
+	blockExec.metrics.UpdateMempoolTime.Observe(float64(time.Since(start)))
 
 	return res.RetainHeight, err
 }

--- a/internal/state/execution.go
+++ b/internal/state/execution.go
@@ -413,18 +413,22 @@ func (blockExec *BlockExecutor) Commit(
 
 	// while mempool is Locked, flush to ensure all async requests have completed
 	// in the ABCI app before Commit.
+	start := time.Now()
 	err := blockExec.mempool.FlushAppConn(ctx)
 	if err != nil {
 		blockExec.logger.Error("client error during mempool.FlushAppConn", "err", err)
 		return 0, err
 	}
+	blockExec.metrics.FlushAppConnectionTime.Set(float64(time.Since(start)))
 
 	// Commit block, get hash back
+	start = time.Now()
 	res, err := blockExec.appClient.Commit(ctx)
 	if err != nil {
 		blockExec.logger.Error("client error during proxyAppConn.Commit", "err", err)
 		return 0, err
 	}
+	blockExec.metrics.ApplicationCommitTime.Set(float64(time.Since(start)))
 
 	// ResponseCommit has no error code - just data
 	blockExec.logger.Info(
@@ -436,6 +440,7 @@ func (blockExec *BlockExecutor) Commit(
 	)
 
 	// Update mempool.
+	start = time.Now()
 	err = blockExec.mempool.Update(
 		ctx,
 		block.Height,
@@ -445,6 +450,7 @@ func (blockExec *BlockExecutor) Commit(
 		TxPostCheckForState(state),
 		state.ConsensusParams.ABCI.RecheckTx,
 	)
+	blockExec.metrics.UpdateMempoolTime.Set(float64(time.Since(start)))
 
 	return res.RetainHeight, err
 }

--- a/internal/state/metrics.gen.go
+++ b/internal/state/metrics.gen.go
@@ -34,13 +34,34 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 			Name:      "validator_set_updates",
 			Help:      "Number of validator set updates returned by the application since process start.",
 		}, labels).With(labelsAndValues...),
+		FlushAppConnectionTime: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "flush_app_connection_time",
+			Help:      "ValidatorSetUpdates measures how long it takes async ABCI requests to be flushed before committing application state",
+		}, labels).With(labelsAndValues...),
+		ApplicationCommitTime: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "application_commit_time",
+			Help:      "ApplicationCommitTime meaures how long it takes to commit application state",
+		}, labels).With(labelsAndValues...),
+		UpdateMempoolTime: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "update_mempool_time",
+			Help:      "UpdateMempoolTime meaures how long it takes to update mempool after commiting, including reCheckTx",
+		}, labels).With(labelsAndValues...),
 	}
 }
 
 func NopMetrics() *Metrics {
 	return &Metrics{
-		BlockProcessingTime:   discard.NewHistogram(),
-		ConsensusParamUpdates: discard.NewCounter(),
-		ValidatorSetUpdates:   discard.NewCounter(),
+		BlockProcessingTime:    discard.NewHistogram(),
+		ConsensusParamUpdates:  discard.NewCounter(),
+		ValidatorSetUpdates:    discard.NewCounter(),
+		FlushAppConnectionTime: discard.NewGauge(),
+		ApplicationCommitTime:  discard.NewGauge(),
+		UpdateMempoolTime:      discard.NewGauge(),
 	}
 }

--- a/internal/state/metrics.gen.go
+++ b/internal/state/metrics.gen.go
@@ -34,19 +34,19 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 			Name:      "validator_set_updates",
 			Help:      "Number of validator set updates returned by the application since process start.",
 		}, labels).With(labelsAndValues...),
-		FlushAppConnectionTime: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
+		FlushAppConnectionTime: prometheus.NewHistogramFrom(stdprometheus.HistogramOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "flush_app_connection_time",
 			Help:      "ValidatorSetUpdates measures how long it takes async ABCI requests to be flushed before committing application state",
 		}, labels).With(labelsAndValues...),
-		ApplicationCommitTime: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
+		ApplicationCommitTime: prometheus.NewHistogramFrom(stdprometheus.HistogramOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "application_commit_time",
 			Help:      "ApplicationCommitTime meaures how long it takes to commit application state",
 		}, labels).With(labelsAndValues...),
-		UpdateMempoolTime: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
+		UpdateMempoolTime: prometheus.NewHistogramFrom(stdprometheus.HistogramOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "update_mempool_time",
@@ -60,8 +60,8 @@ func NopMetrics() *Metrics {
 		BlockProcessingTime:    discard.NewHistogram(),
 		ConsensusParamUpdates:  discard.NewCounter(),
 		ValidatorSetUpdates:    discard.NewCounter(),
-		FlushAppConnectionTime: discard.NewGauge(),
-		ApplicationCommitTime:  discard.NewGauge(),
-		UpdateMempoolTime:      discard.NewGauge(),
+		FlushAppConnectionTime: discard.NewHistogram(),
+		ApplicationCommitTime:  discard.NewHistogram(),
+		UpdateMempoolTime:      discard.NewHistogram(),
 	}
 }

--- a/internal/state/metrics.go
+++ b/internal/state/metrics.go
@@ -29,12 +29,12 @@ type Metrics struct {
 
 	// ValidatorSetUpdates measures how long it takes async ABCI requests to be flushed before
 	// committing application state
-	FlushAppConnectionTime metrics.Gauge
+	FlushAppConnectionTime metrics.Histogram
 
 	// ApplicationCommitTime meaures how long it takes to commit application state
-	ApplicationCommitTime metrics.Gauge
+	ApplicationCommitTime metrics.Histogram
 
 	// UpdateMempoolTime meaures how long it takes to update mempool after commiting, including
 	// reCheckTx
-	UpdateMempoolTime metrics.Gauge
+	UpdateMempoolTime metrics.Histogram
 }

--- a/internal/state/metrics.go
+++ b/internal/state/metrics.go
@@ -26,4 +26,15 @@ type Metrics struct {
 	// udated the validator set since process start.
 	//metrics:Number of validator set updates returned by the application since process start.
 	ValidatorSetUpdates metrics.Counter
+
+	// ValidatorSetUpdates measures how long it takes async ABCI requests to be flushed before
+	// committing application state
+	FlushAppConnectionTime metrics.Gauge
+
+	// ApplicationCommitTime meaures how long it takes to commit application state
+	ApplicationCommitTime metrics.Gauge
+
+	// UpdateMempoolTime meaures how long it takes to update mempool after commiting, including
+	// reCheckTx
+	UpdateMempoolTime metrics.Gauge
 }


### PR DESCRIPTION
## Describe your changes and provide context
Add gauge metrics at 4 places:
- between receiving the proposal header and processing the last part of the proposal
- flushing async ABCI requests before application commit
- application commit
- mempool update (include recheck tx) after application commit

## Testing performed to validate your change

