### PR TITLE
[EVM] Adjust locking for replacement

### DIFF
--- a/internal/mempool/mempool.go
+++ b/internal/mempool/mempool.go
@@ -665,15 +665,11 @@ func (txmp *TxMempool) addNewTransaction(wtx *WrappedTx, res *abci.ResponseCheck
 		txInfo.SenderID: {},
 	}
 
-	txmp.metrics.Size.Set(float64(txmp.SizeWithoutPending()))
-	txmp.metrics.PendingSize.Set(float64(txmp.PendingSize()))
-
 	if txmp.isInMempool(wtx.tx) {
 		return nil
 	}
 
 	if txmp.insertTx(wtx) {
-		txmp.metrics.TxSizeBytes.Observe(float64(wtx.Size()))
 		txmp.logger.Debug(
 			"inserted good transaction",
 			"priority", wtx.priority,
@@ -872,6 +868,10 @@ func (txmp *TxMempool) insertTx(wtx *WrappedTx) bool {
 	if !inserted {
 		return false
 	}
+	txmp.metrics.TxSizeBytes.Observe(float64(wtx.Size()))
+	txmp.metrics.Size.Set(float64(txmp.SizeWithoutPending()))
+	txmp.metrics.PendingSize.Set(float64(txmp.PendingSize()))
+
 	if replacedTx != nil {
 		txmp.removeTx(replacedTx, true, false, false)
 	}

--- a/internal/mempool/mempool.go
+++ b/internal/mempool/mempool.go
@@ -665,11 +665,15 @@ func (txmp *TxMempool) addNewTransaction(wtx *WrappedTx, res *abci.ResponseCheck
 		txInfo.SenderID: {},
 	}
 
+	txmp.metrics.Size.Set(float64(txmp.SizeWithoutPending()))
+	txmp.metrics.PendingSize.Set(float64(txmp.PendingSize()))
+
 	if txmp.isInMempool(wtx.tx) {
 		return nil
 	}
 
 	if txmp.insertTx(wtx) {
+		txmp.metrics.TxSizeBytes.Observe(float64(wtx.Size()))
 		txmp.logger.Debug(
 			"inserted good transaction",
 			"priority", wtx.priority,
@@ -679,10 +683,6 @@ func (txmp *TxMempool) addNewTransaction(wtx *WrappedTx, res *abci.ResponseCheck
 		)
 		txmp.notifyTxsAvailable()
 	}
-
-	txmp.metrics.TxSizeBytes.Observe(float64(wtx.Size()))
-	txmp.metrics.Size.Set(float64(txmp.SizeWithoutPending()))
-	txmp.metrics.PendingSize.Set(float64(txmp.PendingSize()))
 
 	return nil
 }

--- a/internal/mempool/reactor_test.go
+++ b/internal/mempool/reactor_test.go
@@ -167,7 +167,7 @@ func TestReactorBroadcastDoesNotPanic(t *testing.T) {
 	secondaryReactor.observePanic = observePanic
 
 	firstTx := &WrappedTx{}
-	primaryMempool.insertTx(firstTx, true)
+	primaryMempool.insertTx(firstTx)
 
 	// run the router
 	rts.start(ctx, t)
@@ -180,7 +180,7 @@ func TestReactorBroadcastDoesNotPanic(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			primaryMempool.insertTx(next, true)
+			primaryMempool.insertTx(next)
 		}()
 	}
 


### PR DESCRIPTION
## Describe your changes and provide context
- duplicate nonces cannot coexist in the queue now  (insert is now like an upsert)
- inserts to priority queue will now attempt replacement
- only update stats if the new transaction was inserted
- early bail if already in mempool (moved from insert logic out)

## Testing performed to validate your change
- unit tests
- lower env testing

