### PR TITLE
Fix debug log

### DIFF
--- a/internal/consensus/reactor_test.go
+++ b/internal/consensus/reactor_test.go
@@ -97,6 +97,7 @@ func setup(
 			state.eventBus,
 			true,
 			NopMetrics(),
+			config.DefaultConfig(),
 		)
 
 		reactor.SetStateChannel(rts.stateChannels[nodeID])
@@ -697,6 +698,7 @@ func TestSwitchToConsensusVoteExtensions(t *testing.T) {
 				cs.eventBus,
 				true,
 				NopMetrics(),
+				config.DefaultConfig(),
 			)
 
 			if testCase.shouldPanic {

--- a/node/node.go
+++ b/node/node.go
@@ -349,6 +349,7 @@ func makeNode(
 		eventBus,
 		waitSync,
 		nodeMetrics.consensus,
+		cfg,
 	)
 
 	node.router.AddChDescToBeAdded(consensus.GetStateChannelDescriptor(), csReactor.SetStateChannel)


### PR DESCRIPTION
## Describe your changes and provide context
The debug log in `pickSendVote` accesses peer state in a manner that's subject to race condition, which may lead to page fault when debug is on. This PR changes the access to be via `ToJSON` which is guarded by a mutext. Since `ToJSON` is rather expensive, we only do that if log level is debug.

## Testing performed to validate your change
unit test

