### PR TITLE
Add event data to result event

### DIFF
--- a/cmd/tendermint/commands/reset.go
+++ b/cmd/tendermint/commands/reset.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 
@@ -183,7 +182,6 @@ func ResetPeerStore(dbDir string) error {
 }
 
 func MakeUnsafeResetAllCommand(conf *config.Config, logger log.Logger) *cobra.Command {
-	fmt.Println("MakeUnsafeResetAllCommand")
 	var keyType string
 
 	resetAllCmd := &cobra.Command{

--- a/cmd/tendermint/commands/reset.go
+++ b/cmd/tendermint/commands/reset.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -182,6 +183,7 @@ func ResetPeerStore(dbDir string) error {
 }
 
 func MakeUnsafeResetAllCommand(conf *config.Config, logger log.Logger) *cobra.Command {
+	fmt.Println("MakeUnsafeResetAllCommand")
 	var keyType string
 
 	resetAllCmd := &cobra.Command{

--- a/internal/rpc/core/events.go
+++ b/internal/rpc/core/events.go
@@ -83,10 +83,9 @@ func (env *Environment) Subscribe(ctx context.Context, req *coretypes.RequestSub
 
 			// We have a message to deliver to the client.
 			resp := callInfo.RPCRequest.MakeResponse(&coretypes.ResultEvent{
-				Query:     req.Query,
-				Data:      msg.LegacyData(),
-				Events:    msg.Events(),
-				EventData: msg.Data(),
+				Query:  req.Query,
+				Data:   msg.Data(),
+				Events: msg.Events(),
 			})
 			wctx, cancel := context.WithTimeout(opctx, 10*time.Second)
 			err = callInfo.WSConn.WriteRPCResponse(wctx, resp)

--- a/internal/rpc/core/events.go
+++ b/internal/rpc/core/events.go
@@ -83,9 +83,10 @@ func (env *Environment) Subscribe(ctx context.Context, req *coretypes.RequestSub
 
 			// We have a message to deliver to the client.
 			resp := callInfo.RPCRequest.MakeResponse(&coretypes.ResultEvent{
-				Query:  req.Query,
-				Data:   msg.LegacyData(),
-				Events: msg.Events(),
+				Query:     req.Query,
+				Data:      msg.LegacyData(),
+				Events:    msg.Events(),
+				EventData: msg.Data(),
 			})
 			wctx, cancel := context.WithTimeout(opctx, 10*time.Second)
 			err = callInfo.WSConn.WriteRPCResponse(wctx, resp)

--- a/rpc/client/local/local.go
+++ b/rpc/client/local/local.go
@@ -273,8 +273,7 @@ func (c *Local) eventsRoutine(ctx context.Context, sub eventbus.Subscription, su
 		case outc <- coretypes.ResultEvent{
 			SubscriptionID: msg.SubscriptionID(),
 			Query:          qstr,
-			Data:           msg.LegacyData(),
-			EventData:      msg.Data(),
+			Data:           msg.Data(),
 			Events:         msg.Events(),
 		}:
 		case <-ctx.Done():

--- a/rpc/client/local/local.go
+++ b/rpc/client/local/local.go
@@ -274,6 +274,7 @@ func (c *Local) eventsRoutine(ctx context.Context, sub eventbus.Subscription, su
 			SubscriptionID: msg.SubscriptionID(),
 			Query:          qstr,
 			Data:           msg.LegacyData(),
+			EventData:      msg.Data(),
 			Events:         msg.Events(),
 		}:
 		case <-ctx.Done():

--- a/rpc/client/rpc_test.go
+++ b/rpc/client/rpc_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+
 	"fmt"
 	"math"
 	"net/http"
@@ -21,6 +22,7 @@ import (
 	"github.com/tendermint/tendermint/crypto/encoding"
 	"github.com/tendermint/tendermint/internal/mempool"
 	rpccore "github.com/tendermint/tendermint/internal/rpc/core"
+
 	tmjson "github.com/tendermint/tendermint/libs/json"
 	"github.com/tendermint/tendermint/libs/log"
 	tmmath "github.com/tendermint/tendermint/libs/math"
@@ -495,9 +497,9 @@ func TestClientMethodCalls(t *testing.T) {
 					for i := int64(0); i < 3; i++ {
 						event := <-eventCh
 
-						blockEvent, ok := event.Data.(types.LegacyEventDataNewBlock)
+						blockEvent, ok := event.Data.(types.EventDataNewBlock)
 						if !ok {
-							blockEventPtr, okPtr := event.Data.(*types.LegacyEventDataNewBlock)
+							blockEventPtr, okPtr := event.Data.(*types.EventDataNewBlock)
 							if okPtr {
 								blockEvent = *blockEventPtr
 							}

--- a/rpc/coretypes/responses.go
+++ b/rpc/coretypes/responses.go
@@ -329,6 +329,7 @@ type ResultEvent struct {
 	Query          string
 	Data           types.LegacyEventData
 	Events         []abci.Event
+	EventData      types.EventData
 }
 
 type resultEventJSON struct {
@@ -336,6 +337,7 @@ type resultEventJSON struct {
 	Query          string              `json:"query"`
 	Data           json.RawMessage     `json:"data"`
 	Events         map[string][]string `json:"events"`
+	EventData      types.EventData     `json:"event_data"`
 }
 
 func (r ResultEvent) MarshalJSON() ([]byte, error) {
@@ -348,6 +350,7 @@ func (r ResultEvent) MarshalJSON() ([]byte, error) {
 		Query:          r.Query,
 		Data:           evt,
 		Events:         compactEvents(r.Events),
+		EventData:      r.EventData,
 	})
 }
 
@@ -362,6 +365,7 @@ func (r *ResultEvent) UnmarshalJSON(data []byte) error {
 	r.SubscriptionID = res.SubscriptionID
 	r.Query = res.Query
 	r.Events = decompactEvents(res.Events)
+	r.EventData = res.EventData
 	return nil
 }
 

--- a/rpc/coretypes/responses.go
+++ b/rpc/coretypes/responses.go
@@ -327,9 +327,8 @@ type (
 type ResultEvent struct {
 	SubscriptionID string
 	Query          string
-	Data           types.LegacyEventData
+	Data           types.EventData
 	Events         []abci.Event
-	EventData      types.EventData
 }
 
 type resultEventJSON struct {
@@ -337,7 +336,6 @@ type resultEventJSON struct {
 	Query          string              `json:"query"`
 	Data           json.RawMessage     `json:"data"`
 	Events         map[string][]string `json:"events"`
-	EventData      types.EventData     `json:"event_data"`
 }
 
 func (r ResultEvent) MarshalJSON() ([]byte, error) {
@@ -350,7 +348,6 @@ func (r ResultEvent) MarshalJSON() ([]byte, error) {
 		Query:          r.Query,
 		Data:           evt,
 		Events:         compactEvents(r.Events),
-		EventData:      r.EventData,
 	})
 }
 
@@ -365,7 +362,6 @@ func (r *ResultEvent) UnmarshalJSON(data []byte) error {
 	r.SubscriptionID = res.SubscriptionID
 	r.Query = res.Query
 	r.Events = decompactEvents(res.Events)
-	r.EventData = res.EventData
 	return nil
 }
 


### PR DESCRIPTION
## Describe your changes and provide context

While working on the subscription endpoint for the EVM RPC in sei-chain, ran into an issue when trying to implement the [eth_subscribe endpoint for newHeads](https://docs.alchemy.com/reference/newheads). Notice how the endpoint should return metadata about an eth block but we are querying tendermint for a tendermint block, so we need to convert the tm block to an eth block. This means we need to unmarshal the tm block to get its contents to encode it by doing something like [this](https://github.com/sei-protocol/sei-chain/blob/11b421deaa9b41e30f60bdc7d073ee4276215d6b/evmrpc/block.go#L81).

For the non-subscription endpoint, we use [Events()](https://github.com/sei-protocol/sei-tendermint/blob/f31c31846c491a8a6574acd093e7a775f55fe6b8/rpc/client/interface.go#L131) to get the event data. The EventItem field in the ResultEvents struct has a [Data field](https://github.com/sei-protocol/sei-tendermint/blob/f31c31846c491a8a6574acd093e7a775f55fe6b8/rpc/coretypes/responses.go#L480) which is just raw bytes, which makes it easy to unmarshal the data from it.

However, for [Subscribe()](https://github.com/sei-protocol/sei-tendermint/blob/f31c31846c491a8a6574acd093e7a775f55fe6b8/rpc/client/interface.go#L150), notice how it returns a channel for ResultEvent (not ResultEvents). ResultEvent has a Data field of type LegacyEventData and an Events field with type []abci.Event. So let's say I make a newBlock subscription via Subscribe(). It would return an [EventDataNewBlock](https://github.com/sei-protocol/sei-tendermint/blob/f31c31846c491a8a6574acd093e7a775f55fe6b8/types/events.go#L132) which would be converted to an `abci.Event` via [this](https://github.com/sei-protocol/sei-tendermint/blob/f31c31846c491a8a6574acd093e7a775f55fe6b8/types/events.go#L143), which makes it quite difficult to unmarshal to get its contents.

Therefore, we are adding an `EventData` field to the `ResultEvent` struct which should allow tendermint to return a marshalled version of the msg in raw bytes to easily be unmarshalled from Subscribe().

## Testing performed to validate your change
rely on existing testing.
