### PR TITLE
Add new endpoint to expose lag

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -515,6 +515,9 @@ type RPCConfig struct {
 
 	// pprof listen address (https://golang.org/pkg/net/http/pprof)
 	PprofListenAddress string `mapstructure:"pprof-laddr"`
+
+	// Lag threshold determines the threshold for whether the /lag_status endpoint returns OK or not
+	LagThreshold int64 `mapstructure:"lag-threshold"`
 }
 
 // DefaultRPCConfig returns a default configuration for the RPC server
@@ -540,8 +543,9 @@ func DefaultRPCConfig() *RPCConfig {
 		MaxBodyBytes:   int64(1000000), // 1MB
 		MaxHeaderBytes: 1 << 20,        // same as the net/http default
 
-		TLSCertFile: "",
-		TLSKeyFile:  "",
+		TLSCertFile:  "",
+		TLSKeyFile:   "",
+		LagThreshold: 300,
 	}
 }
 
@@ -579,6 +583,9 @@ func (cfg *RPCConfig) ValidateBasic() error {
 	}
 	if cfg.MaxHeaderBytes < 0 {
 		return errors.New("max-header-bytes can't be negative")
+	}
+	if cfg.LagThreshold < 0 {
+		return errors.New("lag-threshold can't be negative")
 	}
 	return nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -554,6 +554,7 @@ func TestRPCConfig() *RPCConfig {
 	cfg := DefaultRPCConfig()
 	cfg.ListenAddress = "tcp://127.0.0.1:36657"
 	cfg.Unsafe = true
+	cfg.LagThreshold = 300
 	return cfg
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -69,6 +69,7 @@ func TestRPCConfigValidateBasic(t *testing.T) {
 		"TimeoutBroadcastTxCommit",
 		"MaxBodyBytes",
 		"MaxHeaderBytes",
+		"LagThreshold",
 	}
 
 	for _, fieldName := range fieldsToTest {

--- a/internal/p2p/router.go
+++ b/internal/p2p/router.go
@@ -709,7 +709,9 @@ func (r *Router) dialPeer(ctx context.Context, address NodeAddress) (Connection,
 	case err != nil:
 		// Mark the peer as private so it's not broadcasted to other peers.
 		// This is reset upon restart of the node.
-		r.peerManager.options.PrivatePeers[address.NodeID] = struct{}{}
+		if r.peerManager.options.PrivatePeers != nil {
+			r.peerManager.options.PrivatePeers[address.NodeID] = struct{}{}
+		}
 		return nil, fmt.Errorf("failed to resolve address %q: %w", address, err)
 	case len(endpoints) == 0:
 		return nil, fmt.Errorf("address %q did not resolve to any endpoints", address)

--- a/internal/rpc/core/doc.go
+++ b/internal/rpc/core/doc.go
@@ -22,6 +22,7 @@ Available endpoints:
 /net_info
 /num_unconfirmed_txs
 /status
+/lag_status
 /health
 /unconfirmed_txs
 /unsafe_flush_mempool

--- a/internal/rpc/core/events.go
+++ b/internal/rpc/core/events.go
@@ -72,7 +72,7 @@ func (env *Environment) Subscribe(ctx context.Context, req *coretypes.RequestSub
 				return
 			} else if errors.Is(err, tmpubsub.ErrTerminated) {
 				// The subscription was terminated by the publisher.
-				resp := callInfo.RPCRequest.MakeError(err)
+				resp := callInfo.RPCRequest.MakeError(nil, err)
 				ok := callInfo.WSConn.TryWriteRPCResponse(opctx, resp)
 				if !ok {
 					env.Logger.Info("Unable to write response (slow client)",

--- a/internal/rpc/core/lag_status.go
+++ b/internal/rpc/core/lag_status.go
@@ -2,7 +2,6 @@ package core
 
 import (
 	"context"
-	"fmt"
 	"github.com/tendermint/tendermint/rpc/coretypes"
 )
 
@@ -22,8 +21,6 @@ func (env *Environment) LagStatus(ctx context.Context) (*coretypes.ResultLagStat
 		MaxPeerHeight: maxPeerBlockHeight,
 		Lag:           lag,
 	}
-
-	fmt.Printf("[Tendermint-Debug] Lag is %d and threshold is %d\n", lag, env.Config.LagThreshold)
 
 	// Return a response with error code to differentiate the lagging status by http response code
 	if lag > env.Config.LagThreshold {

--- a/internal/rpc/core/lag_status.go
+++ b/internal/rpc/core/lag_status.go
@@ -7,17 +7,17 @@ import (
 
 // LagStatus returns Tendermint lag status, if lag is over a certain threshold
 func (env *Environment) LagStatus(ctx context.Context) (*coretypes.ResultLagStatus, error) {
-	latestHeight := env.BlockStore.Height()
+	currentHeight := env.BlockStore.Height()
 	maxPeerBlockHeight := env.BlockSyncReactor.GetMaxPeerBlockHeight()
 	lag := int64(0)
 
 	// Calculate lag
-	if maxPeerBlockHeight > latestHeight {
-		lag = maxPeerBlockHeight - latestHeight
+	if maxPeerBlockHeight > currentHeight {
+		lag = maxPeerBlockHeight - currentHeight
 	}
 
 	result := &coretypes.ResultLagStatus{
-		LatestHeight:  latestHeight,
+		CurrentHeight: currentHeight,
 		MaxPeerHeight: maxPeerBlockHeight,
 		Lag:           lag,
 	}

--- a/internal/rpc/core/lag_status.go
+++ b/internal/rpc/core/lag_status.go
@@ -1,0 +1,33 @@
+package core
+
+import (
+	"context"
+	"github.com/tendermint/tendermint/rpc/coretypes"
+	"github.com/tendermint/tendermint/rpc/jsonrpc/types"
+)
+
+// LagStatus returns Tendermint lag status, if lag is over a certain threshold
+func (env *Environment) LagStatus(ctx context.Context) (*coretypes.ResultLagStatus, error) {
+	latestHeight := env.BlockStore.Height()
+	maxPeerBlockHeight := env.BlockSyncReactor.GetMaxPeerBlockHeight()
+	lag := int64(0)
+
+	// Calculate lag
+	if maxPeerBlockHeight > latestHeight {
+		lag = maxPeerBlockHeight - latestHeight
+	}
+
+	result := &coretypes.ResultLagStatus{
+		LatestHeight:  latestHeight,
+		MaxPeerHeight: maxPeerBlockHeight,
+		Lag:           lag,
+	}
+
+	// Return a response with error code to differentiate the lagging status by http response code
+	if lag > env.Config.LagThreshold {
+		err := types.LagIsTooHighError
+		return result, err
+	}
+
+	return result, nil
+}

--- a/internal/rpc/core/lag_status.go
+++ b/internal/rpc/core/lag_status.go
@@ -2,8 +2,8 @@ package core
 
 import (
 	"context"
+	"fmt"
 	"github.com/tendermint/tendermint/rpc/coretypes"
-	"github.com/tendermint/tendermint/rpc/jsonrpc/types"
 )
 
 // LagStatus returns Tendermint lag status, if lag is over a certain threshold
@@ -23,10 +23,11 @@ func (env *Environment) LagStatus(ctx context.Context) (*coretypes.ResultLagStat
 		Lag:           lag,
 	}
 
+	fmt.Printf("[Tendermint-Debug] Lag is %d and threshold is %d\n", lag, env.Config.LagThreshold)
+
 	// Return a response with error code to differentiate the lagging status by http response code
 	if lag > env.Config.LagThreshold {
-		err := types.LagIsTooHighError
-		return result, err
+		return result, coretypes.ErrLagIsTooHigh
 	}
 
 	return result, nil

--- a/internal/rpc/core/routes.go
+++ b/internal/rpc/core/routes.go
@@ -36,6 +36,7 @@ func NewRoutesMap(svc RPCService, opts *RouteOptions) RoutesMap {
 		// info API
 		"health":               rpc.NewRPCFunc(svc.Health),
 		"status":               rpc.NewRPCFunc(svc.Status),
+		"lag_status":           rpc.NewRPCFunc(svc.LagStatus),
 		"net_info":             rpc.NewRPCFunc(svc.NetInfo),
 		"blockchain":           rpc.NewRPCFunc(svc.BlockchainInfo),
 		"genesis":              rpc.NewRPCFunc(svc.Genesis),
@@ -109,6 +110,7 @@ type RPCService interface {
 	NumUnconfirmedTxs(ctx context.Context) (*coretypes.ResultUnconfirmedTxs, error)
 	RemoveTx(ctx context.Context, req *coretypes.RequestRemoveTx) error
 	Status(ctx context.Context) (*coretypes.ResultStatus, error)
+	LagStatus(ctx context.Context) (*coretypes.ResultLagStatus, error)
 	Subscribe(ctx context.Context, req *coretypes.RequestSubscribe) (*coretypes.ResultSubscribe, error)
 	Tx(ctx context.Context, req *coretypes.RequestTx) (*coretypes.ResultTx, error)
 	TxSearch(ctx context.Context, req *coretypes.RequestTxSearch) (*coretypes.ResultTxSearch, error)

--- a/light/proxy/routes.go
+++ b/light/proxy/routes.go
@@ -124,6 +124,10 @@ func (p proxyService) Status(ctx context.Context) (*coretypes.ResultStatus, erro
 	return p.Client.Status(ctx)
 }
 
+func (p proxyService) LagStatus(ctx context.Context) (*coretypes.ResultLagStatus, error) {
+	return p.Client.LagStatus(ctx)
+}
+
 func (p proxyService) Subscribe(ctx context.Context, req *coretypes.RequestSubscribe) (*coretypes.ResultSubscribe, error) {
 	return p.Client.SubscribeWS(ctx, req.Query)
 }

--- a/light/rpc/client.go
+++ b/light/rpc/client.go
@@ -26,6 +26,7 @@ import (
 type KeyPathFunc func(path string, key []byte) (merkle.KeyPath, error)
 
 // LightClient is an interface that contains functionality needed by Client from the light client.
+//
 //go:generate ../../scripts/mockery_generate.sh LightClient
 type LightClient interface {
 	ChainID() string
@@ -131,6 +132,11 @@ func (c *Client) Status(ctx context.Context) (*coretypes.ResultStatus, error) {
 		ValidatorInfo:   coretypes.ValidatorInfo{},
 		LightClientInfo: *lightClientInfo,
 	}, nil
+}
+
+// LagStatus  return 0 for lag status
+func (c *Client) LagStatus(ctx context.Context) (*coretypes.ResultLagStatus, error) {
+	return &coretypes.ResultLagStatus{}, nil
 }
 
 func (c *Client) ABCIInfo(ctx context.Context) (*coretypes.ResultABCIInfo, error) {

--- a/rpc/client/http/http.go
+++ b/rpc/client/http/http.go
@@ -199,6 +199,14 @@ func (c *baseRPCClient) Status(ctx context.Context) (*coretypes.ResultStatus, er
 	return result, nil
 }
 
+func (c *baseRPCClient) LagStatus(ctx context.Context) (*coretypes.ResultLagStatus, error) {
+	result := new(coretypes.ResultLagStatus)
+	if err := c.caller.Call(ctx, "lag_status", nil, result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
 func (c *baseRPCClient) ABCIInfo(ctx context.Context) (*coretypes.ResultABCIInfo, error) {
 	result := new(coretypes.ResultABCIInfo)
 	if err := c.caller.Call(ctx, "abci_info", nil, result); err != nil {

--- a/rpc/client/interface.go
+++ b/rpc/client/interface.go
@@ -111,6 +111,7 @@ type HistoryClient interface {
 // StatusClient provides access to general chain info.
 type StatusClient interface {
 	Status(context.Context) (*coretypes.ResultStatus, error)
+	LagStatus(context.Context) (*coretypes.ResultLagStatus, error)
 }
 
 // NetworkClient is general info about the network state. May not be needed

--- a/rpc/client/local/local.go
+++ b/rpc/client/local/local.go
@@ -69,6 +69,10 @@ func (c *Local) Status(ctx context.Context) (*coretypes.ResultStatus, error) {
 	return c.env.Status(ctx)
 }
 
+func (c *Local) LagStatus(ctx context.Context) (*coretypes.ResultLagStatus, error) {
+	return c.env.LagStatus(ctx)
+}
+
 func (c *Local) ABCIInfo(ctx context.Context) (*coretypes.ResultABCIInfo, error) {
 	return c.env.ABCIInfo(ctx)
 }

--- a/rpc/client/mock/client.go
+++ b/rpc/client/mock/client.go
@@ -41,7 +41,6 @@ var _ client.Client = Client{}
 
 // Call is used by recorders to save a call and response.
 // It can also be used to configure mock responses.
-//
 type Call struct {
 	Name     string
 	Args     interface{}
@@ -76,6 +75,10 @@ func (c Call) GetResponse(args interface{}) (interface{}, error) {
 
 func (c Client) Status(ctx context.Context) (*coretypes.ResultStatus, error) {
 	return c.env.Status(ctx)
+}
+
+func (c Client) LagStatus(ctx context.Context) (*coretypes.ResultLagStatus, error) {
+	return c.env.LagStatus(ctx)
 }
 
 func (c Client) ABCIInfo(ctx context.Context) (*coretypes.ResultABCIInfo, error) {

--- a/rpc/client/mock/status.go
+++ b/rpc/client/mock/status.go
@@ -25,6 +25,14 @@ func (m *StatusMock) Status(ctx context.Context) (*coretypes.ResultStatus, error
 	return res.(*coretypes.ResultStatus), nil
 }
 
+func (m *StatusMock) LagStatus(ctx context.Context) (*coretypes.ResultLagStatus, error) {
+	res, err := m.GetResponse(nil)
+	if err != nil {
+		return nil, err
+	}
+	return res.(*coretypes.ResultLagStatus), nil
+}
+
 // StatusRecorder can wrap another type (StatusMock, full client)
 // and record the status calls
 type StatusRecorder struct {
@@ -47,6 +55,16 @@ func (r *StatusRecorder) Status(ctx context.Context) (*coretypes.ResultStatus, e
 	res, err := r.Client.Status(ctx)
 	r.addCall(Call{
 		Name:     "status",
+		Response: res,
+		Error:    err,
+	})
+	return res, err
+}
+
+func (r *StatusRecorder) LagStatus(ctx context.Context) (*coretypes.ResultLagStatus, error) {
+	res, err := r.Client.LagStatus(ctx)
+	r.addCall(Call{
+		Name:     "lag_status",
 		Response: res,
 		Error:    err,
 	})

--- a/rpc/coretypes/responses.go
+++ b/rpc/coretypes/responses.go
@@ -22,6 +22,7 @@ var (
 	ErrZeroOrNegativeHeight   = errors.New("height must be greater than zero")
 	ErrHeightExceedsChainHead = errors.New("height must be less than or equal to the head of the node's blockchain")
 	ErrHeightNotAvailable     = errors.New("height is not available")
+	ErrLagIsTooHigh           = errors.New("lag is too high")
 	// ErrInvalidRequest is used as a wrapper to cover more specific cases where the user has
 	// made an invalid request
 	ErrInvalidRequest = errors.New("invalid request")
@@ -164,6 +165,13 @@ type ResultStatus struct {
 	SyncInfo        SyncInfo              `json:"sync_info"`
 	ValidatorInfo   ValidatorInfo         `json:"validator_info"`
 	LightClientInfo types.LightClientInfo `json:"light_client_info,omitempty"`
+}
+
+// Node lag status
+type ResultLagStatus struct {
+	LatestHeight  int64 `json:"current_height"`
+	MaxPeerHeight int64 `json:"max_peer_height"`
+	Lag           int64 `json:"lag"`
 }
 
 // Is TxIndexing enabled

--- a/rpc/coretypes/responses.go
+++ b/rpc/coretypes/responses.go
@@ -169,7 +169,7 @@ type ResultStatus struct {
 
 // Node lag status
 type ResultLagStatus struct {
-	LatestHeight  int64 `json:"current_height"`
+	CurrentHeight int64 `json:"current_height"`
 	MaxPeerHeight int64 `json:"max_peer_height"`
 	Lag           int64 `json:"lag"`
 }

--- a/rpc/jsonrpc/server/http_json_handler.go
+++ b/rpc/jsonrpc/server/http_json_handler.go
@@ -68,7 +68,7 @@ func makeJSONRPCHandler(funcMap map[string]*RPCFunc, logger log.Logger) http.Han
 			})
 			result, err := rpcFunc.Call(ctx, req.Params)
 			if err != nil {
-				responses = append(responses, req.MakeError(err))
+				responses = append(responses, req.MakeError(result, err))
 			} else {
 				responses = append(responses, req.MakeResponse(result))
 			}

--- a/rpc/jsonrpc/server/http_server.go
+++ b/rpc/jsonrpc/server/http_server.go
@@ -119,12 +119,12 @@ func ServeTLS(ctx context.Context, listener net.Listener, handler http.Handler, 
 	return nil
 }
 
-// writeInternalError writes an internal server error (500) to w with the text
+// writeError writes an internal server error (500) to w with the text
 // of err in the body. This is a fallback used when a handler is unable to
 // write the expected response.
-func writeInternalError(w http.ResponseWriter, err error) {
+func writeError(w http.ResponseWriter, statusCode int, err error) {
 	w.Header().Set("Content-Type", "text/plain")
-	w.WriteHeader(http.StatusInternalServerError)
+	w.WriteHeader(statusCode)
 	fmt.Fprintln(w, err.Error())
 }
 
@@ -140,13 +140,18 @@ func writeHTTPResponse(w http.ResponseWriter, log log.Logger, rsp rpctypes.RPCRe
 	} else {
 		body = rsp.Result
 	}
-	if err != nil {
+	if err != nil && len(body) <= 0 {
 		log.Error("Error encoding RPC response: %w", err)
-		writeInternalError(w, err)
+		writeError(w, http.StatusInternalServerError, err)
 		return
 	}
+	statusCode := http.StatusOK
+	// If there's any error for lag is high, override the status code
+	if rsp.Error.Code == int(rpctypes.CodeLagIsHighError) {
+		statusCode = http.StatusExpectationFailed
+	}
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
+	w.WriteHeader(statusCode)
 	_, _ = w.Write(body)
 }
 
@@ -165,11 +170,19 @@ func writeRPCResponse(w http.ResponseWriter, log log.Logger, rsps ...rpctypes.RP
 	}
 	if err != nil {
 		log.Error("Error encoding RPC response: %w", err)
-		writeInternalError(w, err)
+		writeError(w, http.StatusInternalServerError, err)
 		return
 	}
+	statusCode := http.StatusOK
+	for _, res := range rsps {
+		// If there's any error for lag is high, override the status code
+		if res.Error.Code == int(rpctypes.CodeLagIsHighError) {
+			statusCode = http.StatusExpectationFailed
+			break
+		}
+	}
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
+	w.WriteHeader(statusCode)
 	_, _ = w.Write(body)
 }
 
@@ -203,7 +216,7 @@ func recoverAndLogHandler(handler http.Handler, logger log.Logger) http.Handler 
 
 				logger.Error("Panic in RPC HTTP handler",
 					"err", err, "stack", string(debug.Stack()))
-				writeInternalError(rww, err)
+				writeError(rww, http.StatusInternalServerError, err)
 			}
 		}()
 

--- a/rpc/jsonrpc/server/http_server.go
+++ b/rpc/jsonrpc/server/http_server.go
@@ -147,10 +147,12 @@ func writeHTTPResponse(w http.ResponseWriter, log log.Logger, rsp rpctypes.RPCRe
 	}
 	statusCode := http.StatusOK
 	// If there's any error for lag is high, override the status code
+	fmt.Printf("[Tendermint-Debug] rsp.Error.Code is %d\n", rsp.Error.Code)
 	if rsp.Error != nil && rsp.Error.Code == int(rpctypes.CodeLagIsHighError) {
 		statusCode = http.StatusExpectationFailed
 	}
 	w.Header().Set("Content-Type", "application/json")
+	fmt.Printf("[Tendermint-Debug] Setting status code to %d\n", statusCode)
 	w.WriteHeader(statusCode)
 	_, _ = w.Write(body)
 }

--- a/rpc/jsonrpc/server/http_server.go
+++ b/rpc/jsonrpc/server/http_server.go
@@ -152,7 +152,6 @@ func writeHTTPResponse(w http.ResponseWriter, log log.Logger, rsp rpctypes.RPCRe
 		statusCode = http.StatusExpectationFailed
 	}
 	w.Header().Set("Content-Type", "application/json")
-	fmt.Printf("[Tendermint-Debug] Setting status code to %d\n", statusCode)
 	w.WriteHeader(statusCode)
 	_, _ = w.Write(body)
 }

--- a/rpc/jsonrpc/server/http_server.go
+++ b/rpc/jsonrpc/server/http_server.go
@@ -147,7 +147,7 @@ func writeHTTPResponse(w http.ResponseWriter, log log.Logger, rsp rpctypes.RPCRe
 	}
 	statusCode := http.StatusOK
 	// If there's any error for lag is high, override the status code
-	if rsp.Error.Code == int(rpctypes.CodeLagIsHighError) {
+	if rsp.Error != nil && rsp.Error.Code == int(rpctypes.CodeLagIsHighError) {
 		statusCode = http.StatusExpectationFailed
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -176,7 +176,7 @@ func writeRPCResponse(w http.ResponseWriter, log log.Logger, rsps ...rpctypes.RP
 	statusCode := http.StatusOK
 	for _, res := range rsps {
 		// If there's any error for lag is high, override the status code
-		if res.Error.Code == int(rpctypes.CodeLagIsHighError) {
+		if res.Error != nil && res.Error.Code == int(rpctypes.CodeLagIsHighError) {
 			statusCode = http.StatusExpectationFailed
 			break
 		}

--- a/rpc/jsonrpc/server/http_server.go
+++ b/rpc/jsonrpc/server/http_server.go
@@ -148,7 +148,6 @@ func writeHTTPResponse(w http.ResponseWriter, log log.Logger, rsp rpctypes.RPCRe
 	statusCode := http.StatusOK
 	// If there's any error for lag is high, override the status code
 	if rsp.Error != nil && rsp.Error.Code == int(rpctypes.CodeLagIsHighError) {
-		fmt.Printf("[Tendermint-Debug] rsp.Error.Code is %d\n", rsp.Error.Code)
 		statusCode = http.StatusExpectationFailed
 	}
 	w.Header().Set("Content-Type", "application/json")

--- a/rpc/jsonrpc/server/http_server.go
+++ b/rpc/jsonrpc/server/http_server.go
@@ -147,8 +147,8 @@ func writeHTTPResponse(w http.ResponseWriter, log log.Logger, rsp rpctypes.RPCRe
 	}
 	statusCode := http.StatusOK
 	// If there's any error for lag is high, override the status code
-	fmt.Printf("[Tendermint-Debug] rsp.Error.Code is %d\n", rsp.Error.Code)
 	if rsp.Error != nil && rsp.Error.Code == int(rpctypes.CodeLagIsHighError) {
+		fmt.Printf("[Tendermint-Debug] rsp.Error.Code is %d\n", rsp.Error.Code)
 		statusCode = http.StatusExpectationFailed
 	}
 	w.Header().Set("Content-Type", "application/json")

--- a/rpc/jsonrpc/server/http_server.go
+++ b/rpc/jsonrpc/server/http_server.go
@@ -140,7 +140,7 @@ func writeHTTPResponse(w http.ResponseWriter, log log.Logger, rsp rpctypes.RPCRe
 	} else {
 		body = rsp.Result
 	}
-	if err != nil && len(body) <= 0 {
+	if err != nil {
 		log.Error("Error encoding RPC response: %w", err)
 		writeError(w, http.StatusInternalServerError, err)
 		return

--- a/rpc/jsonrpc/server/http_uri_handler.go
+++ b/rpc/jsonrpc/server/http_uri_handler.go
@@ -35,7 +35,7 @@ func makeHTTPHandler(rpcFunc *RPCFunc, logger log.Logger) func(http.ResponseWrit
 		if err == nil {
 			writeHTTPResponse(w, logger, jreq.MakeResponse(result))
 		} else {
-			writeHTTPResponse(w, logger, jreq.MakeError(err))
+			writeHTTPResponse(w, logger, jreq.MakeError(result, err))
 		}
 	}
 }

--- a/rpc/jsonrpc/server/rpc_func.go
+++ b/rpc/jsonrpc/server/rpc_func.go
@@ -80,6 +80,9 @@ func (rf *RPCFunc) Call(ctx context.Context, params json.RawMessage) (interface{
 
 	// Case 2: There is a non-error result.
 	if oerr := returns[1].Interface(); oerr != nil {
+		if res := returns[0].Interface(); res != nil {
+			return res, oerr.(error)
+		}
 		// In case of error, report the error and ignore the result.
 		return nil, oerr.(error)
 	}
@@ -140,10 +143,10 @@ func (rf *RPCFunc) adjustParams(data []byte) (json.RawMessage, error) {
 // NewRPCFunc constructs an RPCFunc for f, which must be a function whose type
 // signature matches one of these schemes:
 //
-//     func(context.Context) error
-//     func(context.Context) (R, error)
-//     func(context.Context, *T) error
-//     func(context.Context, *T) (R, error)
+//	func(context.Context) error
+//	func(context.Context) (R, error)
+//	func(context.Context, *T) error
+//	func(context.Context, *T) (R, error)
 //
 // for an arbitrary struct type T and type R. NewRPCFunc will panic if f does
 // not have one of these forms.  A newly-constructed RPCFunc has a default

--- a/rpc/jsonrpc/server/ws_handler.go
+++ b/rpc/jsonrpc/server/ws_handler.go
@@ -82,7 +82,7 @@ func (wm *WebsocketManager) WebsocketHandler(w http.ResponseWriter, r *http.Requ
 	// starting the conn is blocking
 	if err = conn.Start(r.Context()); err != nil {
 		wm.logger.Error("Failed to start connection", "err", err)
-		writeInternalError(w, err)
+		writeError(w, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -336,7 +336,7 @@ func (wsc *wsConnection) readRoutine(ctx context.Context) {
 			if err == nil {
 				resp = request.MakeResponse(result)
 			} else {
-				resp = request.MakeError(err)
+				resp = request.MakeError(result, err)
 			}
 			if err := wsc.WriteRPCResponse(writeCtx, resp); err != nil {
 				wsc.Logger.Error("error writing RPC response", "err", err)

--- a/rpc/jsonrpc/types/types.go
+++ b/rpc/jsonrpc/types/types.go
@@ -32,6 +32,7 @@ const (
 	CodeMethodNotFound ErrorCode = -32601 // The method does not exist or is unavailable
 	CodeInvalidParams  ErrorCode = -32602 // Invalid method parameters
 	CodeInternalError  ErrorCode = -32603 // Internal JSON-RPC error
+	CodeLagIsHighError ErrorCode = -32604 // Lag is too high error
 )
 
 var errorCodeString = map[ErrorCode]string{
@@ -40,7 +41,10 @@ var errorCodeString = map[ErrorCode]string{
 	CodeMethodNotFound: "Method not found",
 	CodeInvalidParams:  "Invalid params",
 	CodeInternalError:  "Internal error",
+	CodeLagIsHighError: "Lag is too high",
 }
+
+var LagIsTooHighError = errors.New(errorCodeString[CodeLagIsHighError])
 
 //----------------------------------------
 // REQUEST
@@ -138,10 +142,21 @@ func (req RPCRequest) MakeErrorf(code ErrorCode, msg string, args ...interface{}
 
 // MakeError constructs an error response to req from the given error value.
 // This function will panic if err == nil.
-func (req RPCRequest) MakeError(err error) RPCResponse {
+func (req RPCRequest) MakeError(result interface{}, err error) RPCResponse {
 	if err == nil {
 		panic("cannot construct an error response for nil")
 	}
+
+	// Handle lag is high error specifically to avoid changing the logic for existing endpoints
+	if errors.Is(err, coretypes.ErrLagIsTooHigh) && result != nil {
+		data, _ := tmjson.Marshal(result)
+		return RPCResponse{id: req.id, Result: data, Error: &RPCError{
+			Code:    int(CodeLagIsHighError),
+			Message: CodeLagIsHighError.String(),
+			Data:    err.Error(),
+		}}
+	}
+
 	if e, ok := err.(*RPCError); ok {
 		return RPCResponse{id: req.id, Error: e}
 	}

--- a/rpc/jsonrpc/types/types.go
+++ b/rpc/jsonrpc/types/types.go
@@ -151,7 +151,7 @@ func (req RPCRequest) MakeError(result interface{}, err error) RPCResponse {
 		return RPCResponse{id: req.id, Result: data, Error: &RPCError{
 			Code:    int(CodeLagIsHighError),
 			Message: CodeLagIsHighError.String(),
-			Data:    err.Error(),
+			Data:    string(data),
 		}}
 	}
 

--- a/rpc/jsonrpc/types/types.go
+++ b/rpc/jsonrpc/types/types.go
@@ -44,8 +44,6 @@ var errorCodeString = map[ErrorCode]string{
 	CodeLagIsHighError: "Lag is too high",
 }
 
-var LagIsTooHighError = errors.New(errorCodeString[CodeLagIsHighError])
-
 //----------------------------------------
 // REQUEST
 

--- a/rpc/jsonrpc/types/types.go
+++ b/rpc/jsonrpc/types/types.go
@@ -147,6 +147,7 @@ func (req RPCRequest) MakeError(result interface{}, err error) RPCResponse {
 
 	// Handle lag is high error specifically to avoid changing the logic for existing endpoints
 	if errors.Is(err, coretypes.ErrLagIsTooHigh) && result != nil {
+		fmt.Printf("[Tendermint-Debug] Creating an error response with code %d\n", CodeLagIsHighError)
 		data, _ := tmjson.Marshal(result)
 		return RPCResponse{id: req.id, Result: data, Error: &RPCError{
 			Code:    int(CodeLagIsHighError),

--- a/rpc/jsonrpc/types/types.go
+++ b/rpc/jsonrpc/types/types.go
@@ -147,7 +147,6 @@ func (req RPCRequest) MakeError(result interface{}, err error) RPCResponse {
 
 	// Handle lag is high error specifically to avoid changing the logic for existing endpoints
 	if errors.Is(err, coretypes.ErrLagIsTooHigh) && result != nil {
-		fmt.Printf("[Tendermint-Debug] Creating an error response with code %d\n", CodeLagIsHighError)
 		data, _ := tmjson.Marshal(result)
 		return RPCResponse{id: req.id, Result: data, Error: &RPCError{
 			Code:    int(CodeLagIsHighError),

--- a/rpc/openapi/openapi.yaml
+++ b/rpc/openapi/openapi.yaml
@@ -661,6 +661,33 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+  /lag_status:
+    get:
+      summary: Lag Status
+      operationId: lag_status
+      tags:
+        - Info
+      description: |
+        Get Tendermint lag status including latest height, current max peer height, and lag height.
+      responses:
+        "200":
+          description: Lag Status of the node and is not lagging
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/LagStatusResponse"
+        "299":
+          description: Lag Status of the node and is lagging over the threshold
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/LagStatusResponse"
+        "500":
+          description: lag is high error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
   /net_info:
     get:
       summary: Network information
@@ -1716,6 +1743,27 @@ components:
           properties:
             result:
               $ref: "#/components/schemas/Status"
+    LagStatus:
+      description: Lag Status Response
+      type: object
+      properties:
+        latest_height:
+          type: integer
+          example: "1"
+        max_peer_height:
+          type: integer
+          example: "1"
+        lag:
+          type: integer
+          example: "0"
+    LagStatusResponse:
+      description: Lag Status Response
+      allOf:
+        - $ref: "#/components/schemas/JSONRPC"
+        - type: object
+          properties:
+            result:
+              $ref: "#/components/schemas/LagStatus"
     Monitor:
       type: object
       properties:


### PR DESCRIPTION
## Describe your changes and provide context
**Problem**:
AWS ELB/ALB required health check endpoint to respond a non 200 response to indicate the service is not healthy. This is currently not available for RPC nodes.

**Solution**:
We will add a new endpoint /lag_status, which will respond a 200 OK when lag is below lag-threshold, and will respond with a non 200 status code when lag is above the lag threshold. In that way, we can easily configure ALB to detect the health of an RPC node

## Testing performed to validate your change
<img width="771" alt="image" src="https://github.com/sei-protocol/sei-tendermint/assets/50607998/09a22347-c638-4f0d-914f-184c83482efd">


