### PR TITLE
[EVM] Fix duplicate evm txs from priority queue

### DIFF
--- a/internal/mempool/mempool.go
+++ b/internal/mempool/mempool.go
@@ -281,6 +281,7 @@ func (txmp *TxMempool) CheckTx(
 	// transaction is already present in the cache, i.e. false is returned, then we
 	// check if we've seen this transaction and error if we have.
 	if !txmp.cache.Push(tx) {
+		fmt.Printf("DEBUG: DUPLICATE hash=%x\n", txHash)
 		txmp.txStore.GetOrSetPeerByTxHash(txHash, txInfo.SenderID)
 		return types.ErrTxInCache
 	}
@@ -290,6 +291,8 @@ func (txmp *TxMempool) CheckTx(
 		txmp.cache.Remove(tx)
 		res.Log = txmp.AppendCheckTxErr(res.Log, err.Error())
 	}
+
+	fmt.Printf("DEBUG: txmp.cache.Push(tx) hash=%x, nonce=%d, address=%s\n", txHash, res.EVMNonce, res.EVMSenderAddress)
 
 	wtx := &WrappedTx{
 		tx:         tx,
@@ -417,6 +420,9 @@ func (txmp *TxMempool) ReapMaxBytesMaxGas(maxBytes, maxGas int64) types.Txs {
 		wtx := txmp.priorityIndex.PopTx()
 		txs = append(txs, wtx.tx)
 		wTxs = append(wTxs, wtx)
+
+		fmt.Printf("DEBUG: priorityIndex.PopTx() hash=%x, nonce=%d, address=%s\n", wtx.tx.Key(), wtx.evmNonce, wtx.evmAddress)
+
 		size := types.ComputeProtoSizeForTxs([]types.Tx{wtx.tx})
 
 		// Ensure we have capacity for the transaction with respect to the

--- a/internal/mempool/mempool.go
+++ b/internal/mempool/mempool.go
@@ -402,15 +402,6 @@ func (txmp *TxMempool) ReapMaxBytesMaxGas(maxBytes, maxGas int64) types.Txs {
 		totalSize int64
 	)
 
-	// wTxs contains a list of *WrappedTx retrieved from the priority queue that
-	// need to be re-enqueued prior to returning.
-	wTxs := make([]*WrappedTx, 0, txmp.priorityIndex.NumTxs())
-	defer func() {
-		for _, wtx := range wTxs {
-			txmp.priorityIndex.PushTx(wtx)
-		}
-	}()
-
 	var txs []types.Tx
 	if uint64(txmp.Size()) < txmp.config.TxNotifyThreshold {
 		// do not reap anything if threshold is not met

--- a/internal/mempool/mempool.go
+++ b/internal/mempool/mempool.go
@@ -281,7 +281,6 @@ func (txmp *TxMempool) CheckTx(
 	// transaction is already present in the cache, i.e. false is returned, then we
 	// check if we've seen this transaction and error if we have.
 	if !txmp.cache.Push(tx) {
-		fmt.Printf("DEBUG: DUPLICATE hash=%x\n", txHash)
 		txmp.txStore.GetOrSetPeerByTxHash(txHash, txInfo.SenderID)
 		return types.ErrTxInCache
 	}
@@ -291,8 +290,6 @@ func (txmp *TxMempool) CheckTx(
 		txmp.cache.Remove(tx)
 		res.Log = txmp.AppendCheckTxErr(res.Log, err.Error())
 	}
-
-	fmt.Printf("DEBUG: txmp.cache.Push(tx) hash=%x, nonce=%d, address=%s\n", txHash, res.EVMNonce, res.EVMSenderAddress)
 
 	wtx := &WrappedTx{
 		tx:         tx,

--- a/internal/mempool/priority_queue.go
+++ b/internal/mempool/priority_queue.go
@@ -197,7 +197,7 @@ func (pq *TxPriorityQueue) checkInvariants(msg string) {
 				}
 			} else {
 				pq.print()
-				panic(fmt.Sprintf("DEBUG INVARIANT (%s): tx in heap but not in evmQueue hash=%x", msg, tx.tx.Key())
+				panic(fmt.Sprintf("DEBUG INVARIANT (%s): tx in heap but not in evmQueue hash=%x", msg, tx.tx.Key()))
 			}
 		}
 	}

--- a/internal/mempool/priority_queue.go
+++ b/internal/mempool/priority_queue.go
@@ -114,7 +114,7 @@ func (pq *TxPriorityQueue) NumTxs() int {
 func (pq *TxPriorityQueue) removeQueuedEvmTxUnsafe(tx *WrappedTx) {
 	if queue, ok := pq.evmQueue[tx.evmAddress]; ok {
 		for i, t := range queue {
-			if t == tx {
+			if t.tx.Key() == tx.tx.Key() {
 				pq.evmQueue[tx.evmAddress] = append(queue[:i], queue[i+1:]...)
 				if len(pq.evmQueue[tx.evmAddress]) == 0 {
 					delete(pq.evmQueue, tx.evmAddress)

--- a/internal/mempool/priority_queue.go
+++ b/internal/mempool/priority_queue.go
@@ -142,7 +142,7 @@ func (pq *TxPriorityQueue) NumTxs() int {
 }
 
 func (pq *TxPriorityQueue) removeQueuedEvmTxUnsafe(tx *WrappedTx) {
-	fmt.Printf("DEBUG: removeQueuedEvmTxUnsafe, hash=%x", tx.tx.Key())
+	fmt.Printf("DEBUG: removeQueuedEvmTxUnsafe, hash=%x\n", tx.tx.Key())
 	if queue, ok := pq.evmQueue[tx.evmAddress]; ok {
 		for i, t := range queue {
 			if t.evmNonce == tx.evmNonce {
@@ -150,14 +150,14 @@ func (pq *TxPriorityQueue) removeQueuedEvmTxUnsafe(tx *WrappedTx) {
 				if len(pq.evmQueue[tx.evmAddress]) == 0 {
 					delete(pq.evmQueue, tx.evmAddress)
 				} else {
-					fmt.Printf("DEBUG: removeQueuedEvmTxUnsafe heap.Push, hash=%x", pq.evmQueue[tx.evmAddress][0].tx.Key())
+					fmt.Printf("DEBUG: removeQueuedEvmTxUnsafe heap.Push, hash=%x\n", pq.evmQueue[tx.evmAddress][0].tx.Key())
 					heap.Push(pq, pq.evmQueue[tx.evmAddress][0])
 				}
 				break
 			}
 		}
 	} else {
-		fmt.Printf("DEBUG: removeQueuedEvmTxUnsafe no queue, hash=%x", pq.evmQueue[tx.evmAddress][0].tx.Key())
+		fmt.Printf("DEBUG: removeQueuedEvmTxUnsafe no queue, hash=%x\n", pq.evmQueue[tx.evmAddress][0].tx.Key())
 	}
 }
 
@@ -167,7 +167,7 @@ func (pq *TxPriorityQueue) findTxIndexUnsafe(tx *WrappedTx) (int, bool) {
 			return i, true
 		}
 	}
-	fmt.Printf("DEBUG: tx not found in heap: %x", tx.tx.Key())
+	fmt.Printf("DEBUG: tx not found in heap: %x\n", tx.tx.Key())
 	return 0, false
 }
 
@@ -200,12 +200,12 @@ func (pq *TxPriorityQueue) pushTxUnsafe(tx *WrappedTx) {
 
 	first := queue[0]
 	if tx.evmNonce < first.evmNonce {
-		fmt.Printf("DEBUG: swapping %d for %d: hash=%x", first.evmNonce, tx.evmNonce, tx.tx.Key())
+		fmt.Printf("DEBUG: swapping %d for %d: hash=%x\n", first.evmNonce, tx.evmNonce, tx.tx.Key())
 		if idx, ok := pq.findTxIndexUnsafe(first); ok {
-			fmt.Printf("DEBUG: swapping %d for %d: %x", first.evmNonce, tx.evmNonce, tx.tx.Key())
+			fmt.Printf("DEBUG: swapping %d for %d: %x\n", first.evmNonce, tx.evmNonce, tx.tx.Key())
 			heap.Remove(pq, idx)
 		} else {
-			fmt.Printf("DEBUG: DID NOT FIND swapping %d for %d: hash=%x", first.evmNonce, tx.evmNonce, tx.tx.Key())
+			fmt.Printf("DEBUG: DID NOT FIND swapping %d for %d: hash=%x\n", first.evmNonce, tx.evmNonce, tx.tx.Key())
 		}
 		heap.Push(pq, tx)
 	}
@@ -228,7 +228,7 @@ func (pq *TxPriorityQueue) popTxUnsafe() *WrappedTx {
 	tx := x.(*WrappedTx)
 
 	if !tx.isEVM {
-		fmt.Printf("DEBUG: popTxUnsafe NOT EVM, hash=%x", tx.tx.Key())
+		fmt.Printf("DEBUG: popTxUnsafe NOT EVM, hash=%x\n", tx.tx.Key())
 		return tx
 	}
 

--- a/internal/mempool/priority_queue.go
+++ b/internal/mempool/priority_queue.go
@@ -240,6 +240,30 @@ func (pq *TxPriorityQueue) PopTx() *WrappedTx {
 }
 
 // dequeue up to `max` transactions and reenqueue while locked
+func (pq *TxPriorityQueue) ForEachTx(handler func(wtx *WrappedTx) bool) {
+	pq.mtx.Lock()
+	defer pq.mtx.Unlock()
+
+	numTxs := len(pq.txs) + pq.numQueuedUnsafe()
+
+	txs := make([]*WrappedTx, 0, numTxs)
+
+	defer func() {
+		for _, tx := range txs {
+			pq.pushTxUnsafe(tx)
+		}
+	}()
+
+	for i := 0; i < numTxs; i++ {
+		popped := pq.popTxUnsafe()
+		txs = append(txs, popped)
+		if !handler(popped) {
+			return
+		}
+	}
+}
+
+// dequeue up to `max` transactions and reenqueue while locked
 func (pq *TxPriorityQueue) PeekTxs(max int) []*WrappedTx {
 	pq.mtx.Lock()
 	defer pq.mtx.Unlock()

--- a/internal/mempool/priority_queue.go
+++ b/internal/mempool/priority_queue.go
@@ -204,7 +204,6 @@ func (pq *TxPriorityQueue) checkInvariants(msg string) {
 
 	// each item in all queues should be unique nonce
 	for _, queue := range pq.evmQueue {
-		uniq := make(map[uint64]bool)
 		hashes := make(map[string]bool)
 		for idx, tx := range queue {
 			if idx == 0 {
@@ -214,16 +213,11 @@ func (pq *TxPriorityQueue) checkInvariants(msg string) {
 					panic(fmt.Sprintf("DEBUG INVARIANT (%s): did not find tx[0] hash=%x nonce=%d in heap", msg, tx.tx.Key(), tx.evmNonce))
 				}
 			}
-			if _, ok := uniq[tx.evmNonce]; ok {
-				pq.print()
-				panic(fmt.Sprintf("DEBUG INVARIANT (%s): duplicate nonce=%d in queue hash=%x", msg, tx.evmNonce, tx.tx.Key()))
-			}
 			if _, ok := hashes[fmt.Sprintf("%x", tx.tx.Key())]; ok {
 				pq.print()
 				panic(fmt.Sprintf("DEBUG INVARIANT (%s): duplicate hash=%x in queue nonce=%d", msg, tx.tx.Key(), tx.evmNonce))
 			}
 			hashes[fmt.Sprintf("%x", tx.tx.Key())] = true
-			uniq[tx.evmNonce] = true
 		}
 	}
 }

--- a/internal/mempool/priority_queue.go
+++ b/internal/mempool/priority_queue.go
@@ -3,9 +3,10 @@ package mempool
 import (
 	"container/heap"
 	"fmt"
-	tmmath "github.com/tendermint/tendermint/libs/math"
 	"sort"
 	"sync"
+
+	tmmath "github.com/tendermint/tendermint/libs/math"
 )
 
 var _ heap.Interface = (*TxPriorityQueue)(nil)

--- a/internal/mempool/priority_queue.go
+++ b/internal/mempool/priority_queue.go
@@ -230,12 +230,12 @@ func (pq *TxPriorityQueue) checkInvariants(msg string) {
 
 func (pq *TxPriorityQueue) print() {
 	for _, tx := range pq.txs {
-		fmt.Printf("DEBUG PRINT: heap: %x\n", tx.tx.Key())
+		fmt.Printf("DEBUG PRINT: heap: nonce=%d, hash=%x\n", tx.evmNonce, tx.tx.Key())
 	}
 
-	for addr, queue := range pq.evmQueue {
+	for _, queue := range pq.evmQueue {
 		for idx, tx := range queue {
-			fmt.Printf("DEBUG PRINT: evmQueue(%s): %d: %x\n", addr, idx, tx.tx.Key())
+			fmt.Printf("DEBUG PRINT: evmQueue[%d]: nonce=%d, hash=%x\n", idx, tx.evmNonce, tx.tx.Key())
 		}
 	}
 }

--- a/internal/mempool/priority_queue.go
+++ b/internal/mempool/priority_queue.go
@@ -142,7 +142,6 @@ func (pq *TxPriorityQueue) NumTxs() int {
 }
 
 func (pq *TxPriorityQueue) removeQueuedEvmTxUnsafe(tx *WrappedTx) {
-	fmt.Printf("DEBUG: removeQueuedEvmTxUnsafe, hash=%x\n", tx.tx.Key())
 	if queue, ok := pq.evmQueue[tx.evmAddress]; ok {
 		for i, t := range queue {
 			if t.evmNonce == tx.evmNonce {
@@ -150,6 +149,9 @@ func (pq *TxPriorityQueue) removeQueuedEvmTxUnsafe(tx *WrappedTx) {
 				if len(pq.evmQueue[tx.evmAddress]) == 0 {
 					delete(pq.evmQueue, tx.evmAddress)
 				} else {
+					if pq.evmQueue[tx.evmAddress][0].tx.Key() == tx.tx.Key() {
+						panic(fmt.Sprintf("DEBUG: DUPLICATE FOUND while pushing next, hash=%x\n", tx.tx.Key()))
+					}
 					fmt.Printf("DEBUG: removeQueuedEvmTxUnsafe heap.Push, hash=%x\n", pq.evmQueue[tx.evmAddress][0].tx.Key())
 					heap.Push(pq, pq.evmQueue[tx.evmAddress][0])
 				}
@@ -181,6 +183,7 @@ func (pq *TxPriorityQueue) RemoveTx(tx *WrappedTx) {
 	}
 
 	if tx.isEVM {
+		fmt.Printf("DEBUG: RemoveTx removeQueuedEvmTxUnsafe, hash=%x\n", tx.tx.Key())
 		pq.removeQueuedEvmTxUnsafe(tx)
 	}
 }
@@ -232,6 +235,7 @@ func (pq *TxPriorityQueue) popTxUnsafe() *WrappedTx {
 		return tx
 	}
 
+	fmt.Printf("DEBUG: popTxUnsafe removeQueuedEvmTxUnsafe, hash=%x\n", tx.tx.Key())
 	pq.removeQueuedEvmTxUnsafe(tx)
 
 	return tx

--- a/internal/mempool/priority_queue.go
+++ b/internal/mempool/priority_queue.go
@@ -117,7 +117,7 @@ func (pq *TxPriorityQueue) NumTxs() int {
 func (pq *TxPriorityQueue) removeQueuedEvmTxUnsafe(tx *WrappedTx) {
 	if queue, ok := pq.evmQueue[tx.evmAddress]; ok {
 		for i, t := range queue {
-			if t.evmNonce == tx.evmNonce {
+			if t == tx {
 				pq.evmQueue[tx.evmAddress] = append(queue[:i], queue[i+1:]...)
 				if len(pq.evmQueue[tx.evmAddress]) == 0 {
 					delete(pq.evmQueue, tx.evmAddress)
@@ -148,6 +148,9 @@ func (pq *TxPriorityQueue) findTxIndexUnsafe(tx *WrappedTx) (int, bool) {
 func (pq *TxPriorityQueue) RemoveTx(tx *WrappedTx) {
 	pq.mtx.Lock()
 	defer pq.mtx.Unlock()
+
+	pq.checkInvariants("RemoveTx start")
+	defer pq.checkInvariants("RemoveTx end")
 
 	if idx, ok := pq.findTxIndexUnsafe(tx); ok {
 		heap.Remove(pq, idx)

--- a/internal/mempool/priority_queue.go
+++ b/internal/mempool/priority_queue.go
@@ -17,10 +17,7 @@ type TxPriorityQueue struct {
 	evmQueue map[string][]*WrappedTx // sorted by nonce
 }
 
-func insertToEVMQueue(queue []*WrappedTx, tx *WrappedTx) []*WrappedTx {
-	// Using BinarySearch to find the appropriate index to insert tx
-	i := binarySearch(queue, tx)
-
+func insertToEVMQueue(queue []*WrappedTx, tx *WrappedTx, i int) []*WrappedTx {
 	// Make room for new value and add it
 	queue = append(queue, nil)
 	copy(queue[i+1:], queue[i:])
@@ -33,7 +30,7 @@ func binarySearch(queue []*WrappedTx, tx *WrappedTx) int {
 	low, high := 0, len(queue)
 	for low < high {
 		mid := low + (high-low)/2
-		if queue[mid].evmNonce < tx.evmNonce {
+		if queue[mid].evmNonce <= tx.evmNonce {
 			low = mid + 1
 		} else {
 			high = mid
@@ -186,7 +183,9 @@ func (pq *TxPriorityQueue) pushTxUnsafe(tx *WrappedTx) {
 		}
 		heap.Push(pq, tx)
 	}
-	pq.evmQueue[tx.evmAddress] = insertToEVMQueue(queue, tx)
+
+	pq.evmQueue[tx.evmAddress] = insertToEVMQueue(queue, tx, binarySearch(queue, tx))
+
 }
 
 func (pq *TxPriorityQueue) checkInvariants(msg string) {

--- a/internal/mempool/priority_queue.go
+++ b/internal/mempool/priority_queue.go
@@ -142,6 +142,7 @@ func (pq *TxPriorityQueue) NumTxs() int {
 }
 
 func (pq *TxPriorityQueue) removeQueuedEvmTxUnsafe(tx *WrappedTx) {
+	fmt.Printf("DEBUG: removeQueuedEvmTxUnsafe, hash=%x", tx.tx.Key())
 	if queue, ok := pq.evmQueue[tx.evmAddress]; ok {
 		for i, t := range queue {
 			if t.evmNonce == tx.evmNonce {
@@ -149,11 +150,14 @@ func (pq *TxPriorityQueue) removeQueuedEvmTxUnsafe(tx *WrappedTx) {
 				if len(pq.evmQueue[tx.evmAddress]) == 0 {
 					delete(pq.evmQueue, tx.evmAddress)
 				} else {
+					fmt.Printf("DEBUG: removeQueuedEvmTxUnsafe heap.Push, hash=%x", pq.evmQueue[tx.evmAddress][0].tx.Key())
 					heap.Push(pq, pq.evmQueue[tx.evmAddress][0])
 				}
 				break
 			}
 		}
+	} else {
+		fmt.Printf("DEBUG: removeQueuedEvmTxUnsafe no queue, hash=%x", pq.evmQueue[tx.evmAddress][0].tx.Key())
 	}
 }
 
@@ -163,6 +167,7 @@ func (pq *TxPriorityQueue) findTxIndexUnsafe(tx *WrappedTx) (int, bool) {
 			return i, true
 		}
 	}
+	fmt.Printf("DEBUG: tx not found in heap: %x", tx.tx.Key())
 	return 0, false
 }
 
@@ -195,12 +200,15 @@ func (pq *TxPriorityQueue) pushTxUnsafe(tx *WrappedTx) {
 
 	first := queue[0]
 	if tx.evmNonce < first.evmNonce {
+		fmt.Printf("DEBUG: swapping %d for %d: hash=%x", first.evmNonce, tx.evmNonce, tx.tx.Key())
 		if idx, ok := pq.findTxIndexUnsafe(first); ok {
+			fmt.Printf("DEBUG: swapping %d for %d: %x", first.evmNonce, tx.evmNonce, tx.tx.Key())
 			heap.Remove(pq, idx)
+		} else {
+			fmt.Printf("DEBUG: DID NOT FIND swapping %d for %d: hash=%x", first.evmNonce, tx.evmNonce, tx.tx.Key())
 		}
 		heap.Push(pq, tx)
 	}
-
 	pq.evmQueue[tx.evmAddress] = insertToEVMQueue(queue, tx)
 }
 
@@ -220,6 +228,7 @@ func (pq *TxPriorityQueue) popTxUnsafe() *WrappedTx {
 	tx := x.(*WrappedTx)
 
 	if !tx.isEVM {
+		fmt.Printf("DEBUG: popTxUnsafe NOT EVM, hash=%x", tx.tx.Key())
 		return tx
 	}
 

--- a/internal/mempool/priority_queue_test.go
+++ b/internal/mempool/priority_queue_test.go
@@ -178,6 +178,7 @@ func TestTxPriorityQueue(t *testing.T) {
 			pq.PushTx(&WrappedTx{
 				priority:  int64(i),
 				timestamp: time.Now(),
+				tx:        []byte(fmt.Sprintf("%d", i)),
 			})
 
 			wg.Done()
@@ -332,6 +333,7 @@ func TestTxPriorityQueue_RemoveTx(t *testing.T) {
 		x := rng.Intn(100000)
 		pq.PushTx(&WrappedTx{
 			priority: int64(x),
+			tx:       []byte(fmt.Sprintf("%d", i)),
 		})
 
 		values[i] = x

--- a/internal/mempool/priority_queue_test.go
+++ b/internal/mempool/priority_queue_test.go
@@ -50,6 +50,29 @@ func TestTxPriorityQueue_ReapHalf(t *testing.T) {
 func TestTxPriorityQueue_PriorityAndNonceOrdering(t *testing.T) {
 	testCases := []TxTestCase{
 		{
+			name: "PriorityWithEVMAndNonEVMDuplicateNonce",
+			inputTxs: []*WrappedTx{
+				{sender: "1", isEVM: true, evmAddress: "0xabc", evmNonce: 1, priority: 10},
+				{sender: "3", isEVM: true, evmAddress: "0xabc", evmNonce: 3, priority: 9},
+				{sender: "2", isEVM: true, evmAddress: "0xabc", evmNonce: 1, priority: 7},
+			},
+			expectedOutput: []int64{1, 2, 3},
+		},
+		{
+			name: "PriorityWithEVMAndNonEVMDuplicateNonce",
+			inputTxs: []*WrappedTx{
+				{sender: "1", isEVM: true, evmAddress: "0xabc", evmNonce: 1, priority: 10},
+				{sender: "2", isEVM: false, priority: 9},
+				{sender: "4", isEVM: true, evmAddress: "0xabc", evmNonce: 0, priority: 9}, // Same EVM address as first, lower nonce
+				{sender: "5", isEVM: true, evmAddress: "0xdef", evmNonce: 1, priority: 7},
+				{sender: "5", isEVM: true, evmAddress: "0xdef", evmNonce: 1, priority: 7},
+				{sender: "3", isEVM: true, evmAddress: "0xdef", evmNonce: 0, priority: 8},
+				{sender: "6", isEVM: false, priority: 6},
+				{sender: "7", isEVM: true, evmAddress: "0xghi", evmNonce: 2, priority: 5},
+			},
+			expectedOutput: []int64{2, 4, 1, 3, 5, 5, 6, 7},
+		},
+		{
 			name: "PriorityWithEVMAndNonEVM",
 			inputTxs: []*WrappedTx{
 				{sender: "1", isEVM: true, evmAddress: "0xabc", evmNonce: 1, priority: 10},
@@ -107,6 +130,7 @@ func TestTxPriorityQueue_PriorityAndNonceOrdering(t *testing.T) {
 			// Add input transactions to the queue and set timestamp to order inserted
 			for i, tx := range tc.inputTxs {
 				tx.timestamp = now.Add(time.Duration(i) * time.Second)
+				tx.tx = []byte(fmt.Sprintf("%d", time.Now().UnixNano()))
 				pq.PushTx(tx)
 			}
 
@@ -126,9 +150,9 @@ func TestTxPriorityQueue_SameAddressDifferentNonces(t *testing.T) {
 	address := "0x123"
 
 	// Insert transactions with the same address but different nonces and priorities
-	pq.PushTx(&WrappedTx{isEVM: true, evmAddress: address, evmNonce: 2, priority: 10})
-	pq.PushTx(&WrappedTx{isEVM: true, evmAddress: address, evmNonce: 1, priority: 5})
-	pq.PushTx(&WrappedTx{isEVM: true, evmAddress: address, evmNonce: 3, priority: 15})
+	pq.PushTx(&WrappedTx{isEVM: true, evmAddress: address, evmNonce: 2, priority: 10, tx: []byte("tx1")})
+	pq.PushTx(&WrappedTx{isEVM: true, evmAddress: address, evmNonce: 1, priority: 5, tx: []byte("tx2")})
+	pq.PushTx(&WrappedTx{isEVM: true, evmAddress: address, evmNonce: 3, priority: 15, tx: []byte("tx3")})
 
 	// Pop transactions and verify they are in the correct order of nonce
 	tx1 := pq.PopTx()
@@ -278,12 +302,14 @@ func TestTxPriorityQueue_RemoveTxEvm(t *testing.T) {
 		isEVM:      true,
 		evmAddress: "0xabc",
 		evmNonce:   1,
+		tx:         []byte("tx1"),
 	}
 	tx2 := &WrappedTx{
 		priority:   1,
 		isEVM:      true,
 		evmAddress: "0xabc",
 		evmNonce:   2,
+		tx:         []byte("tx2"),
 	}
 
 	pq.PushTx(tx1)

--- a/internal/rpc/core/mempool.go
+++ b/internal/rpc/core/mempool.go
@@ -157,6 +157,9 @@ func (env *Environment) UnconfirmedTxs(ctx context.Context, req *coretypes.Reque
 	skipCount := validateSkipCount(page, perPage)
 
 	txs := env.Mempool.ReapMaxTxs(skipCount + tmmath.MinInt(perPage, totalCount-skipCount))
+	if skipCount > len(txs) {
+		skipCount = len(txs)
+	}
 	result := txs[skipCount:]
 
 	return &coretypes.ResultUnconfirmedTxs{

--- a/types/tx.go
+++ b/types/tx.go
@@ -184,7 +184,7 @@ func (t TxRecordSet) Validate(maxSizeBytes int64, otxs Txs) error {
 	for i, cur := range allCopy {
 		// allCopy is sorted, so any duplicated data will be adjacent.
 		if i+1 < len(allCopy) && bytes.Equal(cur, allCopy[i+1]) {
-			return fmt.Errorf("found duplicate transaction with hash: %x", cur.Hash())
+			return fmt.Errorf("found duplicate transaction with hash: %x", cur.Key())
 		}
 	}
 


### PR DESCRIPTION
## Describe your changes and provide context
- Add duplicate nonce support for priority queue so that it doesn't cause duplicates
  - A duplicate nonce is inserted after the first existing one in an account's nonce queue
- Add ForEachTx accessor to add locking to priority index to avoid panic from unconfirmed querying (for transaction hash on pending block)

## Testing performed to validate your change
- Unit test
- It's running on slanders-evm
