### PR TITLE
Add request length check to json rpcs

### DIFF
--- a/rpc/jsonrpc/server/http_json_handler.go
+++ b/rpc/jsonrpc/server/http_json_handler.go
@@ -15,6 +15,8 @@ import (
 
 // HTTP + JSON handler
 
+const REQUEST_BATCH_SIZE_LIMIT = 10
+
 // jsonrpc calls grab the given method's function info and runs reflect.Call
 func makeJSONRPCHandler(funcMap map[string]*RPCFunc, logger log.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, hreq *http.Request) {
@@ -41,7 +43,7 @@ func makeJSONRPCHandler(funcMap map[string]*RPCFunc, logger log.Logger) http.Han
 		}
 
 		requests, err := parseRequests(b)
-		if len(requests) > 10 {
+		if len(requests) > REQUEST_BATCH_SIZE_LIMIT {
 			writeRPCResponse(w, logger, rpctypes.RPCRequest{}.MakeErrorf(
 				rpctypes.CodeParseError, "Batch size limit exceeded."))
 			return

--- a/rpc/jsonrpc/server/http_json_handler.go
+++ b/rpc/jsonrpc/server/http_json_handler.go
@@ -41,6 +41,11 @@ func makeJSONRPCHandler(funcMap map[string]*RPCFunc, logger log.Logger) http.Han
 		}
 
 		requests, err := parseRequests(b)
+		if len(requests) > 10 {
+			writeRPCResponse(w, logger, rpctypes.RPCRequest{}.MakeErrorf(
+				rpctypes.CodeParseError, "Batch size limit exceeded."))
+			return
+		}
 		if err != nil {
 			writeRPCResponse(w, logger, rpctypes.RPCRequest{}.MakeErrorf(
 				rpctypes.CodeParseError, "decoding request: %v", err))

--- a/rpc/jsonrpc/server/http_json_handler_test.go
+++ b/rpc/jsonrpc/server/http_json_handler_test.go
@@ -237,17 +237,17 @@ func TestRPCBatchLimit(t *testing.T) {
 		},
 		{
 			`[
-				{"jsonrpc": "2.0"},
-				{"jsonrpc": "2.0"},
-				{"jsonrpc": "2.0"},
-				{"jsonrpc": "2.0"},
-				{"jsonrpc": "2.0"},
-				{"jsonrpc": "2.0"},
-				{"jsonrpc": "2.0"},
-				{"jsonrpc": "2.0"},
-				{"jsonrpc": "2.0"},
-				{"jsonrpc": "2.0"},
-				{"jsonrpc": "2.0"}
+				{"jsonrpc": "2.0","method":"c","id":"abc","params":["a","10"]},
+				{"jsonrpc": "2.0","method":"c","id":"abc","params":["a","10"]},
+				{"jsonrpc": "2.0","method":"c","id":"abc","params":["a","10"]},
+				{"jsonrpc": "2.0","method":"c","id":"abc","params":["a","10"]},
+				{"jsonrpc": "2.0","method":"c","id":"abc","params":["a","10"]},
+				{"jsonrpc": "2.0","method":"c","id":"abc","params":["a","10"]},
+				{"jsonrpc": "2.0","method":"c","id":"abc","params":["a","10"]},
+				{"jsonrpc": "2.0","method":"c","id":"abc","params":["a","10"]},
+				{"jsonrpc": "2.0","method":"c","id":"abc","params":["a","10"]},
+				{"jsonrpc": "2.0","method":"c","id":"abc","params":["a","10"]},
+				{"jsonrpc": "2.0","method":"c","id":"abc","params":["a","10"]}
 			 ]`,
 			false,
 		},

--- a/rpc/jsonrpc/server/http_json_handler_test.go
+++ b/rpc/jsonrpc/server/http_json_handler_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -218,6 +219,67 @@ func TestRPCNotificationInBatch(t *testing.T) {
 		for _, response := range responses {
 			assert.NotEqual(t, response, new(rpctypes.RPCResponse), "#%d: not expecting a blank RPCResponse", i)
 		}
+	}
+}
+
+func TestRPCBatchLimit(t *testing.T) {
+	mux := testMux()
+	tests := []struct {
+		payload string
+		success bool
+	}{
+		{
+			`[
+				{"jsonrpc": "2.0","method":"c","id":"abc","params":["a","10"]},
+				{"jsonrpc": "2.0","method":"c","id":"abc","params":["a","10"]}
+			 ]`,
+			true,
+		},
+		{
+			`[
+				{"jsonrpc": "2.0"},
+				{"jsonrpc": "2.0"},
+				{"jsonrpc": "2.0"},
+				{"jsonrpc": "2.0"},
+				{"jsonrpc": "2.0"},
+				{"jsonrpc": "2.0"},
+				{"jsonrpc": "2.0"},
+				{"jsonrpc": "2.0"},
+				{"jsonrpc": "2.0"},
+				{"jsonrpc": "2.0"},
+				{"jsonrpc": "2.0"}
+			 ]`,
+			false,
+		},
+	}
+	for i, tt := range tests {
+		req, _ := http.NewRequest("POST", "http://localhost/", strings.NewReader(tt.payload))
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+		res := rec.Result()
+		// Always expecting back a JSONRPCResponse
+		assert.True(t, statusOK(res.StatusCode), "#%d: should always return 2XX", i)
+		blob, err := io.ReadAll(res.Body)
+
+		fmt.Printf("responses: %s\n", blob)
+		if err != nil {
+			t.Errorf("#%d: err reading body: %v", i, err)
+			continue
+		}
+		res.Body.Close()
+
+		var responses []rpctypes.RPCResponse
+		err = json.Unmarshal(blob, &responses)
+		if err != nil {
+			if tt.success {
+				t.Errorf("#%d: expected successful parsing of an RPCResponse\nblob: %s", i, blob)
+				continue
+			} else {
+				fmt.Printf("blob: %s, %d\n", responses, len(responses))
+				assert.Contains(t, string(blob), "Batch size limit exceeded.")
+			}
+		}
+
 	}
 }
 


### PR DESCRIPTION
## Describe your changes and provide context
We should limit the request of json rpc calls
## Testing performed to validate your change
- unit tests
- tested on remote node
