### PR TITLE
add LegacyHexBytes

### DIFF
--- a/libs/bytes/bytes.go
+++ b/libs/bytes/bytes.go
@@ -69,3 +69,15 @@ func (bz HexBytes) Format(s fmt.State, verb rune) {
 		s.Write([]byte(fmt.Sprintf("%X", []byte(bz))))
 	}
 }
+
+type LegacyHexBytes struct {
+	HexBytes
+}
+
+func (bz LegacyHexBytes) MarshalJSON() ([]byte, error) {
+	return bz.MarshalText()
+}
+
+func (bz *LegacyHexBytes) UnmarshalJSON(data []byte) error {
+	return bz.UnmarshalText(data)
+}


### PR DESCRIPTION
## Describe your changes and provide context
`wasmd` needs HexBytes to have `MarshalJSON`\`UnmarshalJSON` implemented whereas sei-tendermint doesn't need to have it (otherwise importing GenDoc would fail)

## Testing performed to validate your change
local sei

