### PR TITLE
Fix bug when popping pending TXs

### DIFF
--- a/internal/mempool/tx.go
+++ b/internal/mempool/tx.go
@@ -342,10 +342,16 @@ func (p *PendingTxs) popTxsAtIndices(indices []int) {
 	newTxs := []TxWithResponse{}
 	start := 0
 	for _, idx := range indices {
+		if idx <= start-1 {
+			panic("indices popped from pending tx store should be sorted without duplicate")
+		}
+		if idx >= len(p.txs) {
+			panic("indices popped from pending tx store out of range")
+		}
 		newTxs = append(newTxs, p.txs[start:idx]...)
-		start = idx
+		start = idx + 1
 	}
-	newTxs = append(newTxs, p.txs[start+1:]...)
+	newTxs = append(newTxs, p.txs[start:]...)
 	p.txs = newTxs
 }
 


### PR DESCRIPTION
## Describe your changes and provide context
There was a bug in the logic that removes transactions (either accepted or rejected) from the pending tx store. Specifically the old logic made it so that only the last index in the parameters gets removed. This PR fixes that and added more test coverage.

## Testing performed to validate your change
unit tests
