### PR TITLE
[EVM] Add evm tx replacement logic

### DIFF
--- a/abci/client/grpc_client.go
+++ b/abci/client/grpc_client.go
@@ -130,8 +130,9 @@ func (cli *grpcClient) Info(ctx context.Context, params *types.RequestInfo) (*ty
 	return cli.client.Info(ctx, types.ToRequestInfo(params).GetInfo(), grpc.WaitForReady(true))
 }
 
-func (cli *grpcClient) CheckTx(ctx context.Context, params *types.RequestCheckTx) (*types.ResponseCheckTx, error) {
-	return cli.client.CheckTx(ctx, types.ToRequestCheckTx(params).GetCheckTx(), grpc.WaitForReady(true))
+func (cli *grpcClient) CheckTx(ctx context.Context, params *types.RequestCheckTx) (*types.ResponseCheckTxV2, error) {
+	resCheckTx, err := cli.client.CheckTx(ctx, types.ToRequestCheckTx(params).GetCheckTx(), grpc.WaitForReady(true))
+	return &types.ResponseCheckTxV2{ResponseCheckTx: resCheckTx}, err
 }
 
 func (cli *grpcClient) Query(ctx context.Context, params *types.RequestQuery) (*types.ResponseQuery, error) {

--- a/abci/client/mocks/client.go
+++ b/abci/client/mocks/client.go
@@ -38,15 +38,15 @@ func (_m *Client) ApplySnapshotChunk(_a0 context.Context, _a1 *types.RequestAppl
 }
 
 // CheckTx provides a mock function with given fields: _a0, _a1
-func (_m *Client) CheckTx(_a0 context.Context, _a1 *types.RequestCheckTx) (*types.ResponseCheckTx, error) {
+func (_m *Client) CheckTx(_a0 context.Context, _a1 *types.RequestCheckTx) (*types.ResponseCheckTxV2, error) {
 	ret := _m.Called(_a0, _a1)
 
-	var r0 *types.ResponseCheckTx
-	if rf, ok := ret.Get(0).(func(context.Context, *types.RequestCheckTx) *types.ResponseCheckTx); ok {
+	var r0 *types.ResponseCheckTxV2
+	if rf, ok := ret.Get(0).(func(context.Context, *types.RequestCheckTx) *types.ResponseCheckTxV2); ok {
 		r0 = rf(_a0, _a1)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*types.ResponseCheckTx)
+			r0 = ret.Get(0).(*types.ResponseCheckTxV2)
 		}
 	}
 

--- a/abci/client/socket_client.go
+++ b/abci/client/socket_client.go
@@ -257,12 +257,12 @@ func (cli *socketClient) Info(ctx context.Context, req *types.RequestInfo) (*typ
 	return res.GetInfo(), nil
 }
 
-func (cli *socketClient) CheckTx(ctx context.Context, req *types.RequestCheckTx) (*types.ResponseCheckTx, error) {
+func (cli *socketClient) CheckTx(ctx context.Context, req *types.RequestCheckTx) (*types.ResponseCheckTxV2, error) {
 	res, err := cli.doRequest(ctx, types.ToRequestCheckTx(req))
 	if err != nil {
 		return nil, err
 	}
-	return res.GetCheckTx(), nil
+	return &types.ResponseCheckTxV2{ResponseCheckTx: res.GetCheckTx()}, nil
 }
 
 func (cli *socketClient) Query(ctx context.Context, req *types.RequestQuery) (*types.ResponseQuery, error) {

--- a/abci/example/kvstore/kvstore.go
+++ b/abci/example/kvstore/kvstore.go
@@ -205,8 +205,8 @@ func (app *Application) FinalizeBlock(_ context.Context, req *types.RequestFinal
 	return &types.ResponseFinalizeBlock{TxResults: respTxs, ValidatorUpdates: app.ValUpdates, AppHash: appHash}, nil
 }
 
-func (*Application) CheckTx(_ context.Context, req *types.RequestCheckTx) (*types.ResponseCheckTx, error) {
-	return &types.ResponseCheckTx{Code: code.CodeTypeOK, GasWanted: 1}, nil
+func (*Application) CheckTx(_ context.Context, req *types.RequestCheckTx) (*types.ResponseCheckTxV2, error) {
+	return &types.ResponseCheckTxV2{ResponseCheckTx: &types.ResponseCheckTx{Code: code.CodeTypeOK, GasWanted: 1}}, nil
 }
 
 func (app *Application) Commit(_ context.Context) (*types.ResponseCommit, error) {

--- a/abci/server/grpc_server.go
+++ b/abci/server/grpc_server.go
@@ -81,3 +81,11 @@ func (app *gRPCApplication) Flush(_ context.Context, req *types.RequestFlush) (*
 func (app *gRPCApplication) Commit(ctx context.Context, req *types.RequestCommit) (*types.ResponseCommit, error) {
 	return app.Application.Commit(ctx)
 }
+
+func (app *gRPCApplication) CheckTx(ctx context.Context, req *types.RequestCheckTx) (*types.ResponseCheckTx, error) {
+	resV2, err := app.Application.CheckTx(ctx, req)
+	if err != nil {
+		return &types.ResponseCheckTx{}, err
+	}
+	return resV2.ResponseCheckTx, nil
+}

--- a/abci/types/application.go
+++ b/abci/types/application.go
@@ -12,7 +12,7 @@ type Application interface {
 	Query(context.Context, *RequestQuery) (*ResponseQuery, error) // Query for state
 
 	// Mempool Connection
-	CheckTx(context.Context, *RequestCheckTx) (*ResponseCheckTx, error) // Validate a tx for the mempool
+	CheckTx(context.Context, *RequestCheckTx) (*ResponseCheckTxV2, error) // Validate a tx for the mempool
 
 	// Consensus Connection
 	InitChain(context.Context, *RequestInitChain) (*ResponseInitChain, error) // Initialize blockchain w validators/other info from TendermintCore
@@ -51,8 +51,8 @@ func (BaseApplication) Info(_ context.Context, req *RequestInfo) (*ResponseInfo,
 	return &ResponseInfo{}, nil
 }
 
-func (BaseApplication) CheckTx(_ context.Context, req *RequestCheckTx) (*ResponseCheckTx, error) {
-	return &ResponseCheckTx{Code: CodeTypeOK}, nil
+func (BaseApplication) CheckTx(_ context.Context, req *RequestCheckTx) (*ResponseCheckTxV2, error) {
+	return &ResponseCheckTxV2{ResponseCheckTx: &ResponseCheckTx{Code: CodeTypeOK}}, nil
 }
 
 func (BaseApplication) Commit(_ context.Context) (*ResponseCommit, error) {

--- a/abci/types/messages.go
+++ b/abci/types/messages.go
@@ -155,9 +155,9 @@ func ToResponseInfo(res *ResponseInfo) *Response {
 	}
 }
 
-func ToResponseCheckTx(res *ResponseCheckTx) *Response {
+func ToResponseCheckTx(res *ResponseCheckTxV2) *Response {
 	return &Response{
-		Value: &Response_CheckTx{res},
+		Value: &Response_CheckTx{res.ResponseCheckTx},
 	}
 }
 

--- a/abci/types/mocks/application.go
+++ b/abci/types/mocks/application.go
@@ -38,15 +38,15 @@ func (_m *Application) ApplySnapshotChunk(_a0 context.Context, _a1 *types.Reques
 }
 
 // CheckTx provides a mock function with given fields: _a0, _a1
-func (_m *Application) CheckTx(_a0 context.Context, _a1 *types.RequestCheckTx) (*types.ResponseCheckTx, error) {
+func (_m *Application) CheckTx(_a0 context.Context, _a1 *types.RequestCheckTx) (*types.ResponseCheckTxV2, error) {
 	ret := _m.Called(_a0, _a1)
 
-	var r0 *types.ResponseCheckTx
-	if rf, ok := ret.Get(0).(func(context.Context, *types.RequestCheckTx) *types.ResponseCheckTx); ok {
+	var r0 *types.ResponseCheckTxV2
+	if rf, ok := ret.Get(0).(func(context.Context, *types.RequestCheckTx) *types.ResponseCheckTxV2); ok {
 		r0 = rf(_a0, _a1)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*types.ResponseCheckTx)
+			r0 = ret.Get(0).(*types.ResponseCheckTxV2)
 		}
 	}
 

--- a/abci/types/types.go
+++ b/abci/types/types.go
@@ -237,3 +237,21 @@ func MarshalTxResults(r []*ExecTxResult) ([][]byte, error) {
 	}
 	return s, nil
 }
+
+type PendingTxCheckerResponse int
+
+const (
+	Accepted PendingTxCheckerResponse = iota
+	Rejected
+	Pending
+)
+
+type PendingTxChecker func() PendingTxCheckerResponse
+
+// V2 response type contains non-protobuf fields, so non-local ABCI clients will not be able
+// to utilize the new fields in V2 type (but still be backwards-compatible)
+type ResponseCheckTxV2 struct {
+	*ResponseCheckTx
+	IsPendingTransaction bool
+	Checker              PendingTxChecker // must not be nil if IsPendingTransaction is true
+}

--- a/internal/consensus/mempool_test.go
+++ b/internal/consensus/mempool_test.go
@@ -308,18 +308,18 @@ func (app *CounterApplication) FinalizeBlock(_ context.Context, req *abci.Reques
 	return res, nil
 }
 
-func (app *CounterApplication) CheckTx(_ context.Context, req *abci.RequestCheckTx) (*abci.ResponseCheckTx, error) {
+func (app *CounterApplication) CheckTx(_ context.Context, req *abci.RequestCheckTx) (*abci.ResponseCheckTxV2, error) {
 	app.mu.Lock()
 	defer app.mu.Unlock()
 
 	txValue := txAsUint64(req.Tx)
 	if txValue != uint64(app.mempoolTxCount) {
-		return &abci.ResponseCheckTx{
+		return &abci.ResponseCheckTxV2{ResponseCheckTx: &abci.ResponseCheckTx{
 			Code: code.CodeTypeBadNonce,
-		}, nil
+		}}, nil
 	}
 	app.mempoolTxCount++
-	return &abci.ResponseCheckTx{Code: code.CodeTypeOK}, nil
+	return &abci.ResponseCheckTxV2{ResponseCheckTx: &abci.ResponseCheckTx{Code: code.CodeTypeOK}}, nil
 }
 
 func txAsUint64(tx []byte) uint64 {

--- a/internal/mempool/mempool.go
+++ b/internal/mempool/mempool.go
@@ -177,7 +177,7 @@ func (txmp *TxMempool) Unlock() {
 // Size returns the number of valid transactions in the mempool. It is
 // thread-safe.
 func (txmp *TxMempool) Size() int {
-	return txmp.txStore.Size()
+	return txmp.txStore.Size() + txmp.pendingTxs.Size()
 }
 
 // SizeBytes return the total sum in bytes of all the valid transactions in the
@@ -436,6 +436,13 @@ func (txmp *TxMempool) ReapMaxTxs(max int) types.Txs {
 	txs := make([]types.Tx, 0, len(wTxs))
 	for _, wtx := range wTxs {
 		txs = append(txs, wtx.tx)
+	}
+	if len(txs) < max {
+		// retrieve more from pending txs
+		pending := txmp.pendingTxs.Peek(max - len(txs))
+		for _, ptx := range pending {
+			txs = append(txs, ptx.tx.tx)
+		}
 	}
 	return txs
 }

--- a/internal/mempool/mempool.go
+++ b/internal/mempool/mempool.go
@@ -177,7 +177,9 @@ func (txmp *TxMempool) Unlock() {
 // Size returns the number of valid transactions in the mempool. It is
 // thread-safe.
 func (txmp *TxMempool) Size() int {
-	return txmp.txStore.Size() + txmp.pendingTxs.Size()
+	txSize := txmp.txStore.Size()
+	pendingSize := txmp.pendingTxs.Size()
+	return txSize + pendingSize
 }
 
 // SizeBytes return the total sum in bytes of all the valid transactions in the

--- a/internal/mempool/mempool.go
+++ b/internal/mempool/mempool.go
@@ -231,6 +231,7 @@ func (txmp *TxMempool) removeExistingTx(res *abci.ResponseCheckTxV2) (bool, erro
 
 	// try to replace existing transaction in mempool
 	if existingTx := txmp.txStore.GetTxBySender(res.Sender); existingTx != nil {
+		fmt.Printf("mempool: priority=%d, new priority=%d\n", existingTx.priority, res.Priority)
 		if existingTx.priority >= res.Priority {
 			return false, types.ErrEvmTxNotReplaced
 		}
@@ -322,9 +323,11 @@ func (txmp *TxMempool) CheckTx(
 			txmp.logger.Error(
 				err.Error(),
 				"tx", fmt.Sprintf("%X", wtx.tx.Hash()),
+				"priority", res.Priority,
 				"sender", res.Sender,
 			)
 			txmp.metrics.RejectedTxs.Add(1)
+			return types.ErrEvmTxNotReplaced
 			// not treated as an error, fallthrough to callback
 		} else {
 			// log the replacement

--- a/internal/mempool/mempool.go
+++ b/internal/mempool/mempool.go
@@ -15,7 +15,6 @@ import (
 	"github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/internal/libs/clist"
 	"github.com/tendermint/tendermint/libs/log"
-	tmmath "github.com/tendermint/tendermint/libs/math"
 	"github.com/tendermint/tendermint/types"
 )
 
@@ -420,24 +419,10 @@ func (txmp *TxMempool) ReapMaxTxs(max int) types.Txs {
 	txmp.mtx.RLock()
 	defer txmp.mtx.RUnlock()
 
-	numTxs := txmp.priorityIndex.NumTxs()
-	if max < 0 {
-		max = numTxs
-	}
-
-	cap := tmmath.MinInt(numTxs, max)
-
-	// wTxs contains a list of *WrappedTx retrieved from the priority queue that
-	// need to be re-enqueued prior to returning.
-	wTxs := make([]*WrappedTx, 0, cap)
-	txs := make([]types.Tx, 0, cap)
-	for txmp.priorityIndex.NumTxs() > 0 && len(txs) < max {
-		wtx := txmp.priorityIndex.PopTx()
-		txs = append(txs, wtx.tx)
-		wTxs = append(wTxs, wtx)
-	}
+	wTxs := txmp.priorityIndex.PeekTxs(max)
+	txs := make([]types.Tx, 0, len(wTxs))
 	for _, wtx := range wTxs {
-		txmp.priorityIndex.PushTx(wtx)
+		txs = append(txs, wtx.tx)
 	}
 	return txs
 }

--- a/internal/mempool/mempool.go
+++ b/internal/mempool/mempool.go
@@ -81,6 +81,10 @@ type TxMempool struct {
 	// index. i.e. older transactions are first.
 	timestampIndex *WrappedTxList
 
+	// pendingTxs stores transactions that are not valid yet but might become valid
+	// if its checker returns Accepted
+	pendingTxs *PendingTxs
+
 	// A read/write lock is used to safe guard updates, insertions and deletions
 	// from the mempool. A read-lock is implicitly acquired when executing CheckTx,
 	// however, a caller must explicitly grab a write-lock via Lock when updating
@@ -120,6 +124,7 @@ func NewTxMempool(
 		timestampIndex: NewWrappedTxList(func(wtx1, wtx2 *WrappedTx) bool {
 			return wtx1.timestamp.After(wtx2.timestamp) || wtx1.timestamp.Equal(wtx2.timestamp)
 		}),
+		pendingTxs:          NewPendingTxs(),
 		failedCheckTxCounts: map[types.NodeID]uint64{},
 		peerManager:         peerManager,
 	}
@@ -286,17 +291,25 @@ func (txmp *TxMempool) CheckTx(
 		height:    txmp.height,
 	}
 
-	// only add new transaction if checkTx passes
 	if err == nil {
-		err = txmp.addNewTransaction(wtx, res, txInfo)
+		// only add new transaction if checkTx passes and is not pending
+		if !res.IsPendingTransaction {
+			err = txmp.addNewTransaction(wtx, res.ResponseCheckTx, txInfo)
 
-		if err != nil {
-			return err
+			if err != nil {
+				return err
+			}
+		} else {
+			// otherwise add to pending txs store
+			if res.Checker == nil {
+				return errors.New("no checker available for pending transaction")
+			}
+			txmp.pendingTxs.Insert(wtx, res, txInfo)
 		}
 	}
 
 	if cb != nil {
-		cb(res)
+		cb(res.ResponseCheckTx)
 	}
 
 	return nil
@@ -470,6 +483,7 @@ func (txmp *TxMempool) Update(
 		}
 	}
 
+	txmp.handlePendingTransactions()
 	txmp.purgeExpiredTxs(blockHeight)
 
 	// If there any uncommitted transactions left in the mempool, we either
@@ -633,7 +647,7 @@ func (txmp *TxMempool) addNewTransaction(wtx *WrappedTx, res *abci.ResponseCheck
 //
 // This method is NOT executed for the initial CheckTx on a new transaction;
 // that case is handled by addNewTransaction instead.
-func (txmp *TxMempool) handleRecheckResult(tx types.Tx, res *abci.ResponseCheckTx) {
+func (txmp *TxMempool) handleRecheckResult(tx types.Tx, res *abci.ResponseCheckTxV2) {
 	if txmp.recheckCursor == nil {
 		return
 	}
@@ -676,10 +690,11 @@ func (txmp *TxMempool) handleRecheckResult(tx types.Tx, res *abci.ResponseCheckT
 	if !txmp.txStore.IsTxRemoved(wtx.hash) {
 		var err error
 		if txmp.postCheck != nil {
-			err = txmp.postCheck(tx, res)
+			err = txmp.postCheck(tx, res.ResponseCheckTx)
 		}
 
-		if res.Code == abci.CodeTypeOK && err == nil {
+		// we will treat a transaction that turns pending in a recheck as invalid and evict it
+		if res.Code == abci.CodeTypeOK && err == nil && !res.IsPendingTransaction {
 			wtx.priority = res.Priority
 		} else {
 			txmp.logger.Debug(
@@ -903,4 +918,18 @@ func (txmp *TxMempool) AppendCheckTxErr(existingLogs string, log string) string 
 	// Marshal the updated slice back into a JSON string
 	jsonData, _ := json.Marshal(logs)
 	return string(jsonData)
+}
+
+func (txmp *TxMempool) handlePendingTransactions() {
+	accepted, rejected := txmp.pendingTxs.EvaluatePendingTransactions()
+	for _, tx := range accepted {
+		if err := txmp.addNewTransaction(tx.tx, tx.checkTxResponse.ResponseCheckTx, tx.txInfo); err != nil {
+			txmp.logger.Error(fmt.Sprintf("error adding pending transaction: %s", err))
+		}
+	}
+	if !txmp.config.KeepInvalidTxsInCache {
+		for _, tx := range rejected {
+			txmp.cache.Remove(tx.tx.tx)
+		}
+	}
 }

--- a/internal/mempool/mempool.go
+++ b/internal/mempool/mempool.go
@@ -296,7 +296,7 @@ func (txmp *TxMempool) CheckTx(
 	if err == nil {
 		// only add new transaction if checkTx passes and is not pending
 		if !res.IsPendingTransaction {
-			err = txmp.addNewTransaction(wtx, res, txInfo)
+			err = txmp.addNewTransaction(wtx, res.ResponseCheckTx, txInfo)
 
 			if err != nil {
 				return err
@@ -535,8 +535,7 @@ func (txmp *TxMempool) Update(
 //
 // NOTE:
 // - An explicit lock is NOT required.
-func (txmp *TxMempool) addNewTransaction(wtx *WrappedTx, resV2 *abci.ResponseCheckTxV2, txInfo TxInfo) error {
-	res := resV2.ResponseCheckTx
+func (txmp *TxMempool) addNewTransaction(wtx *WrappedTx, res *abci.ResponseCheckTx, txInfo TxInfo) error {
 	var err error
 	if txmp.postCheck != nil {
 		err = txmp.postCheck(wtx.tx, res)
@@ -941,7 +940,7 @@ func (txmp *TxMempool) AppendCheckTxErr(existingLogs string, log string) string 
 func (txmp *TxMempool) handlePendingTransactions() {
 	accepted, rejected := txmp.pendingTxs.EvaluatePendingTransactions()
 	for _, tx := range accepted {
-		if err := txmp.addNewTransaction(tx.tx, tx.checkTxResponse, tx.txInfo); err != nil {
+		if err := txmp.addNewTransaction(tx.tx, tx.checkTxResponse.ResponseCheckTx, tx.txInfo); err != nil {
 			txmp.logger.Error(fmt.Sprintf("error adding pending transaction: %s", err))
 		}
 	}

--- a/internal/mempool/mempool_test.go
+++ b/internal/mempool/mempool_test.go
@@ -37,7 +37,7 @@ type testTx struct {
 	priority int64
 }
 
-func (app *application) CheckTx(_ context.Context, req *abci.RequestCheckTx) (*abci.ResponseCheckTx, error) {
+func (app *application) CheckTx(_ context.Context, req *abci.RequestCheckTx) (*abci.ResponseCheckTxV2, error) {
 	var (
 		priority int64
 		sender   string
@@ -48,29 +48,29 @@ func (app *application) CheckTx(_ context.Context, req *abci.RequestCheckTx) (*a
 	if len(parts) == 3 {
 		v, err := strconv.ParseInt(string(parts[2]), 10, 64)
 		if err != nil {
-			return &abci.ResponseCheckTx{
+			return &abci.ResponseCheckTxV2{ResponseCheckTx: &abci.ResponseCheckTx{
 				Priority:  priority,
 				Code:      100,
 				GasWanted: 1,
-			}, nil
+			}}, nil
 		}
 
 		priority = v
 		sender = string(parts[0])
 	} else {
-		return &abci.ResponseCheckTx{
+		return &abci.ResponseCheckTxV2{ResponseCheckTx: &abci.ResponseCheckTx{
 			Priority:  priority,
 			Code:      101,
 			GasWanted: 1,
-		}, nil
+		}}, nil
 	}
 
-	return &abci.ResponseCheckTx{
+	return &abci.ResponseCheckTxV2{ResponseCheckTx: &abci.ResponseCheckTx{
 		Priority:  priority,
 		Sender:    sender,
 		Code:      code.CodeTypeOK,
 		GasWanted: 1,
-	}, nil
+	}}, nil
 }
 
 func setup(t testing.TB, app abciclient.Client, cacheSize int, options ...TxMempoolOption) *TxMempool {

--- a/internal/mempool/tx.go
+++ b/internal/mempool/tx.go
@@ -343,7 +343,7 @@ func (p *PendingTxs) popTxsAtIndices(indices []int) {
 		newTxs = append(newTxs, p.txs[start:idx]...)
 		start = idx
 	}
-	newTxs = append(newTxs, p.txs[indices[len(indices)-1]:]...)
+	newTxs = append(newTxs, p.txs[start+1:]...)
 	p.txs = newTxs
 }
 

--- a/internal/proxy/client.go
+++ b/internal/proxy/client.go
@@ -169,7 +169,7 @@ func (app *proxyClient) Flush(ctx context.Context) error {
 	return app.client.Flush(ctx)
 }
 
-func (app *proxyClient) CheckTx(ctx context.Context, req *types.RequestCheckTx) (*types.ResponseCheckTx, error) {
+func (app *proxyClient) CheckTx(ctx context.Context, req *types.RequestCheckTx) (*types.ResponseCheckTxV2, error) {
 	defer addTimeSample(app.metrics.MethodTiming.With("method", "check_tx", "type", "sync"))()
 	return app.client.CheckTx(ctx, req)
 }

--- a/internal/rpc/core/mempool.go
+++ b/internal/rpc/core/mempool.go
@@ -148,7 +148,6 @@ func (env *Environment) BroadcastTxCommit(ctx context.Context, req *coretypes.Re
 // More: https://docs.tendermint.com/master/rpc/#/Info/unconfirmed_txs
 func (env *Environment) UnconfirmedTxs(ctx context.Context, req *coretypes.RequestUnconfirmedTxs) (*coretypes.ResultUnconfirmedTxs, error) {
 	totalCount := env.Mempool.Size()
-	fmt.Printf("EVMTEST mempool size: %d\n", totalCount)
 	perPage := env.validatePerPage(req.PerPage.IntPtr())
 	page, err := validatePage(req.Page.IntPtr(), perPage, totalCount)
 	if err != nil {
@@ -160,7 +159,6 @@ func (env *Environment) UnconfirmedTxs(ctx context.Context, req *coretypes.Reque
 	txs := env.Mempool.ReapMaxTxs(skipCount + tmmath.MinInt(perPage, totalCount-skipCount))
 	result := txs[skipCount:]
 
-	fmt.Printf("EVMTEST unconfirmed tx result count: %d, skipping %d\n", len(result), skipCount)
 	return &coretypes.ResultUnconfirmedTxs{
 		Count:      len(result),
 		Total:      totalCount,

--- a/internal/rpc/core/mempool.go
+++ b/internal/rpc/core/mempool.go
@@ -148,6 +148,7 @@ func (env *Environment) BroadcastTxCommit(ctx context.Context, req *coretypes.Re
 // More: https://docs.tendermint.com/master/rpc/#/Info/unconfirmed_txs
 func (env *Environment) UnconfirmedTxs(ctx context.Context, req *coretypes.RequestUnconfirmedTxs) (*coretypes.ResultUnconfirmedTxs, error) {
 	totalCount := env.Mempool.Size()
+	fmt.Printf("EVMTEST mempool size: %d\n", totalCount)
 	perPage := env.validatePerPage(req.PerPage.IntPtr())
 	page, err := validatePage(req.Page.IntPtr(), perPage, totalCount)
 	if err != nil {
@@ -159,6 +160,7 @@ func (env *Environment) UnconfirmedTxs(ctx context.Context, req *coretypes.Reque
 	txs := env.Mempool.ReapMaxTxs(skipCount + tmmath.MinInt(perPage, totalCount-skipCount))
 	result := txs[skipCount:]
 
+	fmt.Printf("EVMTEST unconfirmed tx result count: %d, skipping %d\n", len(result), skipCount)
 	return &coretypes.ResultUnconfirmedTxs{
 		Count:      len(result),
 		Total:      totalCount,

--- a/internal/rpc/core/mempool.go
+++ b/internal/rpc/core/mempool.go
@@ -184,7 +184,7 @@ func (env *Environment) CheckTx(ctx context.Context, req *coretypes.RequestCheck
 	if err != nil {
 		return nil, err
 	}
-	return &coretypes.ResultCheckTx{ResponseCheckTx: *res}, nil
+	return &coretypes.ResultCheckTx{ResponseCheckTx: *res.ResponseCheckTx}, nil
 }
 
 func (env *Environment) RemoveTx(ctx context.Context, req *coretypes.RequestRemoveTx) error {

--- a/internal/state/helpers_test.go
+++ b/internal/state/helpers_test.go
@@ -302,8 +302,8 @@ func (app *testApp) FinalizeBlock(_ context.Context, req *abci.RequestFinalizeBl
 	}, nil
 }
 
-func (app *testApp) CheckTx(_ context.Context, req *abci.RequestCheckTx) (*abci.ResponseCheckTx, error) {
-	return &abci.ResponseCheckTx{}, nil
+func (app *testApp) CheckTx(_ context.Context, req *abci.RequestCheckTx) (*abci.ResponseCheckTxV2, error) {
+	return &abci.ResponseCheckTxV2{ResponseCheckTx: &abci.ResponseCheckTx{}}, nil
 }
 
 func (app *testApp) Commit(context.Context) (*abci.ResponseCommit, error) {

--- a/rpc/client/mock/abci.go
+++ b/rpc/client/mock/abci.go
@@ -60,7 +60,7 @@ func (a ABCIApp) BroadcastTxCommit(ctx context.Context, tx types.Tx) (*coretypes
 		return nil, err
 	}
 
-	res := &coretypes.ResultBroadcastTxCommit{CheckTx: *resp}
+	res := &coretypes.ResultBroadcastTxCommit{CheckTx: *resp.ResponseCheckTx}
 	if res.CheckTx.IsErr() {
 		return res, nil
 	}

--- a/test/e2e/app/app.go
+++ b/test/e2e/app/app.go
@@ -163,14 +163,14 @@ func (app *Application) InitChain(_ context.Context, req *abci.RequestInitChain)
 }
 
 // CheckTx implements ABCI.
-func (app *Application) CheckTx(_ context.Context, req *abci.RequestCheckTx) (*abci.ResponseCheckTx, error) {
+func (app *Application) CheckTx(_ context.Context, req *abci.RequestCheckTx) (*abci.ResponseCheckTxV2, error) {
 	app.mu.Lock()
 	defer app.mu.Unlock()
 
 	_, _, err := parseTx(req.Tx)
 	if err != nil {
-		return &abci.ResponseCheckTx{
-			Code: code.CodeTypeEncodingError,
+		return &abci.ResponseCheckTxV2{
+			ResponseCheckTx: &abci.ResponseCheckTx{Code: code.CodeTypeEncodingError},
 		}, nil
 	}
 
@@ -178,7 +178,9 @@ func (app *Application) CheckTx(_ context.Context, req *abci.RequestCheckTx) (*a
 		time.Sleep(time.Duration(app.cfg.CheckTxDelayMS) * time.Millisecond)
 	}
 
-	return &abci.ResponseCheckTx{Code: code.CodeTypeOK, GasWanted: 1}, nil
+	return &abci.ResponseCheckTxV2{
+		ResponseCheckTx: &abci.ResponseCheckTx{Code: code.CodeTypeOK, GasWanted: 1},
+	}, nil
 }
 
 // FinalizeBlock implements ABCI.

--- a/types/mempool.go
+++ b/types/mempool.go
@@ -11,7 +11,7 @@ import (
 var ErrTxInCache = errors.New("tx already exists in cache")
 
 // ErrEvmTxNotReplaced is returned if the same evm nonce is used
-var ErrEvmTxNotReplaced = errors.New("cannot replace tx, priority is not higher than existing pending tx")
+var ErrEvmTxNotReplaced = errors.New("cannot replace tx with same nonce, priority is not higher")
 
 // TxKey is the fixed length array key used as an index.
 type TxKey [sha256.Size]byte

--- a/types/mempool.go
+++ b/types/mempool.go
@@ -10,6 +10,9 @@ import (
 // ErrTxInCache is returned to the client if we saw tx earlier
 var ErrTxInCache = errors.New("tx already exists in cache")
 
+// ErrEvmTxNotReplaced is returned if the same evm nonce is used
+var ErrEvmTxNotReplaced = errors.New("cannot replace tx, priority is not higher than existing pending tx")
+
 // TxKey is the fixed length array key used as an index.
 type TxKey [sha256.Size]byte
 


### PR DESCRIPTION
## Describe your changes and provide context
- EVM transactions will populate sender as `fromAddressHex|nonce`
- If priority is higher on the new transaction, it will remove the old one, otherwise reject new one (if duplicate exists)
- Removes any replaced ones from any pending or mempool if found 

## Testing performed to validate your change
- New Unit Test
