### PR TITLE
Make light block verify request timeout configurable

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -909,6 +909,9 @@ type StateSyncConfig struct {
 
 	// The number of concurrent chunk and block fetchers to run (default: 4).
 	Fetchers int32 `mapstructure:"fetchers"`
+
+	// Only meaningful if using P2P
+	VerifyLightBlockTimeout int `mapstructure:"verify-light-block-timeout"`
 }
 
 func (cfg *StateSyncConfig) TrustHashBytes() []byte {
@@ -923,12 +926,13 @@ func (cfg *StateSyncConfig) TrustHashBytes() []byte {
 // DefaultStateSyncConfig returns a default configuration for the state sync service
 func DefaultStateSyncConfig() *StateSyncConfig {
 	return &StateSyncConfig{
-		TrustPeriod:         168 * time.Hour,
-		DiscoveryTime:       15 * time.Second,
-		ChunkRequestTimeout: 15 * time.Second,
-		Fetchers:            4,
-		BackfillBlocks:      0,
-		BackfillDuration:    0 * time.Second,
+		TrustPeriod:             168 * time.Hour,
+		DiscoveryTime:           15 * time.Second,
+		ChunkRequestTimeout:     15 * time.Second,
+		Fetchers:                4,
+		BackfillBlocks:          0,
+		BackfillDuration:        0 * time.Second,
+		VerifyLightBlockTimeout: 60,
 	}
 }
 
@@ -1277,31 +1281,33 @@ type DBSyncConfig struct {
 	Enable bool `mapstructure:"db-sync-enable"`
 	// This is NOT currently used but reserved for future implementation
 	// of snapshotting logics that don't require chain halts.
-	SnapshotInterval     int           `mapstructure:"snapshot-interval"`
-	SnapshotDirectory    string        `mapstructure:"snapshot-directory"`
-	SnapshotWorkerCount  int           `mapstructure:"snapshot-worker-count"`
-	TimeoutInSeconds     int           `mapstructure:"timeout-in-seconds"`
-	NoFileSleepInSeconds int           `mapstructure:"no-file-sleep-in-seconds"`
-	FileWorkerCount      int           `mapstructure:"file-worker-count"`
-	FileWorkerTimeout    int           `mapstructure:"file-worker-timeout"`
-	TrustHeight          int64         `mapstructure:"trust-height"`
-	TrustHash            string        `mapstructure:"trust-hash"`
-	TrustPeriod          time.Duration `mapstructure:"trust-period"`
+	SnapshotInterval        int           `mapstructure:"snapshot-interval"`
+	SnapshotDirectory       string        `mapstructure:"snapshot-directory"`
+	SnapshotWorkerCount     int           `mapstructure:"snapshot-worker-count"`
+	TimeoutInSeconds        int           `mapstructure:"timeout-in-seconds"`
+	NoFileSleepInSeconds    int           `mapstructure:"no-file-sleep-in-seconds"`
+	FileWorkerCount         int           `mapstructure:"file-worker-count"`
+	FileWorkerTimeout       int           `mapstructure:"file-worker-timeout"`
+	TrustHeight             int64         `mapstructure:"trust-height"`
+	TrustHash               string        `mapstructure:"trust-hash"`
+	TrustPeriod             time.Duration `mapstructure:"trust-period"`
+	VerifyLightBlockTimeout int           `mapstructure:"verify-light-block-timeout"`
 }
 
 func DefaultDBSyncConfig() *DBSyncConfig {
 	return &DBSyncConfig{
-		Enable:               false,
-		SnapshotInterval:     0,
-		SnapshotDirectory:    "",
-		SnapshotWorkerCount:  16,
-		TimeoutInSeconds:     1200,
-		NoFileSleepInSeconds: 1,
-		FileWorkerCount:      32,
-		FileWorkerTimeout:    30,
-		TrustHeight:          0,
-		TrustHash:            "",
-		TrustPeriod:          time.Duration(86400) * time.Second,
+		Enable:                  false,
+		SnapshotInterval:        0,
+		SnapshotDirectory:       "",
+		SnapshotWorkerCount:     16,
+		TimeoutInSeconds:        1200,
+		NoFileSleepInSeconds:    1,
+		FileWorkerCount:         32,
+		FileWorkerTimeout:       30,
+		TrustHeight:             0,
+		TrustHash:               "",
+		TrustPeriod:             time.Duration(86400) * time.Second,
+		VerifyLightBlockTimeout: 60,
 	}
 }
 

--- a/config/toml.go
+++ b/config/toml.go
@@ -449,6 +449,8 @@ chunk-request-timeout = "{{ .StateSync.ChunkRequestTimeout }}"
 # The number of concurrent chunk and block fetchers to run (default: 4).
 fetchers = "{{ .StateSync.Fetchers }}"
 
+verify-light-block-timeout = "{{ .DBSync.VerifyLightBlockTimeout }}"
+
 #######################################################
 ###         Consensus Configuration Options         ###
 #######################################################
@@ -596,6 +598,7 @@ file-worker-timeout = "{{ .DBSync.FileWorkerTimeout }}"
 trust-height = "{{ .DBSync.TrustHeight }}"
 trust-hash = "{{ .DBSync.TrustHash }}"
 trust-period = "{{ .DBSync.TrustPeriod }}"
+verify-light-block-timeout = "{{ .DBSync.VerifyLightBlockTimeout }}"
 `
 
 /****** these are for test settings ***********/

--- a/internal/dbsync/reactor.go
+++ b/internal/dbsync/reactor.go
@@ -208,7 +208,7 @@ func (r *Reactor) OnStart(ctx context.Context) error {
 			providers[idx] = light.NewBlockProvider(p, r.chainID, r.dispatcher)
 		}
 
-		stateProvider, err := light.NewP2PStateProvider(ctx, r.chainID, r.initialHeight, providers, to, r.paramsChannel, r.logger.With("module", "stateprovider"), func(height uint64) proto.Message {
+		stateProvider, err := light.NewP2PStateProvider(ctx, r.chainID, r.initialHeight, r.config.VerifyLightBlockTimeout, providers, to, r.paramsChannel, r.logger.With("module", "stateprovider"), func(height uint64) proto.Message {
 			return &dstypes.ParamsRequest{
 				Height: height,
 			}

--- a/internal/statesync/reactor.go
+++ b/internal/statesync/reactor.go
@@ -182,7 +182,7 @@ type Reactor struct {
 	lastNoAvailablePeers time.Time
 
 	// Used to signal a restart the node on the application level
-	restartCh chan struct{}
+	restartCh                     chan struct{}
 	restartNoAvailablePeersWindow time.Duration
 }
 
@@ -208,23 +208,23 @@ func NewReactor(
 	selfRemediationConfig *config.SelfRemediationConfig,
 ) *Reactor {
 	r := &Reactor{
-		logger:               logger,
-		chainID:              chainID,
-		initialHeight:        initialHeight,
-		cfg:                  cfg,
-		conn:                 conn,
-		peerEvents:           peerEvents,
-		tempDir:              tempDir,
-		stateStore:           stateStore,
-		blockStore:           blockStore,
-		peers:                light.NewPeerList(),
-		providers:            make(map[types.NodeID]*light.BlockProvider),
-		metrics:              ssMetrics,
-		eventBus:             eventBus,
-		postSyncHook:         postSyncHook,
-		needsStateSync:       needsStateSync,
-		lastNoAvailablePeers: time.Time{},
-		restartCh:            restartCh,
+		logger:                        logger,
+		chainID:                       chainID,
+		initialHeight:                 initialHeight,
+		cfg:                           cfg,
+		conn:                          conn,
+		peerEvents:                    peerEvents,
+		tempDir:                       tempDir,
+		stateStore:                    stateStore,
+		blockStore:                    blockStore,
+		peers:                         light.NewPeerList(),
+		providers:                     make(map[types.NodeID]*light.BlockProvider),
+		metrics:                       ssMetrics,
+		eventBus:                      eventBus,
+		postSyncHook:                  postSyncHook,
+		needsStateSync:                needsStateSync,
+		lastNoAvailablePeers:          time.Time{},
+		restartCh:                     restartCh,
 		restartNoAvailablePeersWindow: time.Duration(selfRemediationConfig.StatesyncNoPeersRestartWindowSeconds) * time.Second,
 	}
 
@@ -307,7 +307,7 @@ func (r *Reactor) OnStart(ctx context.Context) error {
 				providers[idx] = light.NewBlockProvider(p, chainID, r.dispatcher)
 			}
 
-			stateProvider, err := light.NewP2PStateProvider(ctx, chainID, initialHeight, providers, to, r.paramsChannel, r.logger.With("module", "stateprovider"), func(height uint64) proto.Message {
+			stateProvider, err := light.NewP2PStateProvider(ctx, chainID, initialHeight, r.cfg.VerifyLightBlockTimeout, providers, to, r.paramsChannel, r.logger.With("module", "stateprovider"), func(height uint64) proto.Message {
 				return &ssproto.ParamsRequest{
 					Height: height,
 				}

--- a/light/stateprovider.go
+++ b/light/stateprovider.go
@@ -208,12 +208,13 @@ func rpcClient(server string) (*rpchttp.HTTP, error) {
 }
 
 type StateProviderP2P struct {
-	sync.Mutex       // light.Client is not concurrency-safe
-	lc               *Client
-	initialHeight    int64
-	paramsSendCh     *p2p.Channel
-	paramsRecvCh     chan types.ConsensusParams
-	paramsReqCreator func(uint64) proto.Message
+	sync.Mutex              // light.Client is not concurrency-safe
+	lc                      *Client
+	initialHeight           int64
+	paramsSendCh            *p2p.Channel
+	paramsRecvCh            chan types.ConsensusParams
+	paramsReqCreator        func(uint64) proto.Message
+	verifyLightBlockTimeout int
 }
 
 // NewP2PStateProvider creates a light client state
@@ -222,6 +223,7 @@ func NewP2PStateProvider(
 	ctx context.Context,
 	chainID string,
 	initialHeight int64,
+	verifyLightBlockTimeout int,
 	providers []lightprovider.Provider,
 	trustOptions TrustOptions,
 	paramsSendCh *p2p.Channel,
@@ -239,16 +241,17 @@ func NewP2PStateProvider(
 	}
 
 	return &StateProviderP2P{
-		lc:               lc,
-		initialHeight:    initialHeight,
-		paramsSendCh:     paramsSendCh,
-		paramsRecvCh:     make(chan types.ConsensusParams),
-		paramsReqCreator: paramsReqCreator,
+		lc:                      lc,
+		initialHeight:           initialHeight,
+		paramsSendCh:            paramsSendCh,
+		paramsRecvCh:            make(chan types.ConsensusParams),
+		paramsReqCreator:        paramsReqCreator,
+		verifyLightBlockTimeout: verifyLightBlockTimeout,
 	}, nil
 }
 
 func (s *StateProviderP2P) verifyLightBlockAtHeight(ctx context.Context, height uint64, ts time.Time) (*types.LightBlock, error) {
-	ctx, cancel := context.WithTimeout(ctx, 20*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, time.Duration(s.verifyLightBlockTimeout*int(time.Second)))
 	defer cancel()
 	return s.lc.VerifyLightBlockAtHeight(ctx, int64(height), ts)
 }


### PR DESCRIPTION
## Describe your changes and provide context
20s is too short for cases where light block verification needs to go back by a lot. Making it configurable so that we can tune it if statesync/dbsync fails repeatedly on light block verification.

## Testing performed to validate your change
tested in atlantic-2

