### PR TITLE
[EVM] prevent duplicate txs from getting inserted

### DIFF
--- a/internal/consensus/mempool_test.go
+++ b/internal/consensus/mempool_test.go
@@ -266,7 +266,6 @@ type CounterApplication struct {
 
 	txCount        int
 	mempoolTxCount int
-	lastTx         int
 	mu             sync.Mutex
 }
 

--- a/internal/consensus/mempool_test.go
+++ b/internal/consensus/mempool_test.go
@@ -176,7 +176,7 @@ func TestMempoolTxConcurrentWithCommit(t *testing.T) {
 			headerEvent := msg.Data().(types.EventDataNewBlockHeader)
 			n += headerEvent.NumTxs
 			logger.Info("new transactions", "nTxs", headerEvent.NumTxs, "total", n)
-		case <-time.After(3 * time.Second):
+		case <-time.After(60 * time.Second):
 			t.Fatal("Timed out waiting 60s to commit blocks with transactions")
 		}
 	}

--- a/internal/consensus/mempool_test.go
+++ b/internal/consensus/mempool_test.go
@@ -166,7 +166,7 @@ func TestMempoolTxConcurrentWithCommit(t *testing.T) {
 	require.NoError(t, err)
 	newBlockHeaderCh := subscribe(ctx, t, cs.eventBus, types.EventQueryNewBlockHeader)
 
-	const numTxs int64 = 100
+	const numTxs int64 = 50
 	go checkTxsRange(ctx, t, cs, 0, int(numTxs))
 
 	startTestRound(ctx, cs, cs.roundState.Height(), cs.roundState.Round())

--- a/internal/consensus/mempool_test.go
+++ b/internal/consensus/mempool_test.go
@@ -313,14 +313,13 @@ func (app *CounterApplication) CheckTx(_ context.Context, req *abci.RequestCheck
 	app.mu.Lock()
 	defer app.mu.Unlock()
 
-	// asserts txs are in order
 	txValue := txAsUint64(req.Tx)
-	if txValue != uint64(app.lastTx) {
+	if txValue != uint64(app.mempoolTxCount) {
 		return &abci.ResponseCheckTxV2{ResponseCheckTx: &abci.ResponseCheckTx{
 			Code: code.CodeTypeBadNonce,
 		}}, nil
 	}
-	app.lastTx++
+	app.mempoolTxCount++
 	return &abci.ResponseCheckTxV2{ResponseCheckTx: &abci.ResponseCheckTx{Code: code.CodeTypeOK}}, nil
 }
 

--- a/internal/mempool/mempool.go
+++ b/internal/mempool/mempool.go
@@ -661,8 +661,6 @@ func (txmp *TxMempool) addNewTransaction(wtx *WrappedTx, res *abci.ResponseCheck
 			"num_txs", txmp.Size(),
 		)
 		txmp.notifyTxsAvailable()
-	} else {
-		fmt.Println("DEBUG: ******************************** NOT INSERTING, ALREADY EXISTS")
 	}
 
 	return nil

--- a/internal/mempool/mempool.go
+++ b/internal/mempool/mempool.go
@@ -346,7 +346,8 @@ func (txmp *TxMempool) CheckTx(
 }
 
 func (txmp *TxMempool) isInMempool(tx types.Tx) bool {
-	return txmp.txStore.GetTxByHash(tx.Key()) != nil && !txmp.txStore.GetTxByHash(tx.Key()).removed
+	existingTx := txmp.txStore.GetTxByHash(tx.Key())
+	return existingTx != nil && !existingTx.removed
 }
 
 func (txmp *TxMempool) RemoveTxByKey(txKey types.TxKey) error {

--- a/internal/mempool/mempool.go
+++ b/internal/mempool/mempool.go
@@ -312,6 +312,9 @@ func (txmp *TxMempool) CheckTx(
 	if err == nil {
 		// only add new transaction if checkTx passes and is not pending
 		if !res.IsPendingTransaction {
+			if txmp.pendingTxs.Exists(wtx) {
+				panic(fmt.Sprintf("INVARIANT: MEMPOOL already pending address=%s, hash=%x, key=%x nonce=%d time=%d in txStore", wtx.evmAddress, wtx.hash, wtx.tx.Key(), wtx.evmNonce, wtx.timestamp.UnixNano()))
+			}
 			err = txmp.addNewTransaction(wtx, res.ResponseCheckTx, txInfo)
 			if err != nil {
 				return err

--- a/internal/mempool/mempool.go
+++ b/internal/mempool/mempool.go
@@ -312,9 +312,6 @@ func (txmp *TxMempool) CheckTx(
 	if err == nil {
 		// only add new transaction if checkTx passes and is not pending
 		if !res.IsPendingTransaction {
-			if txmp.pendingTxs.Exists(wtx) {
-				panic(fmt.Sprintf("INVARIANT: MEMPOOL already pending address=%s, hash=%x, key=%x nonce=%d time=%d in txStore", wtx.evmAddress, wtx.hash, wtx.tx.Key(), wtx.evmNonce, wtx.timestamp.UnixNano()))
-			}
 			err = txmp.addNewTransaction(wtx, res.ResponseCheckTx, txInfo)
 			if err != nil {
 				return err
@@ -831,16 +828,6 @@ func (txmp *TxMempool) canAddTx(wtx *WrappedTx) error {
 	}
 
 	return nil
-}
-
-func (txmp *TxMempool) mustNotExist(msg string, wtx *WrappedTx) {
-	existing := txmp.txStore.GetTxByHash(wtx.hash)
-	if existing != nil && !existing.removed {
-		txmp.priorityIndex.lock()
-		defer txmp.priorityIndex.unlock()
-		txmp.priorityIndex.print()
-		panic(fmt.Sprintf("INVARIANT: MEMPOOL %s address=%s, hash=%x, key=%x nonce=%d time=%d in txStore", msg, wtx.evmAddress, wtx.hash, wtx.tx.Key(), wtx.evmNonce, wtx.timestamp.UnixNano()))
-	}
 }
 
 func (txmp *TxMempool) insertTx(wtx *WrappedTx) bool {

--- a/internal/mempool/mempool.go
+++ b/internal/mempool/mempool.go
@@ -316,19 +316,6 @@ func (txmp *TxMempool) CheckTx(
 			if err != nil {
 				return err
 			}
-		} else if txmp.isInMempool(wtx.tx) {
-			// if a transaction exists as non-pending and arrives as pending, evict
-			txmp.logger.Debug(
-				"existing transaction no longer valid; arrived as pending in CheckTX",
-				"priority", wtx.priority,
-				"tx", fmt.Sprintf("%X", wtx.tx.Hash()),
-				"err", err,
-				"code", res.Code,
-				"evm", res.IsEVM,
-				"nonce", res.EVMNonce,
-				"address", res.EVMSenderAddress,
-			)
-			txmp.removeTx(wtx, !txmp.config.KeepInvalidTxsInCache)
 		} else {
 			// otherwise add to pending txs store
 			if res.Checker == nil {

--- a/internal/mempool/mempool.go
+++ b/internal/mempool/mempool.go
@@ -810,6 +810,14 @@ func (txmp *TxMempool) canAddTx(wtx *WrappedTx) error {
 }
 
 func (txmp *TxMempool) insertTx(wtx *WrappedTx) {
+	existing := txmp.txStore.GetTxByHash(wtx.hash)
+	if existing != nil && !existing.removed {
+		txmp.priorityIndex.lock()
+		defer txmp.priorityIndex.unlock()
+		txmp.priorityIndex.print()
+		panic(fmt.Sprintf("INVARIANT: MEMPOOL address=%s, hash=%x, key=%x nonce=%d in txStore", wtx.evmAddress, wtx.hash, wtx.evmNonce, wtx.tx.Key()))
+	}
+
 	txmp.txStore.SetTx(wtx)
 	txmp.priorityIndex.PushTx(wtx)
 	txmp.heightIndex.Insert(wtx)

--- a/internal/mempool/priority_queue.go
+++ b/internal/mempool/priority_queue.go
@@ -245,7 +245,7 @@ func (pq *TxPriorityQueue) print() {
 			fmt.Printf("DEBUG PRINT: heap (%s): nonce=%d, tx.tx is nil \n", tx.evmAddress, tx.evmNonce)
 			continue
 		}
-		fmt.Printf("DEBUG PRINT: heap (%s): nonce=%d, hash=%x\n", tx.evmAddress, tx.evmNonce, tx.tx.Key())
+		fmt.Printf("DEBUG PRINT: heap (%s): nonce=%d, hash=%x, time=%d\n", tx.evmAddress, tx.evmNonce, tx.tx.Key(), tx.timestamp.UnixNano())
 	}
 
 	for addr, queue := range pq.evmQueue {
@@ -259,7 +259,7 @@ func (pq *TxPriorityQueue) print() {
 				continue
 			}
 
-			fmt.Printf("DEBUG PRINT: evmQueue(%s)[%d]: nonce=%d, hash=%x\n", tx.evmAddress, idx, tx.evmNonce, tx.tx.Key())
+			fmt.Printf("DEBUG PRINT: evmQueue(%s)[%d]: nonce=%d, hash=%x, time=%d\n", tx.evmAddress, idx, tx.evmNonce, tx.tx.Key(), tx.timestamp.UnixNano())
 		}
 	}
 }

--- a/internal/mempool/priority_queue.go
+++ b/internal/mempool/priority_queue.go
@@ -293,6 +293,7 @@ func (pq *TxPriorityQueue) popTxUnsafe() *WrappedTx {
 	}
 	tx := x.(*WrappedTx)
 
+	// non-evm transactions do not have txs waiting on a nonce
 	if !tx.isEVM {
 		return tx
 	}
@@ -300,7 +301,11 @@ func (pq *TxPriorityQueue) popTxUnsafe() *WrappedTx {
 	// evm transactions can have txs waiting on this nonce
 	// if there are any, we should replace the heap with the next nonce
 	// for the address
+
+	// remove the first item from the evmQueue
 	pq.removeQueuedEvmTxUnsafe(tx)
+
+	// if there is a next item, now it can be added to the heap
 	if len(pq.evmQueue[tx.evmAddress]) > 0 {
 		heap.Push(pq, pq.evmQueue[tx.evmAddress][0])
 	}

--- a/internal/mempool/priority_queue.go
+++ b/internal/mempool/priority_queue.go
@@ -230,12 +230,12 @@ func (pq *TxPriorityQueue) checkInvariants(msg string) {
 // for debugging situations where invariant violations occur
 func (pq *TxPriorityQueue) print() {
 	for _, tx := range pq.txs {
-		fmt.Printf("DEBUG PRINT: heap: nonce=%d, hash=%x\n", tx.evmNonce, tx.tx.Key())
+		fmt.Printf("DEBUG PRINT: heap (%s): nonce=%d, hash=%x\n", tx.evmAddress, tx.evmNonce, tx.tx.Key())
 	}
 
 	for _, queue := range pq.evmQueue {
 		for idx, tx := range queue {
-			fmt.Printf("DEBUG PRINT: evmQueue[%d]: nonce=%d, hash=%x\n", idx, tx.evmNonce, tx.tx.Key())
+			fmt.Printf("DEBUG PRINT: evmQueue(%s)[%d]: nonce=%d, hash=%x\n", tx.evmAddress, idx, tx.evmNonce, tx.tx.Key())
 		}
 	}
 }

--- a/internal/mempool/priority_queue.go
+++ b/internal/mempool/priority_queue.go
@@ -202,62 +202,62 @@ func (pq *TxPriorityQueue) pushTxUnsafe(tx *WrappedTx) {
 // These are available if we need to test the invariant checks
 // these can be used to troubleshoot invariant violations
 func (pq *TxPriorityQueue) checkInvariants(msg string) {
-	uniqHashes := make(map[string]bool)
-	for idx, tx := range pq.txs {
-		if tx == nil {
-			pq.print()
-			panic(fmt.Sprintf("DEBUG PRINT: found nil item on heap: idx=%d\n", idx))
-		}
-		if tx.tx == nil {
-			pq.print()
-			panic(fmt.Sprintf("DEBUG PRINT: found nil tx.tx on heap: idx=%d\n", idx))
-		}
-		if _, ok := uniqHashes[fmt.Sprintf("%x", tx.tx.Key())]; ok {
-			pq.print()
-			panic(fmt.Sprintf("INVARIANT (%s): duplicate hash=%x in heap", msg, tx.tx.Key()))
-		}
-		uniqHashes[fmt.Sprintf("%x", tx.tx.Key())] = true
-
-		//if _, ok := pq.keys[tx.tx.Key()]; !ok {
-		//	pq.print()
-		//	panic(fmt.Sprintf("INVARIANT (%s): tx in heap but not in keys hash=%x", msg, tx.tx.Key()))
-		//}
-
-		if tx.isEVM {
-			if queue, ok := pq.evmQueue[tx.evmAddress]; ok {
-				if queue[0].tx.Key() != tx.tx.Key() {
-					pq.print()
-					panic(fmt.Sprintf("INVARIANT (%s): tx in heap but not at front of evmQueue hash=%x", msg, tx.tx.Key()))
-				}
-			} else {
-				pq.print()
-				panic(fmt.Sprintf("INVARIANT (%s): tx in heap but not in evmQueue hash=%x", msg, tx.tx.Key()))
-			}
-		}
-	}
-
-	// each item in all queues should be unique nonce
-	for _, queue := range pq.evmQueue {
-		hashes := make(map[string]bool)
-		for idx, tx := range queue {
-			if idx == 0 {
-				_, ok := pq.findTxIndexUnsafe(tx)
-				if !ok {
-					pq.print()
-					panic(fmt.Sprintf("INVARIANT (%s): did not find tx[0] hash=%x nonce=%d in heap", msg, tx.tx.Key(), tx.evmNonce))
-				}
-			}
-			//if _, ok := pq.keys[tx.tx.Key()]; !ok {
-			//	pq.print()
-			//	panic(fmt.Sprintf("INVARIANT (%s): tx in heap but not in keys hash=%x", msg, tx.tx.Key()))
-			//}
-			if _, ok := hashes[fmt.Sprintf("%x", tx.tx.Key())]; ok {
-				pq.print()
-				panic(fmt.Sprintf("INVARIANT (%s): duplicate hash=%x in queue nonce=%d", msg, tx.tx.Key(), tx.evmNonce))
-			}
-			hashes[fmt.Sprintf("%x", tx.tx.Key())] = true
-		}
-	}
+	//uniqHashes := make(map[string]bool)
+	//for idx, tx := range pq.txs {
+	//	if tx == nil {
+	//		pq.print()
+	//		panic(fmt.Sprintf("DEBUG PRINT: found nil item on heap: idx=%d\n", idx))
+	//	}
+	//	if tx.tx == nil {
+	//		pq.print()
+	//		panic(fmt.Sprintf("DEBUG PRINT: found nil tx.tx on heap: idx=%d\n", idx))
+	//	}
+	//	if _, ok := uniqHashes[fmt.Sprintf("%x", tx.tx.Key())]; ok {
+	//		pq.print()
+	//		panic(fmt.Sprintf("INVARIANT (%s): duplicate hash=%x in heap", msg, tx.tx.Key()))
+	//	}
+	//	uniqHashes[fmt.Sprintf("%x", tx.tx.Key())] = true
+	//
+	//	//if _, ok := pq.keys[tx.tx.Key()]; !ok {
+	//	//	pq.print()
+	//	//	panic(fmt.Sprintf("INVARIANT (%s): tx in heap but not in keys hash=%x", msg, tx.tx.Key()))
+	//	//}
+	//
+	//	if tx.isEVM {
+	//		if queue, ok := pq.evmQueue[tx.evmAddress]; ok {
+	//			if queue[0].tx.Key() != tx.tx.Key() {
+	//				pq.print()
+	//				panic(fmt.Sprintf("INVARIANT (%s): tx in heap but not at front of evmQueue hash=%x", msg, tx.tx.Key()))
+	//			}
+	//		} else {
+	//			pq.print()
+	//			panic(fmt.Sprintf("INVARIANT (%s): tx in heap but not in evmQueue hash=%x", msg, tx.tx.Key()))
+	//		}
+	//	}
+	//}
+	//
+	//// each item in all queues should be unique nonce
+	//for _, queue := range pq.evmQueue {
+	//	hashes := make(map[string]bool)
+	//	for idx, tx := range queue {
+	//		if idx == 0 {
+	//			_, ok := pq.findTxIndexUnsafe(tx)
+	//			if !ok {
+	//				pq.print()
+	//				panic(fmt.Sprintf("INVARIANT (%s): did not find tx[0] hash=%x nonce=%d in heap", msg, tx.tx.Key(), tx.evmNonce))
+	//			}
+	//		}
+	//		//if _, ok := pq.keys[tx.tx.Key()]; !ok {
+	//		//	pq.print()
+	//		//	panic(fmt.Sprintf("INVARIANT (%s): tx in heap but not in keys hash=%x", msg, tx.tx.Key()))
+	//		//}
+	//		if _, ok := hashes[fmt.Sprintf("%x", tx.tx.Key())]; ok {
+	//			pq.print()
+	//			panic(fmt.Sprintf("INVARIANT (%s): duplicate hash=%x in queue nonce=%d", msg, tx.tx.Key(), tx.evmNonce))
+	//		}
+	//		hashes[fmt.Sprintf("%x", tx.tx.Key())] = true
+	//	}
+	//}
 }
 
 // for debugging situations where invariant violations occur

--- a/internal/mempool/priority_queue.go
+++ b/internal/mempool/priority_queue.go
@@ -229,12 +229,25 @@ func (pq *TxPriorityQueue) checkInvariants(msg string) {
 
 // for debugging situations where invariant violations occur
 func (pq *TxPriorityQueue) print() {
-	for _, tx := range pq.txs {
+	for idx, tx := range pq.txs {
+		if tx == nil {
+			panic(fmt.Sprintf("DEBUG PRINT: found nil item on heap: idx=%d\n", idx))
+		}
+		if tx.tx == nil {
+			panic(fmt.Sprintf("DEBUG PRINT: found nil tx.tx on heap: idx=%d\n", idx))
+		}
 		fmt.Printf("DEBUG PRINT: heap (%s): nonce=%d, hash=%x\n", tx.evmAddress, tx.evmNonce, tx.tx.Key())
 	}
 
-	for _, queue := range pq.evmQueue {
+	for addr, queue := range pq.evmQueue {
 		for idx, tx := range queue {
+			if tx == nil {
+				panic(fmt.Sprintf("DEBUG PRINT: found nil item on evmQueue(%s): idx=%d\n", addr, idx))
+			}
+			if tx.tx == nil {
+				panic(fmt.Sprintf("DEBUG PRINT: found nil tx.tx on  evmQueue(%s): idx=%d\n", addr, idx))
+			}
+
 			fmt.Printf("DEBUG PRINT: evmQueue(%s)[%d]: nonce=%d, hash=%x\n", tx.evmAddress, idx, tx.evmNonce, tx.tx.Key())
 		}
 	}
@@ -246,6 +259,13 @@ func (pq *TxPriorityQueue) PushTx(tx *WrappedTx) {
 	pq.checkInvariants("PushTx start")
 	defer pq.checkInvariants("PushTx end")
 	defer pq.mtx.Unlock()
+
+	if tx == nil {
+		panic("PushTx: nil tx")
+	}
+	if tx.tx == nil {
+		panic("PushTx: nil tx.tx")
+	}
 
 	pq.pushTxUnsafe(tx)
 }

--- a/internal/mempool/priority_queue.go
+++ b/internal/mempool/priority_queue.go
@@ -143,11 +143,11 @@ func (pq *TxPriorityQueue) findTxIndexUnsafe(tx *WrappedTx) (int, bool) {
 // RemoveTx removes a specific transaction from the priority queue.
 func (pq *TxPriorityQueue) RemoveTx(tx *WrappedTx) {
 	pq.mtx.Lock()
-
 	pq.checkInvariants("RemoveTx start")
-	defer pq.checkInvariants("RemoveTx end")
-
-	defer pq.mtx.Unlock()
+	defer func() {
+		pq.checkInvariants("RemoveTx end")
+		pq.mtx.Unlock()
+	}()
 
 	if idx, ok := pq.findTxIndexUnsafe(tx); ok {
 		heap.Remove(pq, idx)
@@ -236,6 +236,7 @@ func (pq *TxPriorityQueue) checkInvariants(msg string) {
 
 // for debugging situations where invariant violations occur
 func (pq *TxPriorityQueue) print() {
+	fmt.Println("PRINT PRIORITY QUEUE ****************** ")
 	for _, tx := range pq.txs {
 		if tx == nil {
 			fmt.Printf("DEBUG PRINT: heap (nil): nonce=?, hash=?\n")
@@ -268,8 +269,10 @@ func (pq *TxPriorityQueue) print() {
 func (pq *TxPriorityQueue) PushTx(tx *WrappedTx) {
 	pq.mtx.Lock()
 	pq.checkInvariants("PushTx start")
-	defer pq.checkInvariants("PushTx end")
-	defer pq.mtx.Unlock()
+	defer func() {
+		pq.checkInvariants("PushTx end")
+		pq.mtx.Unlock()
+	}()
 
 	if tx == nil {
 		panic("PushTx: nil tx")
@@ -306,8 +309,10 @@ func (pq *TxPriorityQueue) PopTx() *WrappedTx {
 	pq.mtx.Lock()
 
 	pq.checkInvariants("PopTx start")
-	defer pq.checkInvariants("PopTx end")
-	defer pq.mtx.Unlock()
+	defer func() {
+		pq.checkInvariants("PopTx end")
+		pq.mtx.Unlock()
+	}()
 
 	return pq.popTxUnsafe()
 }

--- a/internal/mempool/priority_queue.go
+++ b/internal/mempool/priority_queue.go
@@ -54,6 +54,14 @@ func NewTxPriorityQueue() *TxPriorityQueue {
 	return pq
 }
 
+func (pq *TxPriorityQueue) lock() {
+	pq.mtx.Lock()
+}
+
+func (pq *TxPriorityQueue) unlock() {
+	pq.mtx.Unlock()
+}
+
 // GetEvictableTxs attempts to find and return a list of *WrappedTx than can be
 // evicted to make room for another *WrappedTx with higher priority. If no such
 // list of *WrappedTx exists, nil will be returned. The returned list of *WrappedTx
@@ -165,7 +173,7 @@ func (pq *TxPriorityQueue) pushTxUnsafe(tx *WrappedTx) {
 	if _, ok := pq.keys[tx.tx.Key()]; ok {
 		return
 	}
-	pq.keys[tx.tx.Key()] = struct{}{}
+	//pq.keys[tx.tx.Key()] = struct{}{}
 
 	if !tx.isEVM {
 		heap.Push(pq, tx)
@@ -239,10 +247,10 @@ func (pq *TxPriorityQueue) checkInvariants(msg string) {
 					panic(fmt.Sprintf("INVARIANT (%s): did not find tx[0] hash=%x nonce=%d in heap", msg, tx.tx.Key(), tx.evmNonce))
 				}
 			}
-			if _, ok := pq.keys[tx.tx.Key()]; !ok {
-				pq.print()
-				panic(fmt.Sprintf("INVARIANT (%s): tx in heap but not in keys hash=%x", msg, tx.tx.Key()))
-			}
+			//if _, ok := pq.keys[tx.tx.Key()]; !ok {
+			//	pq.print()
+			//	panic(fmt.Sprintf("INVARIANT (%s): tx in heap but not in keys hash=%x", msg, tx.tx.Key()))
+			//}
 			if _, ok := hashes[fmt.Sprintf("%x", tx.tx.Key())]; ok {
 				pq.print()
 				panic(fmt.Sprintf("INVARIANT (%s): duplicate hash=%x in queue nonce=%d", msg, tx.tx.Key(), tx.evmNonce))

--- a/internal/mempool/priority_queue.go
+++ b/internal/mempool/priority_queue.go
@@ -171,7 +171,7 @@ func (pq *TxPriorityQueue) pushTxUnsafe(tx *WrappedTx) {
 	}
 
 	first := queue[0]
-	if tx.evmNonce < first.evmNonce {
+	if tx.evmNonce < first.evmNonce || (tx.evmNonce == first.evmNonce && tx.timestamp.Before(first.timestamp)) {
 		if idx, ok := pq.findTxIndexUnsafe(first); ok {
 			heap.Remove(pq, idx)
 		}

--- a/internal/mempool/priority_queue.go
+++ b/internal/mempool/priority_queue.go
@@ -218,10 +218,10 @@ func (pq *TxPriorityQueue) checkInvariants(msg string) {
 		}
 		uniqHashes[fmt.Sprintf("%x", tx.tx.Key())] = true
 
-		if _, ok := pq.keys[tx.tx.Key()]; !ok {
-			pq.print()
-			panic(fmt.Sprintf("INVARIANT (%s): tx in heap but not in keys hash=%x", msg, tx.tx.Key()))
-		}
+		//if _, ok := pq.keys[tx.tx.Key()]; !ok {
+		//	pq.print()
+		//	panic(fmt.Sprintf("INVARIANT (%s): tx in heap but not in keys hash=%x", msg, tx.tx.Key()))
+		//}
 
 		if tx.isEVM {
 			if queue, ok := pq.evmQueue[tx.evmAddress]; ok {

--- a/internal/mempool/priority_queue_test.go
+++ b/internal/mempool/priority_queue_test.go
@@ -196,6 +196,7 @@ func TestTxPriorityQueue(t *testing.T) {
 	pq.PushTx(&WrappedTx{
 		priority:  1000,
 		timestamp: now,
+		tx:        []byte(fmt.Sprintf("%d", time.Now().UnixNano())),
 	})
 	require.Equal(t, 1001, pq.NumTxs())
 

--- a/internal/mempool/tx.go
+++ b/internal/mempool/tx.go
@@ -370,6 +370,17 @@ func (p *PendingTxs) Insert(tx *WrappedTx, resCheckTx *abci.ResponseCheckTxV2, t
 	})
 }
 
+func (p *PendingTxs) Exists(tx *WrappedTx) bool {
+	p.mtx.RLock()
+	defer p.mtx.RUnlock()
+	for _, txWithResponse := range p.txs {
+		if txWithResponse.tx.tx.Key() == tx.tx.Key() {
+			return true
+		}
+	}
+	return false
+}
+
 func (p *PendingTxs) Peek(max int) []TxWithResponse {
 	p.mtx.RLock()
 	defer p.mtx.RUnlock()

--- a/internal/mempool/tx.go
+++ b/internal/mempool/tx.go
@@ -74,6 +74,10 @@ type WrappedTx struct {
 	isEVM      bool
 }
 
+func (wtx *WrappedTx) IsBefore(tx *WrappedTx) bool {
+	return wtx.evmNonce < tx.evmNonce || (wtx.evmNonce == tx.evmNonce && wtx.timestamp.Before(tx.timestamp))
+}
+
 func (wtx *WrappedTx) Size() int {
 	return len(wtx.tx)
 }
@@ -368,17 +372,6 @@ func (p *PendingTxs) Insert(tx *WrappedTx, resCheckTx *abci.ResponseCheckTxV2, t
 		checkTxResponse: resCheckTx,
 		txInfo:          txInfo,
 	})
-}
-
-func (p *PendingTxs) Exists(tx *WrappedTx) bool {
-	p.mtx.RLock()
-	defer p.mtx.RUnlock()
-	for _, txWithResponse := range p.txs {
-		if txWithResponse.tx.tx.Key() == tx.tx.Key() {
-			return true
-		}
-	}
-	return false
 }
 
 func (p *PendingTxs) Peek(max int) []TxWithResponse {

--- a/internal/mempool/tx.go
+++ b/internal/mempool/tx.go
@@ -74,6 +74,8 @@ type WrappedTx struct {
 	isEVM      bool
 }
 
+// IsBefore returns true if the WrappedTx is before the given WrappedTx
+// this applies to EVM transactions only
 func (wtx *WrappedTx) IsBefore(tx *WrappedTx) bool {
 	return wtx.evmNonce < tx.evmNonce || (wtx.evmNonce == tx.evmNonce && wtx.timestamp.Before(tx.timestamp))
 }


### PR DESCRIPTION
## Describe your changes and provide context
- EVM TXs should be sorted by nonce AND timestamp if they are inserted to the mempool 
- Avoid inserting a hash to the mempool if it already exists in mempool
  - This can happen with EVM transactions because certain transactions can transition to/from pending and re-arrive

## Testing performed to validate your change
- Baking in lower environment
