### PR TITLE
Fix root dir for tendermint reindex event command

### DIFF
--- a/cmd/tendermint/commands/reindex_event.go
+++ b/cmd/tendermint/commands/reindex_event.go
@@ -17,6 +17,7 @@ import (
 	"github.com/tendermint/tendermint/internal/state/indexer/sink/kv"
 	"github.com/tendermint/tendermint/internal/state/indexer/sink/psql"
 	"github.com/tendermint/tendermint/internal/store"
+	"github.com/tendermint/tendermint/libs/cli"
 	"github.com/tendermint/tendermint/libs/log"
 	"github.com/tendermint/tendermint/libs/os"
 	"github.com/tendermint/tendermint/rpc/coretypes"
@@ -52,6 +53,8 @@ either or both arguments.
 	tendermint reindex-event --start-height 2 --end-height 10
 	`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			home, err := cmd.Flags().GetString(cli.HomeFlag)
+			conf.RootDir = home
 			bs, ss, err := loadStateAndBlockStore(conf)
 			if err != nil {
 				return fmt.Errorf("%s: %w", reindexFailed, err)

--- a/config/config.go
+++ b/config/config.go
@@ -250,6 +250,7 @@ func DefaultBaseConfig() BaseConfig {
 		FilterPeers: false,
 		DBBackend:   "goleveldb",
 		DBPath:      "data",
+		RootDir:     "/root/.sei",
 	}
 }
 


### PR DESCRIPTION
## Describe your changes and provide context
Problem:
![image](https://github.com/sei-protocol/sei-tendermint/assets/50607998/2b5bfb18-2a49-4e1d-bb7e-199e598c989d)
- Tendermint command failed to parse the data directory correctly
- home flag is not working properly

This PR add a default home dir and also force to parse the home flag for reindex event to replace the root dir, otherwise it will be empty.

## Testing performed to validate your change
Tested locally for verification