### PR TITLE
Don't need to panic for self peer

### DIFF
--- a/internal/p2p/peermanager.go
+++ b/internal/p2p/peermanager.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/tendermint/tendermint/libs/log"
 	"math"
 	"math/rand"
 	"sort"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/tendermint/tendermint/libs/log"
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/google/orderedcode"
@@ -427,7 +428,8 @@ func (m *PeerManager) Add(address NodeAddress) (bool, error) {
 		return false, err
 	}
 	if address.NodeID == m.selfID {
-		return false, fmt.Errorf("can't add self (%v) to peer store", m.selfID)
+		m.logger.Info("can't add self to peer store, skipping address", "address", address.String(), "self", m.selfID)
+		return false, nil
 	}
 
 	m.mtx.Lock()

--- a/internal/p2p/peermanager_test.go
+++ b/internal/p2p/peermanager_test.go
@@ -339,7 +339,7 @@ func TestPeerManager_Add(t *testing.T) {
 
 	// Adding self be fine
 	added, err = peerManager.Add(p2p.NodeAddress{Protocol: "memory", NodeID: selfID})
-	require.Error(t, nil)
+	require.Nil(t, err)
 	require.False(t, added)
 }
 

--- a/internal/p2p/peermanager_test.go
+++ b/internal/p2p/peermanager_test.go
@@ -3,11 +3,12 @@ package p2p_test
 import (
 	"context"
 	"errors"
-	"github.com/tendermint/tendermint/libs/log"
 	"math"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/tendermint/tendermint/libs/log"
 
 	"github.com/fortytw2/leaktest"
 	"github.com/stretchr/testify/assert"
@@ -336,9 +337,10 @@ func TestPeerManager_Add(t *testing.T) {
 	_, err = peerManager.Add(p2p.NodeAddress{Path: "foo"})
 	require.Error(t, err)
 
-	// Adding self should error
-	_, err = peerManager.Add(p2p.NodeAddress{Protocol: "memory", NodeID: selfID})
-	require.Error(t, err)
+	// Adding self be fine
+	added, err = peerManager.Add(p2p.NodeAddress{Protocol: "memory", NodeID: selfID})
+	require.Error(t, nil)
+	require.False(t, added)
 }
 
 func TestPeerManager_DialNext(t *testing.T) {
@@ -919,8 +921,9 @@ func TestPeerManager_Dialed_Self(t *testing.T) {
 	require.NoError(t, err)
 
 	// Dialing self should error.
-	_, err = peerManager.Add(p2p.NodeAddress{Protocol: "memory", NodeID: selfID})
-	require.Error(t, err)
+	added, err := peerManager.Add(p2p.NodeAddress{Protocol: "memory", NodeID: selfID})
+	require.Nil(t, err)
+	require.False(t, added)
 }
 
 func TestPeerManager_Dialed_MaxConnected(t *testing.T) {


### PR DESCRIPTION
## Describe your changes and provide context
Whens state syncing existing nodes, this is an easy way to get a set of persistent/bootstrap peers to start but for existing nodes their node-id might already be in the RPC provider's info, which prevents it from starting. 

Not a big issue but more useful when we have problems like in 3.0.0 where nodes keep crashing and we need to re-sync

```
curl $STATE_SYNC_RPC/net_info |jq -r '.peers[] | .url' |sed -e 's#mconn://##' > PEERS
PERSISTENT_PEERS=$(paste -s -d ',' PEERS)
```

![image](https://github.com/sei-protocol/sei-tendermint/assets/18161326/18fd384c-bae1-409b-8b9e-1b15a4d7c44d)
