### PR TITLE
Pending Txs Update Insert Condition

### DIFF
--- a/internal/mempool/tx.go
+++ b/internal/mempool/tx.go
@@ -377,7 +377,7 @@ func (p *PendingTxs) Insert(tx *WrappedTx, resCheckTx *abci.ResponseCheckTxV2, t
 	p.mtx.Lock()
 	defer p.mtx.Unlock()
 
-	if len(p.txs) >= p.config.PendingSize && uint64(tx.Size())+p.sizeBytes > uint64(p.config.MaxPendingTxsBytes) {
+	if len(p.txs) >= p.config.PendingSize || uint64(tx.Size())+p.sizeBytes > uint64(p.config.MaxPendingTxsBytes) {
 		return errors.New("pending store is full")
 	}
 


### PR DESCRIPTION
## Describe your changes and provide context
- Updates Pending Txs insert condition to reject txs when `either` condition is met: max txs # is exceeded OR max bytes after adding in tx is exceeded
- Previously only rejected when both were true

## Testing performed to validate your change
- Added unit tests
- Testing on node
