### PR TITLE
Add blacklisted peers in peermanager to avoid reconnection storm

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -685,6 +685,8 @@ type P2PConfig struct { //nolint: maligned
 
 	// List of node IDs, to which a connection will be (re)established ignoring any existing limits
 	UnconditionalPeerIDs string `mapstructure:"unconditional-peer-ids"`
+
+	BlacklistTTL time.Duration `mapstructure:"blacklist-ttl"`
 }
 
 // DefaultP2PConfig returns a default configuration for the peer-to-peer layer
@@ -710,6 +712,7 @@ func DefaultP2PConfig() *P2PConfig {
 		DialTimeout:             3 * time.Second,
 		TestDialFail:            false,
 		QueueType:               "simple-priority",
+		BlacklistTTL:            5 * time.Minute,
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tendermint/tendermint
 
-go 1.17
+go 1.18
 
 require (
 	github.com/BurntSushi/toml v1.1.0
@@ -242,6 +242,7 @@ require (
 
 require (
 	github.com/creachadair/tomledit v0.0.22
+	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.34.0

--- a/go.sum
+++ b/go.sum
@@ -595,7 +595,10 @@ github.com/hashicorp/go-version v1.4.0 h1:aAQzgqIrRKRa7w75CKpbBxYsmUoPjzVm1W59ca
 github.com/hashicorp/go-version v1.4.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
+github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
+github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=

--- a/internal/p2p/peermanager.go
+++ b/internal/p2p/peermanager.go
@@ -346,6 +346,7 @@ func NewPeerManager(
 		ready:         map[types.NodeID]bool{},
 		evict:         map[types.NodeID]bool{},
 		evicting:      map[types.NodeID]bool{},
+		blacklisted:   map[types.NodeID]time.Time{},
 		subscriptions: map[*PeerUpdates]*PeerUpdates{},
 		metrics:       metrics,
 	}
@@ -816,13 +817,14 @@ func (m *PeerManager) TryEvictNext() (types.NodeID, error) {
 	return "", nil
 }
 
-func (m *PeerManager) isBlacklisted(peerID types.NodeID) bool {
+func (m *PeerManager) IsBlacklisted(peerID types.NodeID) bool {
 	timestamp, exists := m.blacklisted[peerID]
 	if !exists {
 		return false
 	}
 
-	// If the provider is found, check the TTL
+	// If the peerId is found, check the TTL
+	// TODO (psu): we may want to clean up expired blacklists periodically otherwise it could grow infinitely
 	if time.Since(timestamp) > m.options.BlacklistTTL {
 		// Remove from blacklist if TTL expired
 		delete(m.blacklisted, peerID)

--- a/internal/p2p/peermanager_test.go
+++ b/internal/p2p/peermanager_test.go
@@ -1953,13 +1953,19 @@ func TestPeerManager_Blacklist(t *testing.T) {
 
 	// Create a peer manager with SelfAddress defined.
 	peerManager, err := p2p.NewPeerManager(log.NewNopLogger(), selfID, dbm.NewMemDB(), p2p.PeerManagerOptions{
-		SelfAddress:  self,
-		BlacklistTTL: 10 * time.Millisecond,
+		SelfAddress:        self,
+		BlacklistTTL:       10 * time.Millisecond,
+		BlacklistThreshold: 3,
 	}, p2p.NopMetrics())
 	require.NoError(t, err)
 	added, err := peerManager.Add(a)
 	require.NoError(t, err)
 	require.True(t, added)
+	// require BlacklistThreshold disconnects before blacklisting
+	peerManager.Disconnected(ctx, a.NodeID)
+	require.False(t, peerManager.IsBlacklisted(a.NodeID))
+	peerManager.Disconnected(ctx, a.NodeID)
+	require.False(t, peerManager.IsBlacklisted(a.NodeID))
 	peerManager.Disconnected(ctx, a.NodeID)
 	require.True(t, peerManager.IsBlacklisted(a.NodeID))
 	time.Sleep(20 * time.Millisecond)

--- a/internal/p2p/router.go
+++ b/internal/p2p/router.go
@@ -566,6 +566,10 @@ func (r *Router) openConnection(ctx context.Context, conn Connection) {
 		r.logger.Debug("peer filtered by node ID", "node", peerInfo.NodeID, "err", err)
 		return
 	}
+	if r.peerManager.IsBlacklisted(peerInfo.NodeID) {
+		r.logger.Info("peer is blacklisted, not connecting", "node", peerInfo.NodeID)
+		return
+	}
 
 	if err := r.runWithPeerMutex(func() error { return r.peerManager.Accepted(peerInfo.NodeID) }); err != nil {
 		// If peer is trying to reconnect, error and let it reconnect

--- a/node/setup.go
+++ b/node/setup.go
@@ -226,6 +226,7 @@ func createPeerManager(
 
 	options := p2p.PeerManagerOptions{
 		SelfAddress:            selfAddr,
+		BlacklistTTL:           cfg.P2P.BlacklistTTL,
 		MaxConnected:           maxConns,
 		MaxConnectedUpgrade:    maxUpgradeConns,
 		MaxPeers:               maxUpgradeConns + 2*maxConns,


### PR DESCRIPTION
## Describe your changes and provide context
We hit scenarios where disconnected peers keep getting reconnected
<img width="1726" alt="image" src="https://github.com/sei-protocol/sei-tendermint/assets/3821073/0f09b680-c261-4ce2-95a3-0791fab78e8c">

## Testing performed to validate your change

