### PR TITLE
Add heapIndex with safety check

### DIFF
--- a/internal/mempool/mempool.go
+++ b/internal/mempool/mempool.go
@@ -417,8 +417,8 @@ func (txmp *TxMempool) Flush() {
 //   - Transactions returned are not removed from the mempool transaction
 //     store or indexes.
 func (txmp *TxMempool) ReapMaxBytesMaxGas(maxBytes, maxGas int64) types.Txs {
-	txmp.mtx.RLock()
-	defer txmp.mtx.RUnlock()
+	txmp.mtx.Lock()
+	defer txmp.mtx.Unlock()
 
 	var (
 		totalGas  int64
@@ -458,8 +458,8 @@ func (txmp *TxMempool) ReapMaxBytesMaxGas(maxBytes, maxGas int64) types.Txs {
 //   - Transactions returned are not removed from the mempool transaction
 //     store or indexes.
 func (txmp *TxMempool) ReapMaxTxs(max int) types.Txs {
-	txmp.mtx.RLock()
-	defer txmp.mtx.RUnlock()
+	txmp.mtx.Lock()
+	defer txmp.mtx.Unlock()
 
 	wTxs := txmp.priorityIndex.PeekTxs(max)
 	txs := make([]types.Tx, 0, len(wTxs))

--- a/internal/mempool/mempool_test.go
+++ b/internal/mempool/mempool_test.go
@@ -379,27 +379,43 @@ func TestTxMempool_ReapMaxBytesMaxGas(t *testing.T) {
 		require.Equal(t, priorities[:len(reapedPriorities)], reapedPriorities)
 	}
 
+	var wg sync.WaitGroup
+
 	// reap by gas capacity only
-	reapedTxs := txmp.ReapMaxBytesMaxGas(-1, 50)
-	ensurePrioritized(reapedTxs)
-	require.Equal(t, len(tTxs), txmp.Size())
-	require.Equal(t, int64(5690), txmp.SizeBytes())
-	require.Len(t, reapedTxs, 50)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		reapedTxs := txmp.ReapMaxBytesMaxGas(-1, 50)
+		ensurePrioritized(reapedTxs)
+		require.Equal(t, len(tTxs), txmp.Size())
+		require.Equal(t, int64(5690), txmp.SizeBytes())
+		require.Len(t, reapedTxs, 50)
+	}()
 
 	// reap by transaction bytes only
-	reapedTxs = txmp.ReapMaxBytesMaxGas(1000, -1)
-	ensurePrioritized(reapedTxs)
-	require.Equal(t, len(tTxs), txmp.Size())
-	require.Equal(t, int64(5690), txmp.SizeBytes())
-	require.GreaterOrEqual(t, len(reapedTxs), 16)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		reapedTxs := txmp.ReapMaxBytesMaxGas(1000, -1)
+		ensurePrioritized(reapedTxs)
+		require.Equal(t, len(tTxs), txmp.Size())
+		require.Equal(t, int64(5690), txmp.SizeBytes())
+		require.GreaterOrEqual(t, len(reapedTxs), 16)
+	}()
 
 	// Reap by both transaction bytes and gas, where the size yields 31 reaped
 	// transactions and the gas limit reaps 25 transactions.
-	reapedTxs = txmp.ReapMaxBytesMaxGas(1500, 30)
-	ensurePrioritized(reapedTxs)
-	require.Equal(t, len(tTxs), txmp.Size())
-	require.Equal(t, int64(5690), txmp.SizeBytes())
-	require.Len(t, reapedTxs, 25)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		reapedTxs := txmp.ReapMaxBytesMaxGas(1500, 30)
+		ensurePrioritized(reapedTxs)
+		require.Equal(t, len(tTxs), txmp.Size())
+		require.Equal(t, int64(5690), txmp.SizeBytes())
+		require.Len(t, reapedTxs, 25)
+	}()
+
+	wg.Wait()
 }
 
 func TestTxMempool_ReapMaxTxs(t *testing.T) {
@@ -438,26 +454,42 @@ func TestTxMempool_ReapMaxTxs(t *testing.T) {
 		require.Equal(t, priorities[:len(reapedPriorities)], reapedPriorities)
 	}
 
+	var wg sync.WaitGroup
+
 	// reap all transactions
-	reapedTxs := txmp.ReapMaxTxs(-1)
-	ensurePrioritized(reapedTxs)
-	require.Equal(t, len(tTxs), txmp.Size())
-	require.Equal(t, int64(5690), txmp.SizeBytes())
-	require.Len(t, reapedTxs, len(tTxs))
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		reapedTxs := txmp.ReapMaxTxs(-1)
+		ensurePrioritized(reapedTxs)
+		require.Equal(t, len(tTxs), txmp.Size())
+		require.Equal(t, int64(5690), txmp.SizeBytes())
+		require.Len(t, reapedTxs, len(tTxs))
+	}()
 
 	// reap a single transaction
-	reapedTxs = txmp.ReapMaxTxs(1)
-	ensurePrioritized(reapedTxs)
-	require.Equal(t, len(tTxs), txmp.Size())
-	require.Equal(t, int64(5690), txmp.SizeBytes())
-	require.Len(t, reapedTxs, 1)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		reapedTxs := txmp.ReapMaxTxs(1)
+		ensurePrioritized(reapedTxs)
+		require.Equal(t, len(tTxs), txmp.Size())
+		require.Equal(t, int64(5690), txmp.SizeBytes())
+		require.Len(t, reapedTxs, 1)
+	}()
 
 	// reap half of the transactions
-	reapedTxs = txmp.ReapMaxTxs(len(tTxs) / 2)
-	ensurePrioritized(reapedTxs)
-	require.Equal(t, len(tTxs), txmp.Size())
-	require.Equal(t, int64(5690), txmp.SizeBytes())
-	require.Len(t, reapedTxs, len(tTxs)/2)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		reapedTxs := txmp.ReapMaxTxs(len(tTxs) / 2)
+		ensurePrioritized(reapedTxs)
+		require.Equal(t, len(tTxs), txmp.Size())
+		require.Equal(t, int64(5690), txmp.SizeBytes())
+		require.Len(t, reapedTxs, len(tTxs)/2)
+	}()
+
+	wg.Wait()
 }
 
 func TestTxMempool_CheckTxExceedsMaxSize(t *testing.T) {

--- a/internal/mempool/priority_queue.go
+++ b/internal/mempool/priority_queue.go
@@ -178,12 +178,16 @@ func (pq *TxPriorityQueue) removeQueuedEvmTxUnsafe(tx *WrappedTx) (removedIdx in
 }
 
 func (pq *TxPriorityQueue) findTxIndexUnsafe(tx *WrappedTx) (int, bool) {
-	for i, t := range pq.txs {
-		if t.tx.Key() == tx.tx.Key() {
-			return i, true
+	// safety check to ensure heapIndex did not drift
+	if tx.heapIndex < 0 || tx.heapIndex >= len(pq.txs) || pq.txs[tx.heapIndex].tx.Key() != tx.tx.Key() {
+		for i, t := range pq.txs {
+			if t.tx.Key() == tx.tx.Key() {
+				return i, true
+			}
 		}
+		return 0, false
 	}
-	return 0, false
+	return tx.heapIndex, true
 }
 
 // RemoveTx removes a specific transaction from the priority queue.
@@ -443,7 +447,9 @@ func (pq *TxPriorityQueue) PeekTxs(max int) []*WrappedTx {
 //
 // NOTE: A caller should never call Push. Use PushTx instead.
 func (pq *TxPriorityQueue) Push(x interface{}) {
+	n := len(pq.txs)
 	item := x.(*WrappedTx)
+	item.heapIndex = n
 	pq.txs = append(pq.txs, item)
 }
 
@@ -454,7 +460,8 @@ func (pq *TxPriorityQueue) Pop() interface{} {
 	old := pq.txs
 	n := len(old)
 	item := old[n-1]
-	old[n-1] = nil // avoid memory leak
+	old[n-1] = nil      // avoid memory leak
+	item.heapIndex = -1 // for safety
 	pq.txs = old[0 : n-1]
 	return item
 }
@@ -483,4 +490,6 @@ func (pq *TxPriorityQueue) Less(i, j int) bool {
 // Swap implements the Heap interface. It swaps two transactions in the queue.
 func (pq *TxPriorityQueue) Swap(i, j int) {
 	pq.txs[i], pq.txs[j] = pq.txs[j], pq.txs[i]
+	pq.txs[i].heapIndex = i
+	pq.txs[j].heapIndex = j
 }

--- a/internal/mempool/priority_queue.go
+++ b/internal/mempool/priority_queue.go
@@ -462,8 +462,8 @@ func (pq *TxPriorityQueue) Pop() interface{} {
 	old := pq.txs
 	n := len(old)
 	item := old[n-1]
-	old[n-1] = nil      // avoid memory leak
-	item.heapIndex = -1 // for safety
+	old[n-1] = nil         // avoid memory leak
+	setHeapIndex(item, -1) // for safety
 	pq.txs = old[0 : n-1]
 	return item
 }
@@ -492,6 +492,14 @@ func (pq *TxPriorityQueue) Less(i, j int) bool {
 // Swap implements the Heap interface. It swaps two transactions in the queue.
 func (pq *TxPriorityQueue) Swap(i, j int) {
 	pq.txs[i], pq.txs[j] = pq.txs[j], pq.txs[i]
-	pq.txs[i].heapIndex = i
-	pq.txs[j].heapIndex = j
+	setHeapIndex(pq.txs[i], i)
+	setHeapIndex(pq.txs[j], j)
+}
+
+func setHeapIndex(tx *WrappedTx, i int) {
+	// a removed tx can be nil
+	if tx == nil {
+		return
+	}
+	tx.heapIndex = i
 }

--- a/internal/mempool/priority_queue.go
+++ b/internal/mempool/priority_queue.go
@@ -179,9 +179,11 @@ func (pq *TxPriorityQueue) removeQueuedEvmTxUnsafe(tx *WrappedTx) (removedIdx in
 
 func (pq *TxPriorityQueue) findTxIndexUnsafe(tx *WrappedTx) (int, bool) {
 	// safety check for race situation where heapIndex is out of range of txs
-	if tx.heapIndex >= 0 && tx.heapIndex < len(pq.txs) && pq.txs[tx.heapIndex].tx.Key() == tx.tx.Key() {
-		return tx.heapIndex, true
-	}
+
+	// commenting out to prove perf improvement
+	//if tx.heapIndex >= 0 && tx.heapIndex < len(pq.txs) && pq.txs[tx.heapIndex].tx.Key() == tx.tx.Key() {
+	//	return tx.heapIndex, true
+	//}
 
 	// heap index isn't trustable here, so attempt to find it
 	for i, t := range pq.txs {

--- a/internal/mempool/priority_queue.go
+++ b/internal/mempool/priority_queue.go
@@ -179,11 +179,9 @@ func (pq *TxPriorityQueue) removeQueuedEvmTxUnsafe(tx *WrappedTx) (removedIdx in
 
 func (pq *TxPriorityQueue) findTxIndexUnsafe(tx *WrappedTx) (int, bool) {
 	// safety check for race situation where heapIndex is out of range of txs
-
-	// commenting out to prove perf improvement
-	//if tx.heapIndex >= 0 && tx.heapIndex < len(pq.txs) && pq.txs[tx.heapIndex].tx.Key() == tx.tx.Key() {
-	//	return tx.heapIndex, true
-	//}
+	if tx.heapIndex >= 0 && tx.heapIndex < len(pq.txs) && pq.txs[tx.heapIndex].tx.Key() == tx.tx.Key() {
+		return tx.heapIndex, true
+	}
 
 	// heap index isn't trustable here, so attempt to find it
 	for i, t := range pq.txs {


### PR DESCRIPTION
## Describe your changes and provide context
- uses heapIndex 
- has safety check to try to mitigate that rare nil panic 
- includes locking adjustment from https://github.com/sei-protocol/sei-tendermint/pull/209

## Testing performed to validate your change
- load testing
- unit tests
