### PR TITLE
[DBSync] allow empty files to be synced

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1261,7 +1261,14 @@ func (cfg *InstrumentationConfig) ValidateBasic() error {
 }
 
 type DBSyncConfig struct {
-	Enable               bool          `mapstructure:"db-sync-enable"`
+	// When true, the node will try to import DB files that overwrite its
+	// application DB. Note that it will NOT automatically detect whether
+	// the application DB is good-to-go or not upon start, and will always
+	// perform the import, so if the import is complete, this flag should
+	// be turned off the next time the chain restarts.
+	Enable bool `mapstructure:"db-sync-enable"`
+	// This is NOT currently used but reserved for future implementation
+	// of snapshotting logics that don't require chain halts.
 	SnapshotInterval     int           `mapstructure:"snapshot-interval"`
 	SnapshotDirectory    string        `mapstructure:"snapshot-directory"`
 	SnapshotWorkerCount  int           `mapstructure:"snapshot-worker-count"`

--- a/internal/dbsync/reactor.go
+++ b/internal/dbsync/reactor.go
@@ -349,7 +349,9 @@ func (r *Reactor) handleFileMessage(ctx context.Context, envelope *p2p.Envelope)
 		return r.handleFileRequest(ctx, msg, envelope.From)
 
 	case *dstypes.FileResponse:
-		if len(msg.Data) == 0 {
+		// using msg.Height is a more reliable check for empty response than
+		// check msg.Data since it's valid to have empty files sync'ed over
+		if msg.Height == 0 {
 			return nil
 		}
 		r.syncer.PushFile(msg)


### PR DESCRIPTION
## Describe your changes and provide context
It's possible for a valid file to have no data in it, in which case we don't want to discard it. Using whether the height associated with the file is zero is a more reliable check for whether the response is empty

## Testing performed to validate your change
tested on psu-test-4

