### PR TITLE
Add backfill-blocks and backfill-duration configuration to config.toml

### DIFF
--- a/config/toml.go
+++ b/config/toml.go
@@ -434,6 +434,15 @@ trust-hash = "{{ .StateSync.TrustHash }}"
 # period should suffice.
 trust-period = "{{ .StateSync.TrustPeriod }}"
 
+# Backfill sequentially fetches after state sync completes, verifies and stores light blocks in reverse order.
+# backfill-blocks means it will keep reverse fetching up to backfill-blocks number of blocks behind state sync position
+# backfill-duration means it will keep fetching up to backfill-duration old time
+# The actual backfill process will take at backfill-blocks as priority:
+# - If backfill-blocks is set, use backfill-blocks to backfill
+# - If backfill-blocks is not set to be greater than 0, use backfill-duration to backfill
+backfill-blocks = "{{ .StateSync.BackfillBlocks }}"
+backfill-duration = "{{ .StateSync.BackfillDuration }}"
+
 # Time to spend discovering snapshots before initiating a restore.
 discovery-time = "{{ .StateSync.DiscoveryTime }}"
 

--- a/docs/nodes/configuration.md
+++ b/docs/nodes/configuration.md
@@ -368,6 +368,13 @@ rpc-servers = ""
 trust-height = 0
 trust-hash = ""
 
+# Backfill sequentially fetches after state sync completes, verifies and stores light blocks in reverse order.
+# The actual backfill process will stop if it meets either backfill-blocks or backfill-duration condition
+# backfill-blocks means it will keep reverse fetching up to backfill-blocks number of blocks behind state sync position
+# backfill-duration means it will keep fetching up to backfill-duration old time
+backfill-blocks = 0
+backfill-duration = "0s"
+
 # The trust period should be set so that Tendermint can detect and gossip misbehavior before
 # it is considered expired. For chains based on the Cosmos SDK, one day less than the unbonding
 # period should suffice.
@@ -538,7 +545,7 @@ This section will cover settings within the p2p section of the `config.toml`.
 - `pex` = turns the peer exchange reactor on or off. Validator node will want the `pex` turned off so it would not begin gossiping to unknown peers on the network. PeX can also be turned off for statically configured networks with fixed network connectivity. For full nodes on open, dynamic networks, it should be turned on.
 - `private-peer-ids` = is a comma-separated list of node ids that will _not_ be exposed to other peers (i.e., you will not tell other peers about the ids in this list). This can be filled with a validator's node id.
 
-Recently the Tendermint Team conducted a refactor of the p2p layer. This lead to multiple config parameters being deprecated and/or replaced. 
+Recently the Tendermint Team conducted a refactor of the p2p layer. This lead to multiple config parameters being deprecated and/or replaced.
 
 We will cover the new and deprecated parameters below.
 ### New Parameters
@@ -546,7 +553,7 @@ We will cover the new and deprecated parameters below.
 There are three new parameters, which are enabled if use-legacy is set to false.
 
 - `queue-type` = sets a type of queue to use in the p2p layer. There are three options available `fifo`, `priority` and `wdrr`. The default is priority
-- `bootstrap-peers` = is a list of comma seperated peers which will be used to bootstrap the address book. 
+- `bootstrap-peers` = is a list of comma seperated peers which will be used to bootstrap the address book.
 - `max-connections` = is the max amount of allowed inbound and outbound connections.
 ### Deprecated Parameters
 


### PR DESCRIPTION
## Describe your changes and provide context

**Changes**:
backfill-blocks and backfill-duration are two existing configs available, but not yet exposed to the config file. This change is just exposing them to the config.toml file so that we can start using them

## Testing performed to validate your change
Existing test coverage already cover the logic of backfill.
For config validation, we will test that in integration test
