### PR TITLE
[EVM] check removed including wrapped tx state

### DIFF
--- a/internal/mempool/mempool.go
+++ b/internal/mempool/mempool.go
@@ -736,7 +736,7 @@ func (txmp *TxMempool) handleRecheckResult(tx types.Tx, res *abci.ResponseCheckT
 	// Only evaluate transactions that have not been removed. This can happen
 	// if an existing transaction is evicted during CheckTx and while this
 	// callback is being executed for the same evicted transaction.
-	if !txmp.txStore.IsTxRemoved(wtx.hash) {
+	if !txmp.txStore.IsTxRemoved(wtx) {
 		var err error
 		if txmp.postCheck != nil {
 			err = txmp.postCheck(tx, res.ResponseCheckTx)
@@ -806,7 +806,7 @@ func (txmp *TxMempool) updateReCheckTxs(ctx context.Context) {
 
 		// Only execute CheckTx if the transaction is not marked as removed which
 		// could happen if the transaction was evicted.
-		if !txmp.txStore.IsTxRemoved(wtx.hash) {
+		if !txmp.txStore.IsTxRemoved(wtx) {
 			res, err := txmp.proxyAppConn.CheckTx(ctx, &abci.RequestCheckTx{
 				Tx:   wtx.tx,
 				Type: abci.CheckTxType_Recheck,
@@ -893,7 +893,7 @@ func (txmp *TxMempool) insertTx(wtx *WrappedTx) bool {
 }
 
 func (txmp *TxMempool) removeTx(wtx *WrappedTx, removeFromCache bool, shouldReenqueue bool, updatePriorityIndex bool) {
-	if txmp.txStore.IsTxRemoved(wtx.hash) {
+	if txmp.txStore.IsTxRemoved(wtx) {
 		return
 	}
 

--- a/internal/mempool/tx.go
+++ b/internal/mempool/tx.go
@@ -147,15 +147,22 @@ func (txs *TxStore) GetTxByHash(hash types.TxKey) *WrappedTx {
 
 // IsTxRemoved returns true if a transaction by hash is marked as removed and
 // false otherwise.
-func (txs *TxStore) IsTxRemoved(hash types.TxKey) bool {
+func (txs *TxStore) IsTxRemoved(wtx *WrappedTx) bool {
 	txs.mtx.RLock()
 	defer txs.mtx.RUnlock()
 
-	wtx, ok := txs.hashTxs[hash]
+	// if this instance has already been marked, return true
+	if wtx.removed == true {
+		return true
+	}
+
+	// otherwise if the same hash exists, return its state
+	wtx, ok := txs.hashTxs[wtx.hash]
 	if ok {
 		return wtx.removed
 	}
 
+	// otherwise we haven't seen this tx
 	return false
 }
 


### PR DESCRIPTION
## Describe your changes and provide context
- if a tx has been removed from the hashedTxs, then we need to consider its state to answer `is removed` 
## Testing performed to validate your change
- validating in atlantic-2

