### PR TITLE
Add check for nil peer address map

### DIFF
--- a/internal/p2p/peermanager.go
+++ b/internal/p2p/peermanager.go
@@ -444,6 +444,9 @@ func (m *PeerManager) Add(address NodeAddress) (bool, error) {
 	}
 
 	// else add the new address
+	if len(peer.AddressInfo) == 0 {
+		peer.AddressInfo = make(map[NodeAddress]*peerAddressInfo)
+	}
 	peer.AddressInfo[address] = &peerAddressInfo{Address: address}
 	m.logger.Info(fmt.Sprintf("Adding new peer %s with address %s to peer store\n", peer.ID, address.String()))
 	if err := m.store.Set(peer); err != nil {


### PR DESCRIPTION
## Describe your changes and provide context
Validator reported following error:
```
panic: assignment to entry in nil map

goroutine 968 [running]:
github.com/tendermint/tendermint/internal/p2p.(PeerManager).Add(0xc0002b8000, {{0xc0d0557928, 0x28}, {0xc0d0557920, 0x5}, {0xc0d0557951, 0x1b}, 0x777d, {0x0, 0x0}})
        /root/go/pkg/mod/github.com/sei-protocol/sei-tendermint@v0.2.4/internal/p2p/peermanager.go:435 +0x505
github.com/tendermint/tendermint/internal/p2p/pex.(Reactor).handlePexMessage(0xc002187040, {0x2bb9610, 0xc0005b88c0}, 0xc133f48800, 0x1?)
        /root/go/pkg/mod/github.com/sei-protocol/sei-tendermint@v0.2.4/internal/p2p/pex/reactor.go:303 +0x72b
github.com/tendermint/tendermint/internal/p2p/pex.(Reactor).processPexCh(0xc002187040, {0x2bb9610?, 0xc0005b88c0}, 0xc0027064e0)
        /root/go/pkg/mod/github.com/sei-protocol/sei-tendermint@v0.2.4/internal/p2p/pex/reactor.go:221 +0x528
created by github.com/tendermint/tendermint/internal/p2p/pex.(Reactor).OnStart
        /root/go/pkg/mod/github.com/sei-protocol/sei-tendermint@v0.2.4/internal/p2p/pex/reactor.go:152 +0xd0
```

This adds a check to fix it
## Testing performed to validate your change
unit tests, and will deploy
