### PR TITLE
Fix empty prevote latency metrics

### DIFF
--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -2318,6 +2318,10 @@ func (cs *State) RecordMetrics(height int64, block *types.Block) {
 		for roundId := 0; int32(roundId) <= roundState.ValidRound; roundId++ {
 			preVotes := roundState.Votes.Prevotes(int32(roundId))
 			pl := preVotes.List()
+			if pl == nil || len(pl) == 0 {
+				cs.logger.Info("no prevotes to emit latency metrics for", "height", height, "round", roundId)
+				continue
+			}
 			sort.Slice(pl, func(i, j int) bool {
 				return pl[i].Timestamp.Before(pl[j].Timestamp)
 			})


### PR DESCRIPTION
## Describe your changes and provide context
The node would crash if there is no prevotes info for a previous round

https://linear.app/seilabs/issue/SEI-5251/tendermint-rpc-bug

## Testing performed to validate your change
tested with block sync without round info
