### PR TITLE
reformat RPC logs for transaction broadcast failure case for easier debugging in frontend

### DIFF
--- a/internal/mempool/mempool.go
+++ b/internal/mempool/mempool.go
@@ -3,9 +3,9 @@ package mempool
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -907,15 +907,14 @@ func (txmp *TxMempool) GetPeerFailedCheckTxCount(nodeID types.NodeID) uint64 {
 
 // AppendCheckTxErr wraps error message into an ABCIMessageLogs json string
 func (txmp *TxMempool) AppendCheckTxErr(existingLogs string, log string) string {
-	var logs []map[string]interface{}
-	json.Unmarshal([]byte(existingLogs), &logs)
+	var builder strings.Builder
 
-	// Append the new ABCIMessageLog to the slice
-	logs = append(logs, map[string]interface{}{
-		"log": log,
-	})
+	builder.WriteString(existingLogs)
+	// If there are already logs, append the new log with a separator
+	if builder.Len() > 0 {
+		builder.WriteString("; ")
+	}
+	builder.WriteString(log)
 
-	// Marshal the updated slice back into a JSON string
-	jsonData, _ := json.Marshal(logs)
-	return string(jsonData)
+	return builder.String()
 }

--- a/internal/mempool/mempool_test.go
+++ b/internal/mempool/mempool_test.go
@@ -3,7 +3,6 @@ package mempool
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -707,24 +706,17 @@ func TestAppendCheckTxErr(t *testing.T) {
 	}
 	t.Cleanup(client.Wait)
 	txmp := setup(t, client, 500)
-	existingData := `[{"log":"existing error log"}]`
+	existingLogData := "existing error log"
+	newLogData := "sample error log"
 
 	// Append new error
-	result := txmp.AppendCheckTxErr(existingData, "sample error msg")
+	actualResult := txmp.AppendCheckTxErr(existingLogData, newLogData)
+	expectedResult := fmt.Sprintf("%s; %s", existingLogData, newLogData)
 
-	// Unmarshal the result
-	var data []map[string]interface{}
-	err := json.Unmarshal([]byte(result), &data)
-	require.NoError(t, err)
-	require.Equal(t, len(data), 2)
-	require.Equal(t, data[1]["log"], "sample error msg")
+	require.Equal(t, expectedResult, actualResult)
 
 	// Append new error to empty log
-	result = txmp.AppendCheckTxErr("", "sample error msg")
+	actualResult = txmp.AppendCheckTxErr("", newLogData)
 
-	// Unmarshal the result
-	err = json.Unmarshal([]byte(result), &data)
-	require.NoError(t, err)
-	require.Equal(t, len(data), 1)
-	require.Equal(t, data[0]["log"], "sample error msg")
+	require.Equal(t, newLogData, actualResult)
 }


### PR DESCRIPTION
## Describe your changes and provide context
On sei-js side, when transaction broadcast fails, up until recently we were observing error like the following
```
BroadcastTxError: Broadcasting transaction failed with code 10 (codespace: sdk). Log:
    at SigningStargateClient.broadcastTx (/Users/bryantran/code/sei/nft/script/node_modules/@cosmjs/stargate/build/stargateclient.js:267:35)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async main (file:///Users/bryantran/code/sei/nft/script/evm/test.js:17:18) {
  code: 10,
  codespace: 'sdk',
  log: ''
}
```
With recent change https://github.com/sei-protocol/sei-tendermint/pull/201, the log looks like.
```
 log: '[{"log":"insufficient fees; got: 1200usei required: 12000usei: insufficient fee"}]'
```

We would like to tweak formatting a bit (from json, to a simple string) , so the output of the log is more like
```
log: 'insufficient fees; got: 1200usei required: 12000usei: insufficient fee'
```

With full error message looking like
```
BroadcastTxError: Broadcasting transaction failed with code 13 (codespace: sdk). Log: insufficient fees; got: 1200usei required: 12000usei: insufficient fee
    at SigningStargateClient.broadcastTxSync (/Users/denyssinyakov/repos/experimental/cosmos-test/node_modules/@cosmjs/stargate/build/stargateclient.js:290:35)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async SigningStargateClient.broadcastTx (/Users/denyssinyakov/repos/experimental/cosmos-test/node_modules/@cosmjs/stargate/build/stargateclient.js:267:31) {
  code: 13,
  codespace: 'sdk',
  log: 'insufficient fees; got: 1200usei required: 12000usei: insufficient fee'
}


```
## Testing performed to validate your change

- Unit testing
- Local node + js client