### PR TITLE
State sync fixes: Remove Bad Witnesses and Don't Wait on All Witnesses for ConsensusParams

### DIFF
--- a/cmd/tendermint/commands/light.go
+++ b/cmd/tendermint/commands/light.go
@@ -39,6 +39,7 @@ func MakeLightCommand(conf *config.Config, logger log.Logger) *cobra.Command {
 		trustedHeight  int64
 		trustedHash    []byte
 		trustLevelStr  string
+		blacklistTTL   time.Duration
 
 		logLevel  string
 		logFormat string
@@ -158,6 +159,7 @@ for applications built w/ Cosmos SDK).
 				primaryAddr,
 				witnessesAddrs,
 				dbs.New(db),
+				blacklistTTL,
 				options...,
 			)
 			if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -685,7 +685,6 @@ type P2PConfig struct { //nolint: maligned
 
 	// List of node IDs, to which a connection will be (re)established ignoring any existing limits
 	UnconditionalPeerIDs string `mapstructure:"unconditional-peer-ids"`
-
 }
 
 // DefaultP2PConfig returns a default configuration for the peer-to-peer layer
@@ -913,10 +912,6 @@ type StateSyncConfig struct {
 
 	// Timeout before considering light block verification failed
 	VerifyLightBlockTimeout time.Duration `mapstructure:"verify-light-block-timeout"`
-
-	// Minimum time bad witnesses must spend in blacklist before potentially being
-	// added back as a provider again.
-	BlackListTTL time.Duration `mapstructure:"black-list-ttl"`
 }
 
 func (cfg *StateSyncConfig) TrustHashBytes() []byte {
@@ -938,7 +933,6 @@ func DefaultStateSyncConfig() *StateSyncConfig {
 		BackfillBlocks:          0,
 		BackfillDuration:        0 * time.Second,
 		VerifyLightBlockTimeout: 60 * time.Second,
-		BlackListTTL:            30000 * time.Millisecond,
 	}
 }
 
@@ -1002,10 +996,6 @@ func (cfg *StateSyncConfig) ValidateBasic() error {
 
 	if cfg.Fetchers <= 0 {
 		return errors.New("fetchers is required")
-	}
-
-	if cfg.BlackListTTL < 0 {
-		return errors.New("black-list-ttl must not be negative")
 	}
 
 	return nil

--- a/config/config.go
+++ b/config/config.go
@@ -912,6 +912,9 @@ type StateSyncConfig struct {
 
 	// Timeout before considering light block verification failed
 	VerifyLightBlockTimeout time.Duration `mapstructure:"verify-light-block-timeout"`
+
+	// Time before which a blacklisted witness can not be added back as a provider
+	BlacklistTTL time.Duration `mapstructure:"verify-light-block-timeout"`
 }
 
 func (cfg *StateSyncConfig) TrustHashBytes() []byte {
@@ -933,6 +936,7 @@ func DefaultStateSyncConfig() *StateSyncConfig {
 		BackfillBlocks:          0,
 		BackfillDuration:        0 * time.Second,
 		VerifyLightBlockTimeout: 60 * time.Second,
+		BlacklistTTL:            5 * time.Minute,
 	}
 }
 
@@ -1292,6 +1296,7 @@ type DBSyncConfig struct {
 	TrustHash               string        `mapstructure:"trust-hash"`
 	TrustPeriod             time.Duration `mapstructure:"trust-period"`
 	VerifyLightBlockTimeout time.Duration `mapstructure:"verify-light-block-timeout"`
+	BlacklistTTL            time.Duration `mapstructure:"blacklist-ttl"`
 }
 
 func DefaultDBSyncConfig() *DBSyncConfig {
@@ -1308,6 +1313,7 @@ func DefaultDBSyncConfig() *DBSyncConfig {
 		TrustHash:               "",
 		TrustPeriod:             86400 * time.Second,
 		VerifyLightBlockTimeout: 60 * time.Second,
+		BlacklistTTL:            5 * time.Minute,
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -685,6 +685,7 @@ type P2PConfig struct { //nolint: maligned
 
 	// List of node IDs, to which a connection will be (re)established ignoring any existing limits
 	UnconditionalPeerIDs string `mapstructure:"unconditional-peer-ids"`
+
 }
 
 // DefaultP2PConfig returns a default configuration for the peer-to-peer layer
@@ -912,6 +913,10 @@ type StateSyncConfig struct {
 
 	// Timeout before considering light block verification failed
 	VerifyLightBlockTimeout time.Duration `mapstructure:"verify-light-block-timeout"`
+
+	// Minimum time bad witnesses must spend in blacklist before potentially being
+	// added back as a provider again.
+	BlackListTTL time.Duration `mapstructure:"black-list-ttl"`
 }
 
 func (cfg *StateSyncConfig) TrustHashBytes() []byte {
@@ -933,6 +938,7 @@ func DefaultStateSyncConfig() *StateSyncConfig {
 		BackfillBlocks:          0,
 		BackfillDuration:        0 * time.Second,
 		VerifyLightBlockTimeout: 60 * time.Second,
+		BlackListTTL:            30000 * time.Millisecond,
 	}
 }
 
@@ -996,6 +1002,10 @@ func (cfg *StateSyncConfig) ValidateBasic() error {
 
 	if cfg.Fetchers <= 0 {
 		return errors.New("fetchers is required")
+	}
+
+	if cfg.BlackListTTL < 0 {
+		return errors.New("black-list-ttl must not be negative")
 	}
 
 	return nil

--- a/config/config.go
+++ b/config/config.go
@@ -914,7 +914,7 @@ type StateSyncConfig struct {
 	VerifyLightBlockTimeout time.Duration `mapstructure:"verify-light-block-timeout"`
 
 	// Time before which a blacklisted witness can not be added back as a provider
-	BlacklistTTL time.Duration `mapstructure:"verify-light-block-timeout"`
+	BlacklistTTL time.Duration `mapstructure:"blacklist-ttl"`
 }
 
 func (cfg *StateSyncConfig) TrustHashBytes() []byte {

--- a/config/toml.go
+++ b/config/toml.go
@@ -460,6 +460,8 @@ fetchers = "{{ .StateSync.Fetchers }}"
 
 verify-light-block-timeout = "{{ .StateSync.VerifyLightBlockTimeout }}"
 
+blacklist-ttl = "{{ .StateSync.BlacklistTTL }}"
+
 #######################################################
 ###         Consensus Configuration Options         ###
 #######################################################
@@ -608,6 +610,7 @@ trust-height = "{{ .DBSync.TrustHeight }}"
 trust-hash = "{{ .DBSync.TrustHash }}"
 trust-period = "{{ .DBSync.TrustPeriod }}"
 verify-light-block-timeout = "{{ .DBSync.VerifyLightBlockTimeout }}"
+blacklist-ttl = "{{ .DBSync.BlacklistTTL }}"
 `
 
 /****** these are for test settings ***********/

--- a/config/toml.go
+++ b/config/toml.go
@@ -345,7 +345,6 @@ recv-rate = {{ .P2P.RecvRate }}
 # List of node IDs, to which a connection will be (re)established ignoring any existing limits
 unconditional-peer-ids = "{{ .P2P.UnconditionalPeerIDs }}"
 
-
 #######################################################
 ###          Mempool Configuration Option          ###
 #######################################################
@@ -459,6 +458,10 @@ chunk-request-timeout = "{{ .StateSync.ChunkRequestTimeout }}"
 fetchers = "{{ .StateSync.Fetchers }}"
 
 verify-light-block-timeout = "{{ .StateSync.VerifyLightBlockTimeout }}"
+
+# Minimum time bad witnesses must spend in blacklist before potentially being
+# added back as a provider again.
+black-list-ttl = "{{ .P2P.BlackListTTL }}"
 
 #######################################################
 ###         Consensus Configuration Options         ###

--- a/config/toml.go
+++ b/config/toml.go
@@ -345,6 +345,7 @@ recv-rate = {{ .P2P.RecvRate }}
 # List of node IDs, to which a connection will be (re)established ignoring any existing limits
 unconditional-peer-ids = "{{ .P2P.UnconditionalPeerIDs }}"
 
+
 #######################################################
 ###          Mempool Configuration Option          ###
 #######################################################
@@ -458,10 +459,6 @@ chunk-request-timeout = "{{ .StateSync.ChunkRequestTimeout }}"
 fetchers = "{{ .StateSync.Fetchers }}"
 
 verify-light-block-timeout = "{{ .StateSync.VerifyLightBlockTimeout }}"
-
-# Minimum time bad witnesses must spend in blacklist before potentially being
-# added back as a provider again.
-black-list-ttl = "{{ .P2P.BlackListTTL }}"
 
 #######################################################
 ###         Consensus Configuration Options         ###

--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -2318,6 +2318,10 @@ func (cs *State) RecordMetrics(height int64, block *types.Block) {
 		for roundId := 0; int32(roundId) <= roundState.ValidRound; roundId++ {
 			preVotes := roundState.Votes.Prevotes(int32(roundId))
 			pl := preVotes.List()
+			if pl == nil || len(pl) == 0 {
+				cs.logger.Info("no prevotes to emit latency metrics for", "height", height, "round", roundId)
+				continue
+			}
 			sort.Slice(pl, func(i, j int) bool {
 				return pl[i].Timestamp.Before(pl[j].Timestamp)
 			})

--- a/internal/dbsync/reactor.go
+++ b/internal/dbsync/reactor.go
@@ -208,7 +208,7 @@ func (r *Reactor) OnStart(ctx context.Context) error {
 			providers[idx] = light.NewBlockProvider(p, r.chainID, r.dispatcher)
 		}
 
-		stateProvider, err := light.NewP2PStateProvider(ctx, r.chainID, r.initialHeight, r.config.VerifyLightBlockTimeout, providers, to, r.paramsChannel, r.logger.With("module", "stateprovider"), func(height uint64) proto.Message {
+		stateProvider, err := light.NewP2PStateProvider(ctx, r.chainID, r.initialHeight, r.config.VerifyLightBlockTimeout, providers, to, r.paramsChannel, r.logger.With("module", "stateprovider"), r.config.BlacklistTTL, func(height uint64) proto.Message {
 			return &dstypes.ParamsRequest{
 				Height: height,
 			}

--- a/internal/statesync/reactor.go
+++ b/internal/statesync/reactor.go
@@ -307,7 +307,7 @@ func (r *Reactor) OnStart(ctx context.Context) error {
 				providers[idx] = light.NewBlockProvider(p, chainID, r.dispatcher)
 			}
 
-			stateProvider, err := light.NewP2PStateProvider(ctx, chainID, initialHeight, r.cfg.VerifyLightBlockTimeout, providers, to, r.paramsChannel, r.logger.With("module", "stateprovider"), func(height uint64) proto.Message {
+			stateProvider, err := light.NewP2PStateProvider(ctx, chainID, initialHeight, r.cfg.VerifyLightBlockTimeout, providers, to, r.paramsChannel, r.logger.With("module", "stateprovider"), r.cfg.BlacklistTTL, func(height uint64) proto.Message {
 				return &ssproto.ParamsRequest{
 					Height: height,
 				}
@@ -319,7 +319,7 @@ func (r *Reactor) OnStart(ctx context.Context) error {
 			return nil
 		}
 
-		stateProvider, err := light.NewRPCStateProvider(ctx, chainID, initialHeight, r.cfg.VerifyLightBlockTimeout, r.cfg.RPCServers, to, spLogger)
+		stateProvider, err := light.NewRPCStateProvider(ctx, chainID, initialHeight, r.cfg.VerifyLightBlockTimeout, r.cfg.RPCServers, to, spLogger, r.cfg.BlacklistTTL)
 		if err != nil {
 			return fmt.Errorf("failed to initialize RPC state provider: %w", err)
 		}

--- a/light/client.go
+++ b/light/client.go
@@ -886,8 +886,8 @@ func (c *Client) AddProvider(p provider.Provider) {
 
 	// If the provider is blacklisted, don't add it
 	if c.isBlacklisted(p) {
-        return
-    }
+		return
+	}
 
 	c.witnesses = append(c.witnesses, p)
 }

--- a/light/client.go
+++ b/light/client.go
@@ -1010,7 +1010,7 @@ func (c *Client) getLightBlock(ctx context.Context, p provider.Provider, height 
 
 // addWitnessToBlacklist adds a witness to the blacklist
 // NOTE: requires a providerMutex lock
-func (c *Client) addWitnessToBlacklist(providers []provider.Provider) {
+func (c *Client) addWitnessesToBlacklist(providers []provider.Provider) {
 	if len(providers) == 0 {
 		return
 	}
@@ -1049,17 +1049,10 @@ func (c *Client) removeWitnesses(indexes []int) error {
 	// we need to make sure that we remove witnesses by index in the reverse
 	// order so as to not affect the indexes themselves
 	sort.Ints(indexes)
-	blacklistWitnesses := []provider.Provider{}
 	for i := len(indexes) - 1; i >= 0; i-- {
-		// Add witness to blacklist
-		removedWitness := c.witnesses[indexes[i]]
-		blacklistWitnesses = append(blacklistWitnesses, removedWitness)
-
 		c.witnesses[indexes[i]] = c.witnesses[len(c.witnesses)-1]
 		c.witnesses = c.witnesses[:len(c.witnesses)-1]
 	}
-
-	c.addWitnessToBlacklist(blacklistWitnesses)
 
 	return nil
 }

--- a/light/client.go
+++ b/light/client.go
@@ -1019,6 +1019,7 @@ func (c *Client) addWitnessToBlacklist(providers []provider.Provider) {
 		c.blacklist[provider.ID()] = time.Now()
 	}
 }
+
 func (c *Client) findIndexForWitness(ID types.NodeID) (int, bool) {
 	for i, w := range c.witnesses {
 		if w.ID() == string(ID) {

--- a/light/client.go
+++ b/light/client.go
@@ -279,6 +279,8 @@ func NewClientFromTrustedStore(
 	return c, nil
 }
 
+// isBlacklisted checks whether provider is black listed
+// NOTE: requires a providerMutex lock
 func (c *Client) isBlacklisted(p provider.Provider) bool {
     timestamp, exists := c.blacklist[p.ID()]
     if !exists {

--- a/light/client.go
+++ b/light/client.go
@@ -148,13 +148,6 @@ type Client struct {
 	logger log.Logger
 }
 
-// blacklistedWitness represents a witness who has been removed
-// and temporarily prevents them being added back for a configurable time.
-type blacklistedWitness struct {
-	witness   provider.Provider
-	timestamp time.Time
-}
-
 // NewClient returns a new light client. It returns an error if it fails to
 // obtain the light block from the primary, or they are invalid (e.g. trust
 // hash does not match with the one from the headers).

--- a/light/client.go
+++ b/light/client.go
@@ -134,7 +134,7 @@ type Client struct {
 
 	// Map of witnesses, who have been removed
 	// and not allowed to be added back as a provider,
-	// to the time they were added to the blacklist
+	// to the timadd they were added to the blacklist
 	blacklist map[string]time.Time
 
 	// Where trusted light blocks are stored.
@@ -1008,6 +1008,18 @@ func (c *Client) getLightBlock(ctx context.Context, p provider.Provider, height 
 	return l, err
 }
 
+// addWitnessToBlacklist adds a witness to the blacklist
+// NOTE: requires a providerMutex lock
+func (c *Client) addWitnessToBlacklist(providers []provider.Provider) {
+	if len(providers) == 0 {
+		return
+	}
+
+	for _, provider := range providers {
+		c.blacklist[provider.ID()] = time.Now()
+	}
+}
+
 // NOTE: requires a providerMutex lock
 func (c *Client) removeWitnesses(indexes []int) error {
 	if len(c.witnesses) <= len(indexes) {
@@ -1017,14 +1029,17 @@ func (c *Client) removeWitnesses(indexes []int) error {
 	// we need to make sure that we remove witnesses by index in the reverse
 	// order so as to not affect the indexes themselves
 	sort.Ints(indexes)
+	blacklistWitnesses := []provider.Provider{}
 	for i := len(indexes) - 1; i >= 0; i-- {
 		// Add witness to blacklist
 		removedWitness := c.witnesses[indexes[i]]
-		c.blacklist[removedWitness.ID()] = time.Now()
+		blacklistWitnesses = append(blacklistWitnesses, removedWitness)
 
 		c.witnesses[indexes[i]] = c.witnesses[len(c.witnesses)-1]
 		c.witnesses = c.witnesses[:len(c.witnesses)-1]
 	}
+
+	c.addWitnessToBlacklist(blacklistWitnesses)
 
 	return nil
 }

--- a/light/client.go
+++ b/light/client.go
@@ -56,7 +56,7 @@ const (
 	// 30s for minimum time a witness must remain in blacklist before
 	// it can be added back as a provider.
 	// TODO: Make configurable
-	defaultBlackListTTL = 30 * time.Second
+	defaultBlacklistTTL = 30 * time.Second
 )
 
 // Option sets a parameter for the light client.
@@ -128,6 +128,7 @@ type Client struct {
 	trustLevel       tmmath.Fraction
 	maxClockDrift    time.Duration
 	maxBlockLag      time.Duration
+	blacklistTTL     time.Duration
 
 	// Mutex for locking during changes of the light clients providers
 	providerMutex sync.Mutex
@@ -213,6 +214,7 @@ func NewClient(
 		trustLevel:       DefaultTrustLevel,
 		maxClockDrift:    defaultMaxClockDrift,
 		maxBlockLag:      defaultMaxBlockLag,
+		blacklistTTL:     defaultBlacklistTTL,
 		pruningSize:      defaultPruningSize,
 		logger:           log.NewNopLogger(),
 	}
@@ -252,6 +254,7 @@ func NewClientFromTrustedStore(
 		trustLevel:       DefaultTrustLevel,
 		maxClockDrift:    defaultMaxClockDrift,
 		maxBlockLag:      defaultMaxBlockLag,
+		blacklistTTL:     defaultBlacklistTTL,
 		primary:          primary,
 		witnesses:        witnesses,
 		trustedStore:     trustedStore,
@@ -283,7 +286,7 @@ func (c *Client) isBlacklisted(p provider.Provider) bool {
     }
 
     // If the provider is found, check the TTL
-    if time.Since(timestamp) > 30*time.Second {
+    if time.Since(timestamp) > c.blacklistTTL {
         // Remove from blacklist if TTL expired
         delete(c.blacklist, p.ID())
         return false

--- a/light/client_benchmark_test.go
+++ b/light/client_benchmark_test.go
@@ -86,6 +86,7 @@ func BenchmarkSequence(b *testing.B) {
 		benchmarkFullNode,
 		[]provider.Provider{benchmarkFullNode},
 		dbs.New(dbm.NewMemDB()),
+		5 * time.Minute,
 		light.Logger(logger),
 		light.SequentialVerification(),
 	)
@@ -123,6 +124,7 @@ func BenchmarkBisection(b *testing.B) {
 		benchmarkFullNode,
 		[]provider.Provider{benchmarkFullNode},
 		dbs.New(dbm.NewMemDB()),
+		5 * time.Minute,
 		light.Logger(logger),
 	)
 	if err != nil {
@@ -159,6 +161,7 @@ func BenchmarkBackwards(b *testing.B) {
 		benchmarkFullNode,
 		[]provider.Provider{benchmarkFullNode},
 		dbs.New(dbm.NewMemDB()),
+		5 * time.Minute,
 		light.Logger(logger),
 	)
 	if err != nil {

--- a/light/client_benchmark_test.go
+++ b/light/client_benchmark_test.go
@@ -86,7 +86,7 @@ func BenchmarkSequence(b *testing.B) {
 		benchmarkFullNode,
 		[]provider.Provider{benchmarkFullNode},
 		dbs.New(dbm.NewMemDB()),
-		5 * time.Minute,
+		5*time.Minute,
 		light.Logger(logger),
 		light.SequentialVerification(),
 	)
@@ -124,7 +124,7 @@ func BenchmarkBisection(b *testing.B) {
 		benchmarkFullNode,
 		[]provider.Provider{benchmarkFullNode},
 		dbs.New(dbm.NewMemDB()),
-		5 * time.Minute,
+		5*time.Minute,
 		light.Logger(logger),
 	)
 	if err != nil {
@@ -161,7 +161,7 @@ func BenchmarkBackwards(b *testing.B) {
 		benchmarkFullNode,
 		[]provider.Provider{benchmarkFullNode},
 		dbs.New(dbm.NewMemDB()),
-		5 * time.Minute,
+		5*time.Minute,
 		light.Logger(logger),
 	)
 	if err != nil {

--- a/light/client_test.go
+++ b/light/client_test.go
@@ -77,6 +77,7 @@ func TestClient(t *testing.T) {
 		id1 = "id1"
 		id2 = "id2"
 		id3 = "id3"
+		blacklistTTL = 5 * time.Minute
 	)
 	t.Run("ValidateTrustOptions", func(t *testing.T) {
 		testCases := []struct {
@@ -238,6 +239,7 @@ func TestClient(t *testing.T) {
 					mockNode,
 					[]provider.Provider{mockNode},
 					dbs.New(dbm.NewMemDB()),
+					blacklistTTL,
 					light.SequentialVerification(),
 					light.Logger(logger),
 				)
@@ -365,6 +367,7 @@ func TestClient(t *testing.T) {
 					mockNode,
 					[]provider.Provider{mockNode},
 					dbs.New(dbm.NewMemDB()),
+					blacklistTTL,
 					light.SkippingVerification(light.DefaultTrustLevel),
 					light.Logger(logger),
 				)
@@ -421,6 +424,7 @@ func TestClient(t *testing.T) {
 			mockNode,
 			[]provider.Provider{mockNode},
 			dbs.New(dbm.NewMemDB()),
+			blacklistTTL,
 			light.SkippingVerification(light.DefaultTrustLevel),
 		)
 		require.NoError(t, err)
@@ -450,6 +454,7 @@ func TestClient(t *testing.T) {
 			mockFullNode,
 			[]provider.Provider{mockFullNode},
 			dbs.New(dbm.NewMemDB()),
+			blacklistTTL,
 			light.SkippingVerification(light.DefaultTrustLevel),
 		)
 		require.NoError(t, err)
@@ -480,6 +485,7 @@ func TestClient(t *testing.T) {
 			mockFullNode,
 			[]provider.Provider{mockFullNode},
 			dbs.New(dbm.NewMemDB()),
+			blacklistTTL,
 			light.Logger(logger),
 		)
 		require.NoError(t, err)
@@ -520,6 +526,7 @@ func TestClient(t *testing.T) {
 				mockNode,
 				[]provider.Provider{mockNode},
 				trustedStore,
+				blacklistTTL,
 				light.Logger(logger),
 			)
 			require.NoError(t, err)
@@ -559,6 +566,7 @@ func TestClient(t *testing.T) {
 				mockNode,
 				[]provider.Provider{mockNode},
 				trustedStore,
+				blacklistTTL,
 				light.Logger(logger),
 			)
 			require.NoError(t, err)
@@ -591,6 +599,7 @@ func TestClient(t *testing.T) {
 			mockFullNode,
 			[]provider.Provider{mockFullNode},
 			dbs.New(dbm.NewMemDB()),
+			blacklistTTL,
 			light.Logger(logger),
 		)
 		require.NoError(t, err)
@@ -620,6 +629,7 @@ func TestClient(t *testing.T) {
 			mockFullNode,
 			[]provider.Provider{mockFullNode},
 			dbs.New(dbm.NewMemDB()),
+			blacklistTTL,
 			light.Logger(logger),
 		)
 		require.NoError(t, err)
@@ -671,6 +681,7 @@ func TestClient(t *testing.T) {
 			mockFullNode,
 			[]provider.Provider{mockFullNode},
 			dbs.New(dbm.NewMemDB()),
+			blacklistTTL,
 			light.Logger(logger),
 		)
 		require.NoError(t, err)
@@ -715,6 +726,7 @@ func TestClient(t *testing.T) {
 			mockDeadNode,
 			[]provider.Provider{mockDeadNode, mockFullNode, mockFullNode1},
 			dbs.New(dbm.NewMemDB()),
+			blacklistTTL,
 			light.Logger(logger),
 		)
 
@@ -750,6 +762,7 @@ func TestClient(t *testing.T) {
 			mockDeadNode,
 			[]provider.Provider{mockFullNode, mockFullNode},
 			dbs.New(dbm.NewMemDB()),
+			blacklistTTL,
 			light.Logger(logger),
 		)
 		require.NoError(t, err)
@@ -784,6 +797,7 @@ func TestClient(t *testing.T) {
 				mockLargeFullNode,
 				[]provider.Provider{mockLargeFullNode},
 				dbs.New(dbm.NewMemDB()),
+				blacklistTTL,
 				light.Logger(logger),
 			)
 			require.NoError(t, err)
@@ -843,6 +857,7 @@ func TestClient(t *testing.T) {
 				mockNode,
 				[]provider.Provider{mockNode},
 				dbs.New(dbm.NewMemDB()),
+				blacklistTTL,
 				light.Logger(logger),
 			)
 			require.NoError(t, err)
@@ -865,6 +880,7 @@ func TestClient(t *testing.T) {
 			mockNode,
 			[]provider.Provider{mockNode},
 			db,
+			blacklistTTL,
 		)
 		require.NoError(t, err)
 
@@ -920,6 +936,7 @@ func TestClient(t *testing.T) {
 			mockFullNode,
 			[]provider.Provider{mockBadNode1, mockBadNode2},
 			dbs.New(dbm.NewMemDB()),
+			blacklistTTL,
 			light.Logger(logger),
 		)
 		// witness should have behaved properly -> no error
@@ -982,6 +999,7 @@ func TestClient(t *testing.T) {
 			mockFullNode,
 			[]provider.Provider{mockBadValSetNode, mockFullNode},
 			dbs.New(dbm.NewMemDB()),
+			blacklistTTL,
 			light.Logger(logger),
 		)
 		require.NoError(t, err)
@@ -1017,6 +1035,7 @@ func TestClient(t *testing.T) {
 			mockFullNode,
 			[]provider.Provider{mockFullNode},
 			dbs.New(dbm.NewMemDB()),
+			blacklistTTL,
 			light.Logger(logger),
 			light.PruningSize(1),
 		)
@@ -1109,6 +1128,7 @@ func TestClient(t *testing.T) {
 					mockBadNode,
 					[]provider.Provider{mockBadNode, mockBadNode},
 					dbs.New(dbm.NewMemDB()),
+					blacklistTTL,
 				)
 				require.NoError(t, err)
 

--- a/light/client_test.go
+++ b/light/client_test.go
@@ -74,6 +74,8 @@ func TestClient(t *testing.T) {
 		l1 = &types.LightBlock{SignedHeader: h1, ValidatorSet: vals}
 		l2 = &types.LightBlock{SignedHeader: h2, ValidatorSet: vals}
 		l3 = &types.LightBlock{SignedHeader: h3, ValidatorSet: vals}
+		id1 = "id1"
+		id2 = "id2"
 	)
 	t.Run("ValidateTrustOptions", func(t *testing.T) {
 		testCases := []struct {
@@ -658,6 +660,7 @@ func TestClient(t *testing.T) {
 			1: h1,
 			2: h2,
 		}, valSet)
+		mockFullNode.On("ID", mock.Anything, mock.Anything).Return(id1, nil)
 		logger := log.NewNopLogger()
 
 		c, err := light.NewClient(
@@ -694,8 +697,10 @@ func TestClient(t *testing.T) {
 
 		mockFullNode := &provider_mocks.Provider{}
 		mockFullNode.On("LightBlock", mock.Anything, mock.Anything).Return(l1, nil)
+		mockFullNode.On("ID", mock.Anything, mock.Anything).Return(id1, nil)
 		mockDeadNode := &provider_mocks.Provider{}
 		mockDeadNode.On("LightBlock", mock.Anything, mock.Anything).Return(nil, provider.ErrNoResponse)
+		mockFullNode.On("ID", mock.Anything, mock.Anything).Return(id2, nil)
 
 		logger := log.NewNopLogger()
 
@@ -728,10 +733,12 @@ func TestClient(t *testing.T) {
 
 		mockFullNode := &provider_mocks.Provider{}
 		mockFullNode.On("LightBlock", mock.Anything, mock.Anything).Return(l1, nil)
+		mockFullNode.On("ID", mock.Anything, mock.Anything).Return(id1, nil)
 
 		logger := log.NewNopLogger()
 		mockDeadNode := &provider_mocks.Provider{}
 		mockDeadNode.On("LightBlock", mock.Anything, mock.Anything).Return(nil, provider.ErrLightBlockNotFound)
+		mockDeadNode.On("ID", mock.Anything, mock.Anything).Return(id2, nil)
 
 		c, err := light.NewClient(
 			ctx,
@@ -882,6 +889,7 @@ func TestClient(t *testing.T) {
 		}
 		mockBadNode1 := mockNodeFromHeadersAndVals(headers1, vals1)
 		mockBadNode1.On("LightBlock", mock.Anything, mock.Anything).Return(nil, provider.ErrLightBlockNotFound)
+		mockBadNode1.On("ID", mock.Anything, mock.Anything).Return(id1, nil)
 
 		// header is empty
 		headers2 := map[int64]*types.SignedHeader{
@@ -894,6 +902,7 @@ func TestClient(t *testing.T) {
 		}
 		mockBadNode2 := mockNodeFromHeadersAndVals(headers2, vals2)
 		mockBadNode2.On("LightBlock", mock.Anything, mock.Anything).Return(nil, provider.ErrLightBlockNotFound)
+		mockBadNode2.On("ID", mock.Anything, mock.Anything).Return(id2, nil)
 
 		mockFullNode := mockNodeFromHeadersAndVals(headerSet, valSet)
 
@@ -953,6 +962,7 @@ func TestClient(t *testing.T) {
 				1: vals,
 				2: differentVals,
 			})
+		mockBadValSetNode.On("ID", mock.Anything, mock.Anything).Return(id1, nil)
 
 		mockFullNode := mockNodeFromHeadersAndVals(
 			map[int64]*types.SignedHeader{
@@ -963,6 +973,7 @@ func TestClient(t *testing.T) {
 				1: vals,
 				2: vals,
 			})
+		mockFullNode.On("ID", mock.Anything, mock.Anything).Return(id1, nil)
 
 		c, err := light.NewClient(
 			ctx,

--- a/light/client_test.go
+++ b/light/client_test.go
@@ -77,7 +77,7 @@ func TestClient(t *testing.T) {
 		id1 = "id1"
 		id2 = "id2"
 		id3 = "id3"
-		// Set duration to 5 seconds for testing
+		// Set duration to 10 seconds for testing
 		blacklistTTL = 10 * time.Second
 	)
 	t.Run("ValidateTrustOptions", func(t *testing.T) {

--- a/light/detector.go
+++ b/light/detector.go
@@ -119,7 +119,7 @@ func (c *Client) compareNewHeaderWithWitness(ctx context.Context, errc chan erro
 
 	// the witness hasn't been helpful in comparing headers, we mark the response and continue
 	// comparing with the rest of the witnesses
-	case provider.ErrNoResponse, provider.ErrLightBlockNotFound, context.DeadlineExceeded, context.Canceled:
+	case context.DeadlineExceeded, context.Canceled:
 		errc <- err
 		return
 
@@ -189,7 +189,7 @@ func (c *Client) compareNewHeaderWithWitness(ctx context.Context, errc chan erro
 		return
 
 	default:
-		// all other errors (i.e. invalid block, closed connection or unreliable provider) we mark the
+		// all other errors (i.e. no response, invalid block, closed connection or unreliable provider) we mark the
 		// witness as bad and remove it
 		errc <- errBadWitness{Reason: err, WitnessIndex: witnessIndex}
 		return

--- a/light/detector.go
+++ b/light/detector.go
@@ -189,7 +189,7 @@ func (c *Client) compareNewHeaderWithWitness(ctx context.Context, errc chan erro
 		return
 
 	default:
-		// all other errors (i.e. no response, invalid block, closed connection or unreliable provider) we mark the
+		// all other errors (i.e. no response, light block not found, invalid block, closed connection or unreliable provider) we mark the
 		// witness as bad and remove it
 		errc <- errBadWitness{Reason: err, WitnessIndex: witnessIndex}
 		return

--- a/light/detector_test.go
+++ b/light/detector_test.go
@@ -93,6 +93,7 @@ func TestLightClientAttackEvidence_Lunatic(t *testing.T) {
 		mockPrimary,
 		[]provider.Provider{mockWitness},
 		dbs.New(dbm.NewMemDB()),
+		5 * time.Minute,
 		light.Logger(logger),
 	)
 	require.NoError(t, err)
@@ -213,6 +214,7 @@ func TestLightClientAttackEvidence_Equivocation(t *testing.T) {
 				mockPrimary,
 				[]provider.Provider{mockWitness},
 				dbs.New(dbm.NewMemDB()),
+				5 * time.Minute,
 				light.Logger(logger),
 				testCase.lightOption,
 			)
@@ -312,6 +314,7 @@ func TestLightClientAttackEvidence_ForwardLunatic(t *testing.T) {
 		mockPrimary,
 		[]provider.Provider{mockWitness, accomplice},
 		dbs.New(dbm.NewMemDB()),
+		5 * time.Minute,
 		light.Logger(logger),
 		light.MaxClockDrift(1*time.Second),
 		light.MaxBlockLag(1*time.Second),
@@ -373,6 +376,7 @@ func TestLightClientAttackEvidence_ForwardLunatic(t *testing.T) {
 		mockPrimary,
 		[]provider.Provider{mockLaggingWitness, accomplice},
 		dbs.New(dbm.NewMemDB()),
+		5 * time.Minute,
 		light.Logger(logger),
 		light.MaxClockDrift(1*time.Second),
 		light.MaxBlockLag(1*time.Second),
@@ -412,6 +416,7 @@ func TestClientDivergentTraces1(t *testing.T) {
 		mockPrimary,
 		[]provider.Provider{mockWitness},
 		dbs.New(dbm.NewMemDB()),
+		5 * time.Minute,
 		light.Logger(logger),
 	)
 	require.Error(t, err)
@@ -445,6 +450,7 @@ func TestClientDivergentTraces2(t *testing.T) {
 		mockPrimaryNode,
 		[]provider.Provider{mockDeadNode, mockDeadNode, mockPrimaryNode},
 		dbs.New(dbm.NewMemDB()),
+		5 * time.Minute,
 		light.Logger(logger),
 	)
 	require.NoError(t, err)
@@ -488,6 +494,7 @@ func TestClientDivergentTraces3(t *testing.T) {
 		mockPrimary,
 		[]provider.Provider{mockWitness},
 		dbs.New(dbm.NewMemDB()),
+		5 * time.Minute,
 		light.Logger(logger),
 	)
 	require.NoError(t, err)
@@ -531,6 +538,7 @@ func TestClientDivergentTraces4(t *testing.T) {
 		mockPrimary,
 		[]provider.Provider{mockWitness},
 		dbs.New(dbm.NewMemDB()),
+		5 * time.Minute,
 		light.Logger(logger),
 	)
 	require.NoError(t, err)

--- a/light/detector_test.go
+++ b/light/detector_test.go
@@ -283,6 +283,7 @@ func TestLightClientAttackEvidence_ForwardLunatic(t *testing.T) {
 	lastBlock, _ = mockWitness.LightBlock(ctx, latestHeight)
 	mockWitness.On("LightBlock", mock.Anything, int64(0)).Return(lastBlock, nil).Once()
 	mockWitness.On("LightBlock", mock.Anything, int64(12)).Return(nil, provider.ErrHeightTooHigh)
+	mockWitness.On("ID", mock.Anything, mock.Anything).Return("mockWitness", nil)
 
 	mockWitness.On("ReportEvidence", mock.Anything, mock.MatchedBy(func(evidence types.Evidence) bool {
 		// Check evidence was sent to the witness against the full node
@@ -358,6 +359,7 @@ func TestLightClientAttackEvidence_ForwardLunatic(t *testing.T) {
 	// in enough time
 	mockLaggingWitness := mockNodeFromHeadersAndVals(witnessHeaders, witnessValidators)
 	mockLaggingWitness.On("LightBlock", mock.Anything, int64(12)).Return(nil, provider.ErrHeightTooHigh)
+	mockLaggingWitness.On("ID", mock.Anything, mock.Anything).Return("mockLaggingWitness", nil)
 	lastBlock, _ = mockLaggingWitness.LightBlock(ctx, latestHeight)
 	mockLaggingWitness.On("LightBlock", mock.Anything, int64(0)).Return(lastBlock, nil)
 	c, err = light.NewClient(
@@ -449,7 +451,7 @@ func TestClientDivergentTraces2(t *testing.T) {
 
 	_, err = c.VerifyLightBlockAtHeight(ctx, 2, bTime.Add(1*time.Hour))
 	assert.NoError(t, err)
-	assert.Equal(t, 3, len(c.Witnesses()))
+	assert.Equal(t, 1, len(c.Witnesses()))
 	mockDeadNode.AssertExpectations(t)
 	mockPrimaryNode.AssertExpectations(t)
 }

--- a/light/detector_test.go
+++ b/light/detector_test.go
@@ -3,9 +3,10 @@ package light_test
 import (
 	"bytes"
 	"context"
-	provider_mocks "github.com/tendermint/tendermint/light/provider/mocks"
 	"testing"
 	"time"
+
+	provider_mocks "github.com/tendermint/tendermint/light/provider/mocks"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -436,7 +437,6 @@ func TestClientDivergentTraces2(t *testing.T) {
 	mockPrimaryNode := mockNodeFromHeadersAndVals(headers, vals)
 	mockDeadNode := &provider_mocks.Provider{}
 	mockDeadNode.On("LightBlock", mock.Anything, mock.Anything).Return(nil, provider.ErrNoResponse)
-	mockDeadNode.On("ID", mock.Anything, mock.Anything).Return("id1", nil)
 	firstBlock, err := mockPrimaryNode.LightBlock(ctx, 1)
 	require.NoError(t, err)
 	c, err := light.NewClient(

--- a/light/detector_test.go
+++ b/light/detector_test.go
@@ -93,7 +93,7 @@ func TestLightClientAttackEvidence_Lunatic(t *testing.T) {
 		mockPrimary,
 		[]provider.Provider{mockWitness},
 		dbs.New(dbm.NewMemDB()),
-		5 * time.Minute,
+		5*time.Minute,
 		light.Logger(logger),
 	)
 	require.NoError(t, err)
@@ -214,7 +214,7 @@ func TestLightClientAttackEvidence_Equivocation(t *testing.T) {
 				mockPrimary,
 				[]provider.Provider{mockWitness},
 				dbs.New(dbm.NewMemDB()),
-				5 * time.Minute,
+				5*time.Minute,
 				light.Logger(logger),
 				testCase.lightOption,
 			)
@@ -314,7 +314,7 @@ func TestLightClientAttackEvidence_ForwardLunatic(t *testing.T) {
 		mockPrimary,
 		[]provider.Provider{mockWitness, accomplice},
 		dbs.New(dbm.NewMemDB()),
-		5 * time.Minute,
+		5*time.Minute,
 		light.Logger(logger),
 		light.MaxClockDrift(1*time.Second),
 		light.MaxBlockLag(1*time.Second),
@@ -376,7 +376,7 @@ func TestLightClientAttackEvidence_ForwardLunatic(t *testing.T) {
 		mockPrimary,
 		[]provider.Provider{mockLaggingWitness, accomplice},
 		dbs.New(dbm.NewMemDB()),
-		5 * time.Minute,
+		5*time.Minute,
 		light.Logger(logger),
 		light.MaxClockDrift(1*time.Second),
 		light.MaxBlockLag(1*time.Second),
@@ -416,7 +416,7 @@ func TestClientDivergentTraces1(t *testing.T) {
 		mockPrimary,
 		[]provider.Provider{mockWitness},
 		dbs.New(dbm.NewMemDB()),
-		5 * time.Minute,
+		5*time.Minute,
 		light.Logger(logger),
 	)
 	require.Error(t, err)
@@ -426,7 +426,7 @@ func TestClientDivergentTraces1(t *testing.T) {
 }
 
 // 2. Two out of three nodes don't respond but the third has a header that matches
-// => verification should be successful and all the witnesses should remain
+// => verification should be successful but two unresponsive witnesses should be blacklisted
 func TestClientDivergentTraces2(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -450,13 +450,14 @@ func TestClientDivergentTraces2(t *testing.T) {
 		mockPrimaryNode,
 		[]provider.Provider{mockDeadNode, mockDeadNode, mockPrimaryNode},
 		dbs.New(dbm.NewMemDB()),
-		5 * time.Minute,
+		5*time.Minute,
 		light.Logger(logger),
 	)
 	require.NoError(t, err)
 
 	_, err = c.VerifyLightBlockAtHeight(ctx, 2, bTime.Add(1*time.Hour))
 	assert.NoError(t, err)
+	// The unreponsive witnesses have been removed and blacklisted
 	assert.Equal(t, 1, len(c.Witnesses()))
 	mockDeadNode.AssertExpectations(t)
 	mockPrimaryNode.AssertExpectations(t)
@@ -494,7 +495,7 @@ func TestClientDivergentTraces3(t *testing.T) {
 		mockPrimary,
 		[]provider.Provider{mockWitness},
 		dbs.New(dbm.NewMemDB()),
-		5 * time.Minute,
+		5*time.Minute,
 		light.Logger(logger),
 	)
 	require.NoError(t, err)
@@ -538,7 +539,7 @@ func TestClientDivergentTraces4(t *testing.T) {
 		mockPrimary,
 		[]provider.Provider{mockWitness},
 		dbs.New(dbm.NewMemDB()),
-		5 * time.Minute,
+		5*time.Minute,
 		light.Logger(logger),
 	)
 	require.NoError(t, err)

--- a/light/detector_test.go
+++ b/light/detector_test.go
@@ -429,6 +429,7 @@ func TestClientDivergentTraces2(t *testing.T) {
 	mockPrimaryNode := mockNodeFromHeadersAndVals(headers, vals)
 	mockDeadNode := &provider_mocks.Provider{}
 	mockDeadNode.On("LightBlock", mock.Anything, mock.Anything).Return(nil, provider.ErrNoResponse)
+	mockDeadNode.On("ID", mock.Anything, mock.Anything).Return("id1", nil)
 	firstBlock, err := mockPrimaryNode.LightBlock(ctx, 1)
 	require.NoError(t, err)
 	c, err := light.NewClient(

--- a/light/example_test.go
+++ b/light/example_test.go
@@ -70,6 +70,7 @@ func TestExampleClient(t *testing.T) {
 		primary,
 		[]provider.Provider{primary},
 		dbs.New(db),
+		5 * time.Minute,
 		light.Logger(logger),
 	)
 	if err != nil {

--- a/light/example_test.go
+++ b/light/example_test.go
@@ -70,7 +70,7 @@ func TestExampleClient(t *testing.T) {
 		primary,
 		[]provider.Provider{primary},
 		dbs.New(db),
-		5 * time.Minute,
+		5*time.Minute,
 		light.Logger(logger),
 	)
 	if err != nil {

--- a/light/light_test.go
+++ b/light/light_test.go
@@ -69,6 +69,7 @@ func TestClientIntegration_Update(t *testing.T) {
 		primary,
 		[]provider.Provider{primary},
 		dbs.New(db),
+		5 * time.Minute,
 		light.Logger(logger),
 	)
 	require.NoError(t, err)
@@ -126,6 +127,7 @@ func TestClientIntegration_VerifyLightBlockAtHeight(t *testing.T) {
 		primary,
 		[]provider.Provider{primary},
 		dbs.New(db),
+		5 * time.Minute,
 		light.Logger(logger),
 	)
 	require.NoError(t, err)
@@ -205,6 +207,7 @@ func TestClientStatusRPC(t *testing.T) {
 		primary,
 		witnesses,
 		dbs.New(db),
+		5 * time.Minute,
 		light.Logger(log.NewNopLogger()),
 	)
 	require.NoError(t, err)

--- a/light/light_test.go
+++ b/light/light_test.go
@@ -69,7 +69,7 @@ func TestClientIntegration_Update(t *testing.T) {
 		primary,
 		[]provider.Provider{primary},
 		dbs.New(db),
-		5 * time.Minute,
+		5*time.Minute,
 		light.Logger(logger),
 	)
 	require.NoError(t, err)
@@ -127,7 +127,7 @@ func TestClientIntegration_VerifyLightBlockAtHeight(t *testing.T) {
 		primary,
 		[]provider.Provider{primary},
 		dbs.New(db),
-		5 * time.Minute,
+		5*time.Minute,
 		light.Logger(logger),
 	)
 	require.NoError(t, err)
@@ -207,7 +207,7 @@ func TestClientStatusRPC(t *testing.T) {
 		primary,
 		witnesses,
 		dbs.New(db),
-		5 * time.Minute,
+		5*time.Minute,
 		light.Logger(log.NewNopLogger()),
 	)
 	require.NoError(t, err)

--- a/light/setup.go
+++ b/light/setup.go
@@ -2,6 +2,7 @@ package light
 
 import (
 	"context"
+	"time"
 
 	"github.com/tendermint/tendermint/light/provider"
 	"github.com/tendermint/tendermint/light/provider/http"
@@ -21,6 +22,7 @@ func NewHTTPClient(
 	primaryAddress string,
 	witnessesAddresses []string,
 	trustedStore store.Store,
+	blacklistTTL time.Duration,
 	options ...Option) (*Client, error) {
 
 	providers, err := providersFromAddresses(append(witnessesAddresses, primaryAddress), chainID)
@@ -35,6 +37,7 @@ func NewHTTPClient(
 		providers[len(providers)-1],
 		providers[:len(providers)-1],
 		trustedStore,
+		blacklistTTL,
 		options...)
 }
 

--- a/light/stateprovider.go
+++ b/light/stateprovider.go
@@ -429,9 +429,10 @@ func (s *StateProviderP2P) consensusParams(ctx context.Context, height int64) (t
 		iterCount++
 
 		childCtx, childCancel := context.WithCancel(ctx)
+		defer childCancel()
+
 		err := retryAll(childCtx)
 		if err != nil {
-			childCancel()
 			return types.ConsensusParams{}, err
 		}
 
@@ -441,14 +442,10 @@ func (s *StateProviderP2P) consensusParams(ctx context.Context, height int64) (t
 
 		select {
 		case param := <-out:
-			childCancel()
 			return param, nil
 		case <-ctx.Done():
-			childCancel()
 			return types.ConsensusParams{}, ctx.Err()
 		case <-timer.C:
-			childCancel()
 		}
 	}
 }
-

--- a/light/stateprovider.go
+++ b/light/stateprovider.go
@@ -428,6 +428,7 @@ func (s *StateProviderP2P) consensusParams(ctx context.Context, height int64) (t
 						case <-ctx.Done():
 							return
 						case out <- params:
+							cancel()
 							return
 						}
 					}

--- a/light/stateprovider.go
+++ b/light/stateprovider.go
@@ -446,6 +446,10 @@ func (s *StateProviderP2P) consensusParams(ctx context.Context, height int64) (t
 		if err != nil {
 			return types.ConsensusParams{}, err
 		}
+		// jitter+backoff the retry loop
+		timer.Reset(time.Duration(iterCount)*consensusParamsResponseTimeout +
+			time.Duration(100*rand.Int63n(iterCount))*time.Millisecond) // nolint:gosec
+
 		select {
 		case param := <-out:
 			return param, nil

--- a/light/stateprovider.go
+++ b/light/stateprovider.go
@@ -442,10 +442,13 @@ func (s *StateProviderP2P) consensusParams(ctx context.Context, height int64) (t
 
 		select {
 		case param := <-out:
+			childCancel()
 			return param, nil
 		case <-ctx.Done():
+			childCancel()
 			return types.ConsensusParams{}, ctx.Err()
 		case <-timer.C:
+			childCancel()
 		}
 	}
 }

--- a/light/stateprovider.go
+++ b/light/stateprovider.go
@@ -369,13 +369,13 @@ func (s *StateProviderP2P) ParamsRecvCh() chan types.ConsensusParams {
 	return s.paramsRecvCh
 }
 
-// consensusParams sends out a request for consensus params blocking
-// until one is returned.
+// consensusParams sends requests for consensus parameters to all witnesses
+// in parallel, retrying with increasing backoff until a response is
+// received or the context is canceled.
 //
-// It attempts to send requests to all witnesses in parallel, but if
-// none responds it will retry them all sometime later until it
-// receives some response. This operation will block until it receives
-// a response or the context is canceled.
+// For each witness, a goroutine sends a parameter request, retrying periodically
+// if no response is obtained, with increasing intervals. It returns the
+// consensus parameters upon receiving a response, or an error if the context is canceled.
 func (s *StateProviderP2P) consensusParams(ctx context.Context, height int64) (types.ConsensusParams, error) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()

--- a/light/stateprovider.go
+++ b/light/stateprovider.go
@@ -429,10 +429,10 @@ func (s *StateProviderP2P) consensusParams(ctx context.Context, height int64) (t
 		iterCount++
 
 		childCtx, childCancel := context.WithCancel(ctx)
-		defer childCancel()
 
 		err := retryAll(childCtx)
 		if err != nil {
+			childCancel()
 			return types.ConsensusParams{}, err
 		}
 


### PR DESCRIPTION
## Describe your changes and provide context
- Removes witnesses for "client failed to respond" and "light block not found" errors
- Add a blacklist with recently removed witnesses and set a minimum duration before they can be added back
- `consensusParams` returns after any witness responds vs waiting on all responses

## Testing performed to validate your change
- Tested on a pacific-1 rpc during state sync w/ p2p and reproed
- Added unit tests
