### PR TITLE
Adjust persistent peer scores as needed as well

### DIFF
--- a/internal/p2p/peermanager.go
+++ b/internal/p2p/peermanager.go
@@ -1373,20 +1373,22 @@ func (p *peerInfo) Score() PeerScore {
 	if p.Unconditional {
 		return PeerScoreUnconditional
 	}
-	if p.Persistent {
-		return PeerScorePersistent
-	}
 
 	score := p.MutableScore
+	if p.Persistent {
+		score = int64(PeerScorePersistent)
+	}
+
 	for _, addr := range p.AddressInfo {
 		// DialFailures is reset when dials succeed, so this
 		// is either the number of dial failures or 0.
 		score -= int64(addr.DialFailures)
 	}
+
 	// We consider lowering the score for every 3 disconnection events
 	score -= p.NumOfDisconnections / 3
 
-	if score > int64(MaxPeerScoreNotPersistent) {
+	if !p.Persistent && score > int64(MaxPeerScoreNotPersistent) {
 		score = int64(MaxPeerScoreNotPersistent)
 	}
 

--- a/internal/p2p/peermanager_scoring_test.go
+++ b/internal/p2p/peermanager_scoring_test.go
@@ -93,14 +93,12 @@ func TestPeerScoring(t *testing.T) {
 	})
 	t.Run("TestNonPersistantPeerUpperBound", func(t *testing.T) {
 		start := int64(peerManager.Scores()[id] + 1)
-		println(peerManager.Scores()[id])
 		for i := start; i <= int64(PeerScorePersistent)+start; i++ {
 			peerManager.processPeerEvent(ctx, PeerUpdate{
 				NodeID: id,
 				Status: PeerStatusGood,
 			})
 
-			println(peerManager.Scores()[id])
 			if i >= int64(PeerScorePersistent) {
 				require.EqualValues(t, MaxPeerScoreNotPersistent, peerManager.Scores()[id])
 			} else {

--- a/internal/p2p/peermanager_test.go
+++ b/internal/p2p/peermanager_test.go
@@ -167,6 +167,7 @@ func TestNewPeerManager_Persistence(t *testing.T) {
 	require.ElementsMatch(t, aAddresses, peerManager.Addresses(aID))
 	require.ElementsMatch(t, bAddresses, peerManager.Addresses(bID))
 	require.ElementsMatch(t, cAddresses, peerManager.Addresses(cID))
+
 	require.Equal(t, map[types.NodeID]p2p.PeerScore{
 		aID: p2p.PeerScorePersistent,
 		bID: 1,

--- a/internal/p2p/peermanager_test.go
+++ b/internal/p2p/peermanager_test.go
@@ -191,6 +191,15 @@ func TestNewPeerManager_Persistence(t *testing.T) {
 		bID: p2p.PeerScorePersistent,
 		cID: 1,
 	}, peerManager.Scores())
+
+	// Introduce a dial failure and persistent peer score should be reduced by one
+	ctx, _ := context.WithCancel(context.Background())
+	peerManager.DialFailed(ctx, bAddresses[0])
+	require.Equal(t, map[types.NodeID]p2p.PeerScore{
+		aID: 0,
+		bID: p2p.PeerScorePersistent - 1,
+		cID: 1,
+	}, peerManager.Scores())
 }
 
 func TestNewPeerManager_Unconditional(t *testing.T) {


### PR DESCRIPTION
## Describe your changes and provide context
Persistent cores are now hard codes to be 254, however it makes more sense to also dynamically adjust the score even if the peer is a persistent peer based on it's actual quality.

## Testing performed to validate your change
Unit test covered the case

