### PR TITLE
Add helper to try unmarshaling eventdata

### DIFF
--- a/types/events.go
+++ b/types/events.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -518,4 +519,13 @@ func eventWithAttr(etype, value string) abci.Event {
 			Key: []byte(parts[1]), Value: []byte(value),
 		}},
 	}
+}
+
+func TryUnmarshalEventData(data json.RawMessage) (EventData, error) {
+	var eventData EventData
+	err := jsontypes.Unmarshal(data, &eventData)
+	if err != nil {
+		return nil, err
+	}
+	return eventData, nil
 }

--- a/types/events_test.go
+++ b/types/events_test.go
@@ -1,10 +1,14 @@
 package types
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tendermint/tendermint/abci/types"
+	"github.com/tendermint/tendermint/internal/jsontypes"
 )
 
 // Verify that the event data types satisfy their shared interface.
@@ -40,4 +44,23 @@ func TestQueryForEvent(t *testing.T) {
 		"tm.event = 'NewEvidence'",
 		QueryForEvent(EventNewEvidenceValue).String(),
 	)
+}
+
+func TestTryUnmarshalForEvent(t *testing.T) {
+	eventData := EventDataTx{
+		TxResult: types.TxResult{
+			Height: 123,
+		},
+	}
+	garbage := json.RawMessage("stuff")
+
+	bz, err := jsontypes.Marshal(eventData)
+	require.NoError(t, err)
+
+	unmarshaled, err := TryUnmarshalEventData(json.RawMessage(bz))
+	require.NoError(t, err)
+	assert.Equal(t, eventData, unmarshaled)
+
+	_, err = TryUnmarshalEventData(garbage)
+	require.Error(t, err)
 }


### PR DESCRIPTION
## Describe your changes and provide context
This adds a helper to parse event data for use with eventstream to make use of parsed eventdata by other applications

## Testing performed to validate your change
Adding unit tests