### PR TITLE
Add metrics for mempool size changes

### DIFF
--- a/internal/mempool/mempool.go
+++ b/internal/mempool/mempool.go
@@ -889,6 +889,7 @@ func (txmp *TxMempool) insertTx(wtx *WrappedTx, updatePriorityIndex bool) bool {
 	gossipEl := txmp.gossipIndex.PushBack(wtx)
 	wtx.gossipEl = gossipEl
 
+	txmp.metrics.InsertedTxs.Add(1)
 	atomic.AddInt64(&txmp.sizeBytes, int64(wtx.Size()))
 	return true
 }
@@ -911,6 +912,7 @@ func (txmp *TxMempool) removeTx(wtx *WrappedTx, removeFromCache bool, shouldReen
 	txmp.gossipIndex.Remove(wtx.gossipEl)
 	wtx.gossipEl.DetachPrev()
 
+	txmp.metrics.RemovedTxs.Add(1)
 	atomic.AddInt64(&txmp.sizeBytes, int64(-wtx.Size()))
 
 	wtx.removeHandler(removeFromCache)

--- a/internal/mempool/metrics.gen.go
+++ b/internal/mempool/metrics.gen.go
@@ -64,6 +64,18 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 			Name:      "recheck_times",
 			Help:      "Number of times transactions are rechecked in the mempool.",
 		}, labels).With(labelsAndValues...),
+		RemovedTxs: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "removed_txs",
+			Help:      "Number of removed tx from mempool",
+		}, labels).With(labelsAndValues...),
+		InsertedTxs: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "inserted_txs",
+			Help:      "Number of txs inserted to mempool",
+		}, labels).With(labelsAndValues...),
 	}
 }
 
@@ -77,5 +89,7 @@ func NopMetrics() *Metrics {
 		EvictedTxs:   discard.NewCounter(),
 		ExpiredTxs:   discard.NewCounter(),
 		RecheckTimes: discard.NewCounter(),
+		RemovedTxs:   discard.NewCounter(),
+		InsertedTxs:  discard.NewCounter(),
 	}
 }

--- a/internal/mempool/metrics.go
+++ b/internal/mempool/metrics.go
@@ -49,4 +49,10 @@ type Metrics struct {
 
 	// Number of times transactions are rechecked in the mempool.
 	RecheckTimes metrics.Counter
+
+	// Number of removed tx from mempool
+	RemovedTxs metrics.Counter
+
+	// Number of txs inserted to mempool
+	InsertedTxs metrics.Counter
 }


### PR DESCRIPTION
## Describe your changes and provide context
This PR added two new metrics for tendermint mempool, which tracks number of txs inserted and removed from mempool
## Testing performed to validate your change

