### PR TITLE
Auto switch to blocksync should only start in consensus mode

### DIFF
--- a/internal/blocksync/reactor.go
+++ b/internal/blocksync/reactor.go
@@ -332,6 +332,7 @@ func (r *Reactor) autoRestartIfBehind(ctx context.Context) {
 		return
 	}
 
+	r.logger.Info("checking if node is behind threshold, auto restarting if its behind", "threshold", r.blocksBehindThreshold, "interval", r.blocksBehindCheckInterval)
 	for {
 		select {
 		case <-time.After(r.blocksBehindCheckInterval):

--- a/internal/blocksync/reactor.go
+++ b/internal/blocksync/reactor.go
@@ -172,8 +172,6 @@ func (r *Reactor) OnStart(ctx context.Context) error {
 		go r.poolRoutine(ctx, false, r.channel)
 	}
 
-	go r.autoRestartIfBehind(ctx)
-
 	go r.processBlockSyncCh(ctx, r.channel)
 	go r.processPeerUpdates(ctx, r.peerEvents(ctx), r.channel)
 
@@ -566,6 +564,9 @@ func (r *Reactor) poolRoutine(ctx context.Context, stateSynced bool, blockSyncCh
 			if r.consReactor != nil {
 				r.logger.Info("switching to consensus reactor", "height", height, "blocks_synced", blocksSynced, "state_synced", stateSynced, "max_peer_height", r.pool.MaxPeerHeight())
 				r.consReactor.SwitchToConsensus(ctx, state, blocksSynced > 0 || stateSynced)
+
+				// Auto restart should only be checked after switching to consensus mode
+				go r.autoRestartIfBehind(ctx)
 			}
 
 			return


### PR DESCRIPTION
## Describe your changes and provide context
we should start the go routine for auto restarting after all the syncs are complete and we switch into consensus mode 

## Testing performed to validate your change
patched rpc node with this change and see that it waited until it finished catching up before it started the go routine

![image](https://github.com/sei-protocol/sei-tendermint/assets/18161326/c0efd81b-118f-4fd8-88b5-a7639a0a2080)


```
#######################################################
###       SelfRemediation Configuration Options     ###
#######################################################
[self-remediation]

# If the node has no p2p peers available then trigger a restart
# Set to 0 to disable
p2p-no-peers-available-window-seconds = 0

# If node has no peers for statesync after a period of time then restart
# Set to 0 to disable
statesync-no-peers-available-window-seconds = 0

# Threshold for how far back the node can be behind the current block height before triggering a restart
# Set to 0 to disable
blocks-behind-threshold = 300

# How often to check if node is behind
blocks-behind-check-interval = 30

# Cooldown between each restart
restart-cooldown-seconds = 1800

```

![image](https://github.com/sei-protocol/sei-tendermint/assets/18161326/94f80216-f516-44df-8c61-56dd485a2faf)
