### PR TITLE
[EVM] Avoid returning nil transactions on ForEach

### DIFF
--- a/internal/mempool/priority_queue.go
+++ b/internal/mempool/priority_queue.go
@@ -153,9 +153,6 @@ func (pq *TxPriorityQueue) RemoveTx(tx *WrappedTx) {
 }
 
 func (pq *TxPriorityQueue) pushTxUnsafe(tx *WrappedTx) {
-	if tx == nil {
-		panic("attempting to push a nil transaction")
-	}
 	if !tx.isEVM {
 		heap.Push(pq, tx)
 		return
@@ -335,15 +332,15 @@ func (pq *TxPriorityQueue) ForEachTx(handler func(wtx *WrappedTx) bool) {
 
 	defer func() {
 		for _, tx := range txs {
-			// if tx is nil by this point, avoid re-pushing
-			if tx != nil {
-				pq.pushTxUnsafe(tx)
-			}
+			pq.pushTxUnsafe(tx)
 		}
 	}()
 
 	for i := 0; i < numTxs; i++ {
 		popped := pq.popTxUnsafe()
+		if popped == nil {
+			break
+		}
 		txs = append(txs, popped)
 		if !handler(popped) {
 			return

--- a/internal/mempool/priority_queue.go
+++ b/internal/mempool/priority_queue.go
@@ -375,10 +375,7 @@ func (pq *TxPriorityQueue) PeekTxs(max int) []*WrappedTx {
 	}
 
 	for _, tx := range res {
-		if tx != nil {
-			// if tx is nil by this point, avoid re-pushing
-			pq.pushTxUnsafe(tx)
-		}
+		pq.pushTxUnsafe(tx)
 	}
 	return res
 }

--- a/internal/mempool/priority_queue.go
+++ b/internal/mempool/priority_queue.go
@@ -293,6 +293,7 @@ func (pq *TxPriorityQueue) popTxUnsafe() *WrappedTx {
 	}
 	tx := x.(*WrappedTx)
 
+	// this situation is primarily for a test case that inserts nils
 	if tx == nil {
 		return nil
 	}

--- a/internal/mempool/priority_queue.go
+++ b/internal/mempool/priority_queue.go
@@ -153,6 +153,9 @@ func (pq *TxPriorityQueue) RemoveTx(tx *WrappedTx) {
 }
 
 func (pq *TxPriorityQueue) pushTxUnsafe(tx *WrappedTx) {
+	if tx == nil {
+		panic("attempting to push a nil transaction")
+	}
 	if !tx.isEVM {
 		heap.Push(pq, tx)
 		return
@@ -332,7 +335,10 @@ func (pq *TxPriorityQueue) ForEachTx(handler func(wtx *WrappedTx) bool) {
 
 	defer func() {
 		for _, tx := range txs {
-			pq.pushTxUnsafe(tx)
+			// if tx is nil by this point, avoid re-pushing
+			if tx != nil {
+				pq.pushTxUnsafe(tx)
+			}
 		}
 	}()
 
@@ -368,7 +374,10 @@ func (pq *TxPriorityQueue) PeekTxs(max int) []*WrappedTx {
 	}
 
 	for _, tx := range res {
-		pq.pushTxUnsafe(tx)
+		if tx != nil {
+			// if tx is nil by this point, avoid re-pushing
+			pq.pushTxUnsafe(tx)
+		}
 	}
 	return res
 }

--- a/internal/mempool/priority_queue.go
+++ b/internal/mempool/priority_queue.go
@@ -371,10 +371,7 @@ func (pq *TxPriorityQueue) PeekTxs(max int) []*WrappedTx {
 	}
 
 	for _, tx := range res {
-		if tx != nil {
-			// if tx is nil by this point, avoid re-pushing
-			pq.pushTxUnsafe(tx)
-		}
+		pq.pushTxUnsafe(tx)
 	}
 	return res
 }

--- a/internal/mempool/priority_queue_test.go
+++ b/internal/mempool/priority_queue_test.go
@@ -47,6 +47,20 @@ func TestTxPriorityQueue_ReapHalf(t *testing.T) {
 	}
 }
 
+func TestAvoidPanicIfTransactionIsNil(t *testing.T) {
+	pq := NewTxPriorityQueue()
+	pq.Push(&WrappedTx{sender: "1", isEVM: true, evmAddress: "0xabc", evmNonce: 1, priority: 10})
+	pq.txs = append(pq.txs, nil)
+
+	var count int
+	pq.ForEachTx(func(tx *WrappedTx) bool {
+		count++
+		return true
+	})
+
+	require.Equal(t, 1, count)
+}
+
 func TestTxPriorityQueue_PriorityAndNonceOrdering(t *testing.T) {
 	testCases := []TxTestCase{
 		{

--- a/internal/mempool/priority_queue_test.go
+++ b/internal/mempool/priority_queue_test.go
@@ -47,6 +47,13 @@ func TestTxPriorityQueue_ReapHalf(t *testing.T) {
 	}
 }
 
+func TestPanicIfTransactionIsNil(t *testing.T) {
+	pq := NewTxPriorityQueue()
+	require.Panics(t, func() {
+		pq.PushTx(nil)
+	})
+}
+
 func TestTxPriorityQueue_PriorityAndNonceOrdering(t *testing.T) {
 	testCases := []TxTestCase{
 		{

--- a/internal/mempool/priority_queue_test.go
+++ b/internal/mempool/priority_queue_test.go
@@ -47,13 +47,6 @@ func TestTxPriorityQueue_ReapHalf(t *testing.T) {
 	}
 }
 
-func TestPanicIfTransactionIsNil(t *testing.T) {
-	pq := NewTxPriorityQueue()
-	require.Panics(t, func() {
-		pq.PushTx(nil)
-	})
-}
-
 func TestTxPriorityQueue_PriorityAndNonceOrdering(t *testing.T) {
 	testCases := []TxTestCase{
 		{


### PR DESCRIPTION
## Describe your changes and provide context
- on read, if nil, it skips the item
- remove stale field heapIndex that can throw nil (no longer used)

## Testing performed to validate your change
- add unit test for nil situation (with nil check on read)
