### PR TITLE
Remove tx from cache when canAddPendingTx fails

### DIFF
--- a/internal/mempool/mempool.go
+++ b/internal/mempool/mempool.go
@@ -337,6 +337,7 @@ func (txmp *TxMempool) CheckTx(
 			}
 			if err := txmp.canAddPendingTx(wtx); err != nil {
 				// TODO: eviction strategy for pending transactions
+				removeHandler(true)
 				return err
 			}
 			atomic.AddInt64(&txmp.pendingSizeBytes, int64(wtx.Size()))


### PR DESCRIPTION
## Describe your changes and provide context
When PendingTxs is full, canAddPendingTx fails [here](https://github.com/sei-protocol/sei-tendermint/blob/f4e9c14ffb9b10cbd3f2cd0c5b34df8f1882426f/internal/mempool/mempool.go#L338), and the [removeHandler](https://github.com/sei-protocol/sei-tendermint/blob/f4e9c14ffb9b10cbd3f2cd0c5b34df8f1882426f/internal/mempool/mempool.go#L301-L308) doesn’t execute. This behavior prevent the addition of identical transactions, as an tx already exists in cache error occurs [here](https://github.com/sei-protocol/sei-tendermint/blob/f4e9c14ffb9b10cbd3f2cd0c5b34df8f1882426f/internal/mempool/mempool.go#L292-L295).
## Testing performed to validate your change
Added unit test coverage

