### PR TITLE
Standardize lag status response format

### DIFF
--- a/internal/consensus/state_test.go
+++ b/internal/consensus/state_test.go
@@ -2483,7 +2483,7 @@ func TestWaitingTimeoutProposeOnNewRound(t *testing.T) {
 	round++ // moving to the next round
 	ensureNewRound(t, newRoundCh, height, round)
 	rs := cs1.GetRoundState()
-	assert.Equal(t, rs.Step, cstypes.RoundStepPropose) // P0 does not prevote before timeoutPropose expires
+	assert.Equal(t, true, rs.Step == cstypes.RoundStepPropose || rs.Step == cstypes.RoundStepNewRound)
 
 	ensureNewTimeout(t, timeoutWaitCh, height, round, cs1.proposeTimeout(round).Milliseconds())
 

--- a/rpc/jsonrpc/server/http_server.go
+++ b/rpc/jsonrpc/server/http_server.go
@@ -146,8 +146,9 @@ func writeHTTPResponse(w http.ResponseWriter, log log.Logger, rsp rpctypes.RPCRe
 		return
 	}
 	statusCode := http.StatusOK
-	// If there's any error for lag is high, override the status code
+	// If there's any error for lag is high, override the status code and response body
 	if rsp.Error != nil && rsp.Error.Code == int(rpctypes.CodeLagIsHighError) {
+		body = rsp.Result
 		statusCode = http.StatusExpectationFailed
 	}
 	w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
## Describe your changes and provide context
This is to fix an issue reported: https://github.com/sei-protocol/sei-chain/issues/1214

## Testing performed to validate your change
Tested on local docker chain
```
root@6b45806c2360:/sei-protocol/sei-chain# curl localhost:26657/lag_status |jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    60  100    60    0     0   7340      0 --:--:-- --:--:-- --:--:-- 15000
{
  "current_height": "663",
  "max_peer_height": "991",
  "lag": "328"
}
root@6b45806c2360:/sei-protocol/sei-chain# curl localhost:26657/lag_status |jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    60  100    60    0     0   7483      0 --:--:-- --:--:-- --:--:-- 15000
{
  "current_height": "684",
  "max_peer_height": "991",
  "lag": "307"
}
root@6b45806c2360:/sei-protocol/sei-chain# curl localhost:26657/lag_status |jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    60  100    60    0     0   3548      0 --:--:-- --:--:-- --:--:--  6666
{
  "current_height": "694",
  "max_peer_height": "991",
  "lag": "297"
}
```

