### PR TITLE
Fix block sync auto restart not working as expected

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1383,9 +1383,9 @@ func DefaultSelfRemediationConfig() *SelfRemediationConfig {
 		P2pNoPeersRestarWindowSeconds:        0,
 		StatesyncNoPeersRestartWindowSeconds: 0,
 		BlocksBehindThreshold:                0,
-		BlocksBehindCheckIntervalSeconds:     30,
+		BlocksBehindCheckIntervalSeconds:     60,
 		// 30 minutes
-		RestartCooldownSeconds: 1800,
+		RestartCooldownSeconds: 600,
 	}
 }
 

--- a/internal/blocksync/pool.go
+++ b/internal/blocksync/pool.go
@@ -210,8 +210,8 @@ func (pool *BlockPool) IsCaughtUp() bool {
 	pool.mtx.RLock()
 	defer pool.mtx.RUnlock()
 
-	// Need at least 1 peer to be considered caught up.
-	if len(pool.peers) == 0 {
+	// Need at least 2 peers to be considered caught up.
+	if len(pool.peers) <= 1 {
 		return false
 	}
 


### PR DESCRIPTION
## Describe your changes and provide context
**Problems:**
- When deciding if we already caught up and should switch to consensus, we might only have one peer that is falling behind by a lot, and at that time we should not switch to consensus because maxPeerHeight is not accurate
- Currently Tendermint self remediation will send a restart signal ignoring the restart cooldown time, and cosmos will determine whether it should restart or not based on cooldown time. This lead to Tendermint not able to know whether a restart does actually happen or not. 

Solution:
- When checking if we caught up or not, we should have at least 2 peers. We should also maintain the previous MaxPeerHeight before auto restart so that after restart, if both peers are bad, we will not immediately switch to consensus 
- We move the cooldown validation from cosmos to Tendermint


## Testing performed to validate your change
Tested in state sync node in testnet
