### PR TITLE
Cancel bprequestor once blocksync finishes

### DIFF
--- a/internal/blocksync/pool.go
+++ b/internal/blocksync/pool.go
@@ -91,8 +91,7 @@ type BlockPool struct {
 	startHeight               int64
 	lastHundredBlockTimeStamp time.Time
 	lastSyncRate              float64
-
-	cancels []context.CancelFunc
+	cancels                   []context.CancelFunc
 }
 
 // NewBlockPool returns a new BlockPool with the height equal to start. Block

--- a/internal/blocksync/pool.go
+++ b/internal/blocksync/pool.go
@@ -29,6 +29,7 @@ eg, L = latency = 0.1s
 
 const (
 	requestInterval           = 2 * time.Millisecond
+	inactiveSleepInterval     = 1 * time.Second
 	maxTotalRequesters        = 600
 	maxPeerErrBuffer          = 1000
 	maxPendingRequests        = maxTotalRequesters
@@ -90,6 +91,8 @@ type BlockPool struct {
 	startHeight               int64
 	lastHundredBlockTimeStamp time.Time
 	lastSyncRate              float64
+
+	cancels []context.CancelFunc
 }
 
 // NewBlockPool returns a new BlockPool with the height equal to start. Block
@@ -126,7 +129,16 @@ func (pool *BlockPool) OnStart(ctx context.Context) error {
 	return nil
 }
 
-func (*BlockPool) OnStop() {}
+func (pool *BlockPool) OnStop() {
+	pool.mtx.Lock()
+	defer pool.mtx.Unlock()
+
+	// cancel all running requesters if any
+	for _, cancel := range pool.cancels {
+		cancel()
+	}
+	pool.cancels = []context.CancelFunc{}
+}
 
 // spawns requesters as needed
 func (pool *BlockPool) makeRequestersRoutine(ctx context.Context) {
@@ -434,6 +446,8 @@ func (pool *BlockPool) makeNextRequester(ctx context.Context) {
 	pool.requesters[nextHeight] = request
 	atomic.AddInt32(&pool.numPending, 1)
 
+	ctx, cancel := context.WithCancel(ctx)
+	pool.cancels = append(pool.cancels, cancel)
 	err := request.Start(ctx)
 	if err != nil {
 		request.logger.Error("error starting request", "err", err)

--- a/internal/blocksync/reactor.go
+++ b/internal/blocksync/reactor.go
@@ -92,8 +92,8 @@ type Reactor struct {
 
 	syncStartTime time.Time
 
-	restartCh chan struct{}
-	blocksBehindThreshold uint64
+	restartCh                 chan struct{}
+	blocksBehindThreshold     uint64
 	blocksBehindCheckInterval time.Duration
 }
 
@@ -112,17 +112,17 @@ func NewReactor(
 	selfRemediationConfig *config.SelfRemediationConfig,
 ) *Reactor {
 	r := &Reactor{
-		logger:      logger,
-		stateStore:  stateStore,
-		blockExec:   blockExec,
-		store:       store,
-		consReactor: consReactor,
-		blockSync:   newAtomicBool(blockSync),
-		peerEvents:  peerEvents,
-		metrics:     metrics,
-		eventBus:    eventBus,
-		restartCh: restartCh,
-		blocksBehindThreshold: selfRemediationConfig.BlocksBehindThreshold,
+		logger:                    logger,
+		stateStore:                stateStore,
+		blockExec:                 blockExec,
+		store:                     store,
+		consReactor:               consReactor,
+		blockSync:                 newAtomicBool(blockSync),
+		peerEvents:                peerEvents,
+		metrics:                   metrics,
+		eventBus:                  eventBus,
+		restartCh:                 restartCh,
+		blocksBehindThreshold:     selfRemediationConfig.BlocksBehindThreshold,
 		blocksBehindCheckInterval: time.Duration(selfRemediationConfig.BlocksBehindCheckIntervalSeconds) * time.Second,
 	}
 
@@ -185,7 +185,6 @@ func (r *Reactor) OnStop() {
 		r.pool.Stop()
 	}
 }
-
 
 // respondToPeer loads a block and sends it to the requesting peer, if we have it.
 // Otherwise, we'll respond saying we do not have it.


### PR DESCRIPTION
## Describe your changes and provide context
Clean up bprequester goroutines after blocksync finishes

## Testing performed to validate your change
atlantic-2 + profiling
