### PR TITLE
Fix remove tx should push next tx

### DIFF
--- a/internal/mempool/priority_queue.go
+++ b/internal/mempool/priority_queue.go
@@ -121,6 +121,8 @@ func (pq *TxPriorityQueue) removeQueuedEvmTxUnsafe(tx *WrappedTx) {
 				pq.evmQueue[tx.evmAddress] = append(queue[:i], queue[i+1:]...)
 				if len(pq.evmQueue[tx.evmAddress]) == 0 {
 					delete(pq.evmQueue, tx.evmAddress)
+				} else {
+					heap.Push(pq, pq.evmQueue[tx.evmAddress][0])
 				}
 				break
 			}
@@ -195,9 +197,6 @@ func (pq *TxPriorityQueue) popTxUnsafe() *WrappedTx {
 	}
 
 	pq.removeQueuedEvmTxUnsafe(tx)
-	if len(pq.evmQueue[tx.evmAddress]) > 0 {
-		heap.Push(pq, pq.evmQueue[tx.evmAddress][0])
-	}
 
 	return tx
 }

--- a/internal/mempool/priority_queue_test.go
+++ b/internal/mempool/priority_queue_test.go
@@ -90,6 +90,13 @@ func TestTxPriorityQueue_PriorityAndNonceOrdering(t *testing.T) {
 			},
 			expectedOutput: []int64{12, 13, 11},
 		},
+		{
+			name: "OneItem",
+			inputTxs: []*WrappedTx{
+				{sender: "14", isEVM: true, evmAddress: "0xabc", evmNonce: 1, priority: 10},
+			},
+			expectedOutput: []int64{14},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -261,6 +268,31 @@ func TestTxPriorityQueue_GetEvictableTxs(t *testing.T) {
 			require.Len(t, evictTxs, tc.expectedLen)
 		})
 	}
+}
+
+func TestTxPriorityQueue_RemoveTxEvm(t *testing.T) {
+	pq := NewTxPriorityQueue()
+
+	tx1 := &WrappedTx{
+		priority:   1,
+		isEVM:      true,
+		evmAddress: "0xabc",
+		evmNonce:   1,
+	}
+	tx2 := &WrappedTx{
+		priority:   1,
+		isEVM:      true,
+		evmAddress: "0xabc",
+		evmNonce:   2,
+	}
+
+	pq.PushTx(tx1)
+	pq.PushTx(tx2)
+
+	pq.RemoveTx(tx1)
+
+	result := pq.PopTx()
+	require.Equal(t, tx2, result)
 }
 
 func TestTxPriorityQueue_RemoveTx(t *testing.T) {


### PR DESCRIPTION
## Describe your changes and provide context
- a direct remove was not pushing the next evm transaction onto the queue

## Testing performed to validate your change
- new unit test 
