### PR TITLE
Remove witness when removing provider for p2p-down

### DIFF
--- a/internal/statesync/reactor.go
+++ b/internal/statesync/reactor.go
@@ -1032,6 +1032,11 @@ func (r *Reactor) processPeerUpdate(ctx context.Context, peerUpdate p2p.PeerUpda
 	case p2p.PeerStatusDown:
 		delete(r.providers, peerUpdate.NodeID)
 		r.syncer.RemovePeer(peerUpdate.NodeID)
+		if sp, ok := r.stateProvider.(*light.StateProviderP2P); ok {
+			if err := sp.RemoveProviderByID(peerUpdate.NodeID); err != nil {
+				r.logger.Error("failed to remove provider", "error", err)
+			}
+		}
 	}
 	r.logger.Debug("processed peer update", "peer", peerUpdate.NodeID, "status", peerUpdate.Status)
 }

--- a/internal/statesync/reactor.go
+++ b/internal/statesync/reactor.go
@@ -1034,7 +1034,7 @@ func (r *Reactor) processPeerUpdate(ctx context.Context, peerUpdate p2p.PeerUpda
 		r.syncer.RemovePeer(peerUpdate.NodeID)
 		if sp, ok := r.stateProvider.(*light.StateProviderP2P); ok {
 			if err := sp.RemoveProviderByID(peerUpdate.NodeID); err != nil {
-				r.logger.Error("failed to remove provider", "error", err)
+				r.logger.Error("failed to remove peer witness", "peer", peerUpdate.NodeID, "error", err)
 			}
 		}
 	}

--- a/light/client.go
+++ b/light/client.go
@@ -1008,6 +1008,26 @@ func (c *Client) getLightBlock(ctx context.Context, p provider.Provider, height 
 	return l, err
 }
 
+func (c *Client) findIndexForWitness(ID types.NodeID) (int, bool) {
+	for i, w := range c.witnesses {
+		if w.ID() == string(ID) {
+			return i, true
+		}
+	}
+	return 0, false
+}
+
+// RemoveProviderByID removes a witness from the light client.
+func (c *Client) RemoveProviderByID(ID types.NodeID) error {
+	c.providerMutex.Lock()
+	defer c.providerMutex.Unlock()
+
+	if idx, ok := c.findIndexForWitness(ID); ok {
+		return c.removeWitnesses([]int{idx})
+	}
+	return nil
+}
+
 // NOTE: requires a providerMutex lock
 func (c *Client) removeWitnesses(indexes []int) error {
 	if len(c.witnesses) <= len(indexes) {

--- a/light/stateprovider.go
+++ b/light/stateprovider.go
@@ -370,6 +370,11 @@ func (s *StateProviderP2P) RemoveProviderByID(ID types.NodeID) error {
 	return s.lc.RemoveProviderByID(ID)
 }
 
+// Providers returns the list of providers (useful for tests)
+func (s *StateProviderP2P) Providers() []lightprovider.Provider {
+	return s.lc.Witnesses()
+}
+
 func (s *StateProviderP2P) ParamsRecvCh() chan types.ConsensusParams {
 	return s.paramsRecvCh
 }

--- a/light/stateprovider.go
+++ b/light/stateprovider.go
@@ -357,12 +357,17 @@ func (s *StateProviderP2P) State(ctx context.Context, height uint64) (sm.State, 
 	return state, nil
 }
 
-// addProvider dynamically adds a peer as a new witness. A limit of 6 providers is kept as a
+// AddProvider dynamically adds a peer as a new witness. A limit of 6 providers is kept as a
 // heuristic. Too many overburdens the network and too little compromises the second layer of security.
 func (s *StateProviderP2P) AddProvider(p lightprovider.Provider) {
 	if len(s.lc.Witnesses()) < 6 {
 		s.lc.AddProvider(p)
 	}
+}
+
+// RemoveProviderByID removes a peer from the light client's witness list.
+func (s *StateProviderP2P) RemoveProviderByID(ID types.NodeID) error {
+	return s.lc.RemoveProviderByID(ID)
 }
 
 func (s *StateProviderP2P) ParamsRecvCh() chan types.ConsensusParams {


### PR DESCRIPTION
## Describe your changes and provide context
- Remove witness when syncer p2p status is down

## Testing performed to validate your change
- Unit test now verifies the witness is removed upon p2p-down