### PR TITLE
Add EVM txs eviction logic

### DIFF
--- a/config/toml.go
+++ b/config/toml.go
@@ -409,7 +409,7 @@ pending-size = {{ .Mempool.PendingSize }}
 
 max-pending-txs-bytes = {{ .Mempool.MaxPendingTxsBytes }}
 
-pending-ttl-duration = {{ .Mempool.PendingTTLDuration }}
+pending-ttl-duration = "{{ .Mempool.PendingTTLDuration }}"
 
 pending-ttl-num-blocks = {{ .Mempool.PendingTTLNumBlocks }}
 

--- a/internal/mempool/mempool_test.go
+++ b/internal/mempool/mempool_test.go
@@ -30,6 +30,8 @@ import (
 // transaction priority based on the value in the key/value pair.
 type application struct {
 	*kvstore.Application
+
+	occupiedNonces map[string][]uint64
 }
 
 type testTx struct {
@@ -38,6 +40,7 @@ type testTx struct {
 }
 
 func (app *application) CheckTx(_ context.Context, req *abci.RequestCheckTx) (*abci.ResponseCheckTxV2, error) {
+
 	var (
 		priority int64
 		sender   string
@@ -58,7 +61,7 @@ func (app *application) CheckTx(_ context.Context, req *abci.RequestCheckTx) (*a
 				GasWanted: 1,
 			}}, nil
 		}
-		nonce, err := strconv.ParseInt(string(parts[3]), 10, 64)
+		nonce, err := strconv.ParseUint(string(parts[3]), 10, 64)
 		if err != nil {
 			// could not parse
 			return &abci.ResponseCheckTxV2{ResponseCheckTx: &abci.ResponseCheckTx{
@@ -67,15 +70,50 @@ func (app *application) CheckTx(_ context.Context, req *abci.RequestCheckTx) (*a
 				GasWanted: 1,
 			}}, nil
 		}
+		if app.occupiedNonces == nil {
+			app.occupiedNonces = make(map[string][]uint64)
+		}
+		if _, exists := app.occupiedNonces[account]; !exists {
+			app.occupiedNonces[account] = []uint64{}
+		}
+		active := true
+		for i := uint64(0); i < nonce; i++ {
+			found := false
+			for _, occ := range app.occupiedNonces[account] {
+				if occ == i {
+					found = true
+					break
+				}
+			}
+			if !found {
+				active = false
+				break
+			}
+		}
+		app.occupiedNonces[account] = append(app.occupiedNonces[account], nonce)
 		return &abci.ResponseCheckTxV2{
 			ResponseCheckTx: &abci.ResponseCheckTx{
 				Priority:  v,
 				Code:      code.CodeTypeOK,
 				GasWanted: 1,
 			},
-			EVMNonce:         uint64(nonce),
-			EVMSenderAddress: account,
-			IsEVM:            true,
+			EVMNonce:             nonce,
+			EVMSenderAddress:     account,
+			IsEVM:                true,
+			IsPendingTransaction: !active,
+			Checker:              func() abci.PendingTxCheckerResponse { return abci.Pending },
+			ExpireTxHandler: func() {
+				idx := -1
+				for i, n := range app.occupiedNonces[account] {
+					if n == nonce {
+						idx = i
+						break
+					}
+				}
+				if idx >= 0 {
+					app.occupiedNonces[account] = append(app.occupiedNonces[account][:idx], app.occupiedNonces[account][idx+1:]...)
+				}
+			},
 		}, nil
 	}
 
@@ -470,11 +508,13 @@ func TestTxMempool_Prioritization(t *testing.T) {
 	txs := [][]byte{
 		[]byte(fmt.Sprintf("sender-0-1=peer=%d", 9)),
 		[]byte(fmt.Sprintf("sender-1-1=peer=%d", 8)),
-		[]byte(fmt.Sprintf("evm-sender=%s=%d=%d", address1, 7, 0)),
-		[]byte(fmt.Sprintf("evm-sender=%s=%d=%d", address1, 9, 1)),
 		[]byte(fmt.Sprintf("evm-sender=%s=%d=%d", address2, 6, 0)),
 		[]byte(fmt.Sprintf("sender-2-1=peer=%d", 5)),
 		[]byte(fmt.Sprintf("sender-3-1=peer=%d", 4)),
+	}
+	evmTxs := [][]byte{
+		[]byte(fmt.Sprintf("evm-sender=%s=%d=%d", address1, 7, 0)),
+		[]byte(fmt.Sprintf("evm-sender=%s=%d=%d", address1, 9, 1)),
 	}
 
 	// copy the slice of txs and shuffle the order randomly
@@ -484,6 +524,16 @@ func TestTxMempool_Prioritization(t *testing.T) {
 	rng.Shuffle(len(txsCopy), func(i, j int) {
 		txsCopy[i], txsCopy[j] = txsCopy[j], txsCopy[i]
 	})
+	txs = [][]byte{
+		[]byte(fmt.Sprintf("sender-0-1=peer=%d", 9)),
+		[]byte(fmt.Sprintf("sender-1-1=peer=%d", 8)),
+		[]byte(fmt.Sprintf("evm-sender=%s=%d=%d", address1, 7, 0)),
+		[]byte(fmt.Sprintf("evm-sender=%s=%d=%d", address1, 9, 1)),
+		[]byte(fmt.Sprintf("evm-sender=%s=%d=%d", address2, 6, 0)),
+		[]byte(fmt.Sprintf("sender-2-1=peer=%d", 5)),
+		[]byte(fmt.Sprintf("sender-3-1=peer=%d", 4)),
+	}
+	txsCopy = append(txsCopy, evmTxs...)
 
 	for i := range txsCopy {
 		require.NoError(t, txmp.CheckTx(ctx, txsCopy[i], nil, TxInfo{SenderID: peerID}))
@@ -502,6 +552,71 @@ func TestTxMempool_Prioritization(t *testing.T) {
 	for i, reapedTx := range reapedTxs {
 		require.Equal(t, txs[i], []byte(reapedTx))
 	}
+}
+
+func TestTxMempool_PendingStoreSize(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	client := abciclient.NewLocalClient(log.NewNopLogger(), &application{Application: kvstore.NewApplication()})
+	if err := client.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(client.Wait)
+
+	txmp := setup(t, client, 100)
+	txmp.config.PendingSize = 1
+	peerID := uint16(1)
+
+	address1 := "0xeD23B3A9DE15e92B9ef9540E587B3661E15A12fA"
+
+	require.NoError(t, txmp.CheckTx(ctx, []byte(fmt.Sprintf("evm-sender=%s=%d=%d", address1, 1, 1)), nil, TxInfo{SenderID: peerID}))
+	err := txmp.CheckTx(ctx, []byte(fmt.Sprintf("evm-sender=%s=%d=%d", address1, 1, 2)), nil, TxInfo{SenderID: peerID})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "mempool pending set is full")
+}
+
+func TestTxMempool_EVMEviction(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	client := abciclient.NewLocalClient(log.NewNopLogger(), &application{Application: kvstore.NewApplication()})
+	if err := client.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(client.Wait)
+
+	txmp := setup(t, client, 100)
+	txmp.config.Size = 1
+	peerID := uint16(1)
+
+	address1 := "0xeD23B3A9DE15e92B9ef9540E587B3661E15A12fA"
+	address2 := "0xfD23B3A9DE15e92B9ef9540E587B3661E15A12fA"
+
+	require.NoError(t, txmp.CheckTx(ctx, []byte(fmt.Sprintf("evm-sender=%s=%d=%d", address1, 1, 0)), nil, TxInfo{SenderID: peerID}))
+	// this should evict the previous tx
+	require.NoError(t, txmp.CheckTx(ctx, []byte(fmt.Sprintf("evm-sender=%s=%d=%d", address1, 2, 0)), nil, TxInfo{SenderID: peerID}))
+	require.Equal(t, 1, txmp.priorityIndex.NumTxs())
+	require.Equal(t, int64(2), txmp.priorityIndex.txs[0].priority)
+
+	txmp.config.Size = 2
+	require.NoError(t, txmp.CheckTx(ctx, []byte(fmt.Sprintf("evm-sender=%s=%d=%d", address1, 3, 1)), nil, TxInfo{SenderID: peerID}))
+	require.Equal(t, 0, txmp.pendingTxs.Size())
+	require.Equal(t, 2, txmp.priorityIndex.NumTxs())
+	// this would evict the tx with priority 2 and cause the tx with priority 3 to go pending
+	require.NoError(t, txmp.CheckTx(ctx, []byte(fmt.Sprintf("evm-sender=%s=%d=%d", address2, 4, 0)), nil, TxInfo{SenderID: peerID}))
+	time.Sleep(1 * time.Second) // reenqueue is async
+	require.Equal(t, 1, txmp.priorityIndex.NumTxs())
+	tx := txmp.priorityIndex.txs[0]
+	require.Equal(t, 1, txmp.pendingTxs.Size())
+
+	require.NoError(t, txmp.CheckTx(ctx, []byte(fmt.Sprintf("evm-sender=%s=%d=%d", address2, 5, 1)), nil, TxInfo{SenderID: peerID}))
+	require.Equal(t, 2, txmp.priorityIndex.NumTxs())
+	txmp.removeTx(tx, true, false)
+	// should not reenqueue
+	require.Equal(t, 1, txmp.priorityIndex.NumTxs())
+	time.Sleep(1 * time.Second) // pendingTxs should still be one even after sleeping for a sec
+	require.Equal(t, 1, txmp.pendingTxs.Size())
 }
 
 func TestTxMempool_CheckTxSamePeer(t *testing.T) {

--- a/internal/mempool/priority_queue_test.go
+++ b/internal/mempool/priority_queue_test.go
@@ -331,7 +331,7 @@ func TestTxPriorityQueue_RemoveTxEvm(t *testing.T) {
 	pq.PushTx(tx1)
 	pq.PushTx(tx2)
 
-	pq.RemoveTx(tx1)
+	pq.RemoveTx(tx1, false)
 
 	result := pq.PopTx()
 	require.Equal(t, tx2, result)
@@ -360,14 +360,14 @@ func TestTxPriorityQueue_RemoveTx(t *testing.T) {
 	max := values[len(values)-1]
 
 	wtx := pq.txs[pq.NumTxs()/2]
-	pq.RemoveTx(wtx)
+	pq.RemoveTx(wtx, false)
 	require.Equal(t, numTxs-1, pq.NumTxs())
 	require.Equal(t, int64(max), pq.PopTx().priority)
 	require.Equal(t, numTxs-2, pq.NumTxs())
 
 	require.NotPanics(t, func() {
-		pq.RemoveTx(&WrappedTx{heapIndex: numTxs})
-		pq.RemoveTx(&WrappedTx{heapIndex: numTxs + 1})
+		pq.RemoveTx(&WrappedTx{heapIndex: numTxs}, false)
+		pq.RemoveTx(&WrappedTx{heapIndex: numTxs + 1}, false)
 	})
 	require.Equal(t, numTxs-2, pq.NumTxs())
 }

--- a/internal/mempool/tx_test.go
+++ b/internal/mempool/tx_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/types"
 )
 
@@ -231,7 +232,7 @@ func TestWrappedTxList_Remove(t *testing.T) {
 }
 
 func TestPendingTxsPopTxsGood(t *testing.T) {
-	pendingTxs := NewPendingTxs()
+	pendingTxs := NewPendingTxs(config.TestMempoolConfig())
 	for _, test := range []struct {
 		origLen    int
 		popIndices []int
@@ -281,7 +282,9 @@ func TestPendingTxsPopTxsGood(t *testing.T) {
 	} {
 		pendingTxs.txs = []TxWithResponse{}
 		for i := 0; i < test.origLen; i++ {
-			pendingTxs.txs = append(pendingTxs.txs, TxWithResponse{txInfo: TxInfo{SenderID: uint16(i)}})
+			pendingTxs.txs = append(pendingTxs.txs, TxWithResponse{
+				tx:     &WrappedTx{tx: []byte{}},
+				txInfo: TxInfo{SenderID: uint16(i)}})
 		}
 		pendingTxs.popTxsAtIndices(test.popIndices)
 		require.Equal(t, len(test.expected), len(pendingTxs.txs))
@@ -292,7 +295,7 @@ func TestPendingTxsPopTxsGood(t *testing.T) {
 }
 
 func TestPendingTxsPopTxsBad(t *testing.T) {
-	pendingTxs := NewPendingTxs()
+	pendingTxs := NewPendingTxs(config.TestMempoolConfig())
 	// out of range
 	require.Panics(t, func() { pendingTxs.popTxsAtIndices([]int{0}) })
 	// out of order


### PR DESCRIPTION
## Describe your changes and provide context
- When an EVM transaction is removed from mempool for any reason other than it being successfully processed and committed (e.g. evicted or expired), we want to move all the transactions after it in the queue back to pending.
- When an EVM transaction is removed from mempool because it's successfully processed, we will only remove itself from the pq without doing anything to the rest of the queue.

## Testing performed to validate your change
unit tests

