### PR TITLE
Do not run DBSync if there is already a readable app version

### DIFF
--- a/internal/dbsync/syncer.go
+++ b/internal/dbsync/syncer.go
@@ -70,6 +70,7 @@ func NewSyncer(
 	logger log.Logger,
 	dbsyncConfig config.DBSyncConfig,
 	baseConfig config.BaseConfig,
+	enable bool,
 	metadataRequestFn func(context.Context) error,
 	fileRequestFn func(context.Context, types.NodeID, uint64, string) error,
 	commitStateFn func(context.Context, uint64) (sm.State, *types.Commit, error),
@@ -78,7 +79,7 @@ func NewSyncer(
 ) *Syncer {
 	return &Syncer{
 		logger:                 logger,
-		active:                 dbsyncConfig.Enable,
+		active:                 enable,
 		timeoutInSeconds:       time.Duration(dbsyncConfig.TimeoutInSeconds) * time.Second,
 		fileQueue:              []*dstypes.FileResponse{},
 		applicationDBDirectory: path.Join(baseConfig.DBDir(), ApplicationDBSubdirectory),

--- a/internal/dbsync/syncer_test.go
+++ b/internal/dbsync/syncer_test.go
@@ -24,6 +24,7 @@ func getTestSyncer(t *testing.T) *Syncer {
 		log.NewNopLogger(),
 		*dbsyncConfig,
 		baseConfig,
+		true,
 		func(ctx context.Context) error { return nil },
 		func(ctx context.Context, ni types.NodeID, u uint64, s string) error { return nil },
 		func(ctx context.Context, u uint64) (state.State, *types.Commit, error) {


### PR DESCRIPTION
## Describe your changes and provide context
If application DB already has a non-zero version (e.g. if the process restarts after DBSync finishes), we do not want to wipe out everything and rerun DBSync

## Testing performed to validate your change
loadtest cluster
