### PR TITLE
Add regex support to query syntax

### DIFF
--- a/internal/pubsub/query/query.go
+++ b/internal/pubsub/query/query.go
@@ -4,12 +4,11 @@
 // Query expressions describe properties of events and their attributes, using
 // strings like:
 //
-//    abci.invoice.number = 22 AND abci.invoice.owner = 'Ivan'
+//	abci.invoice.number = 22 AND abci.invoice.owner = 'Ivan'
 //
 // Query expressions can handle attribute values encoding numbers, strings,
 // dates, and timestamps.  The complete query grammar is described in the
 // query/syntax package.
-//
 package query
 
 import (
@@ -207,12 +206,21 @@ func parseNumber(s string) (float64, error) {
 // An entry does not exist if the combination is not valid.
 //
 // Disable the dupl lint for this map. The result isn't even correct.
+//
 //nolint:dupl
 var opTypeMap = map[syntax.Token]map[syntax.Token]func(interface{}) func(string) bool{
 	syntax.TContains: {
 		syntax.TString: func(v interface{}) func(string) bool {
 			return func(s string) bool {
 				return strings.Contains(s, v.(string))
+			}
+		},
+	},
+	syntax.TMatches: {
+		syntax.TString: func(v interface{}) func(string) bool {
+			return func(s string) bool {
+				match, _ := regexp.MatchString(v.(string), s)
+				return match
 			}
 		},
 	},

--- a/internal/pubsub/query/query_test.go
+++ b/internal/pubsub/query/query_test.go
@@ -12,14 +12,14 @@ import (
 )
 
 // Example events from the OpenAPI documentation:
-//  https://github.com/tendermint/tendermint/blob/master/rpc/openapi/openapi.yaml
+//
+//	https://github.com/tendermint/tendermint/blob/master/rpc/openapi/openapi.yaml
 //
 // Redactions:
 //
 //   - Add an explicit "tm" event for the built-in attributes.
 //   - Remove Index fields (not relevant to tests).
 //   - Add explicit balance values (to use in tests).
-//
 var apiEvents = []types.Event{
 	{
 		Type: "tm",
@@ -126,6 +126,12 @@ func TestCompiledMatches(t *testing.T) {
 			newTestEvents(`abci|owner.name=Igor|owner.name=Ivan`),
 			true},
 		{`abci.owner.name CONTAINS 'Igor'`,
+			newTestEvents(`abci|owner.name=Pavel|owner.name=Ivan`),
+			false},
+		{`abci.owner.name MATCHES '.*or.*'`,
+			newTestEvents(`abci|owner.name=Igor|owner.name=Ivan`),
+			true},
+		{`abci.owner.name MATCHES '.*or.*'`,
 			newTestEvents(`abci|owner.name=Pavel|owner.name=Ivan`),
 			false},
 		{`abci.owner.name = 'Igor'`,

--- a/internal/pubsub/query/syntax/parser.go
+++ b/internal/pubsub/query/syntax/parser.go
@@ -147,7 +147,7 @@ func (p *Parser) parseCond() (Condition, error) {
 		return cond, err
 	}
 	cond.Tag = p.scanner.Text()
-	if err := p.require(TLeq, TGeq, TLt, TGt, TEq, TContains, TExists); err != nil {
+	if err := p.require(TLeq, TGeq, TLt, TGt, TEq, TContains, TExists, TMatches); err != nil {
 		return cond, err
 	}
 	cond.Op = p.scanner.Token()
@@ -160,6 +160,8 @@ func (p *Parser) parseCond() (Condition, error) {
 	case TEq:
 		err = p.require(TNumber, TTime, TDate, TString)
 	case TContains:
+		err = p.require(TString)
+	case TMatches:
 		err = p.require(TString)
 	case TExists:
 		// no argument

--- a/internal/pubsub/query/syntax/scanner.go
+++ b/internal/pubsub/query/syntax/scanner.go
@@ -28,6 +28,7 @@ const (
 	TLeq             // operator: <=
 	TGt              // operator: >
 	TGeq             // operator: >=
+	TMatches         // operator: MATCHES
 
 	// Do not reorder these values without updating the scanner code.
 )
@@ -47,6 +48,7 @@ var tString = [...]string{
 	TLeq:      "<= operator",
 	TGt:       "> operator",
 	TGeq:      ">= operator",
+	TMatches:  "MATCHES operator",
 }
 
 func (t Token) String() string {
@@ -228,6 +230,8 @@ func (s *Scanner) scanTagLike(first rune) error {
 		s.tok = TExists
 	case "CONTAINS":
 		s.tok = TContains
+	case "MATCHES":
+		s.tok = TMatches
 	default:
 		s.tok = TTag
 	}

--- a/internal/pubsub/query/syntax/syntax_test.go
+++ b/internal/pubsub/query/syntax/syntax_test.go
@@ -38,6 +38,7 @@ func TestScanner(t *testing.T) {
 		// Mixed values of various kinds.
 		{`x AND y`, []syntax.Token{syntax.TTag, syntax.TAnd, syntax.TTag}},
 		{`x.y CONTAINS 'z'`, []syntax.Token{syntax.TTag, syntax.TContains, syntax.TString}},
+		{`x.y MATCHES 'z'`, []syntax.Token{syntax.TTag, syntax.TMatches, syntax.TString}},
 		{`foo EXISTS`, []syntax.Token{syntax.TTag, syntax.TExists}},
 		{`and AND`, []syntax.Token{syntax.TTag, syntax.TAnd}},
 
@@ -128,6 +129,7 @@ func TestParseValid(t *testing.T) {
 		{"AND tm.events.type='NewBlock' ", false},
 
 		{"abci.account.name CONTAINS 'Igor'", true},
+		{"abci.account.name MATCHES '*go*'", true},
 
 		{"tx.date > DATE 2013-05-03", true},
 		{"tx.date < DATE 2013-05-03", true},

--- a/internal/state/indexer/block/kv/kv_test.go
+++ b/internal/state/indexer/block/kv/kv_test.go
@@ -120,6 +120,14 @@ func TestBlockIndexer(t *testing.T) {
 			q:       query.MustCompile(`finalize_event1.proposer CONTAINS 'FCAA001'`),
 			results: []int64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11},
 		},
+		"finalize_event.proposer MATCHES '.*FF.*'": {
+			q:       query.MustCompile(`finalize_event1.proposer MATCHES '.*FF.*'`),
+			results: []int64{},
+		},
+		"finalize_event.proposer MATCHES '.*F.*'": {
+			q:       query.MustCompile(`finalize_event1.proposer MATCHES '.*F.*'`),
+			results: []int64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11},
+		},
 	}
 
 	for name, tc := range testCases {

--- a/internal/state/indexer/tx/kv/kv_test.go
+++ b/internal/state/indexer/tx/kv/kv_test.go
@@ -113,6 +113,12 @@ func TestTxSearch(t *testing.T) {
 		{"account.owner CONTAINS 'Vlad'", 0},
 		// search using the wrong key (of numeric type) using CONTAINS
 		{"account.number CONTAINS 'Iv'", 0},
+		// search using MATCHES
+		{"account.owner MATCHES '.*an.*'", 1},
+		// search for non existing value using MATCHES
+		{"account.owner MATCHES '.*lad'", 0},
+		// search using the wrong key (of numeric type) using MATCHES
+		{"account.number MATCHES '.*v.*'", 0},
 		// search using EXISTS
 		{"account.number EXISTS", 1},
 		// search using EXISTS for non existing key


### PR DESCRIPTION
## Describe your changes and provide context
Add regex syntax so that queries like `tx.topics MATCHES '\[.*,xyz,.*\]'` can be written and executed correctly 

## Testing performed to validate your change
unit tests

