### PR TITLE
Add metrics for total txs bytes in mempool

### DIFF
--- a/internal/mempool/metrics.gen.go
+++ b/internal/mempool/metrics.gen.go
@@ -26,13 +26,17 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 			Name:      "pending_size",
 			Help:      "Number of pending transactions in mempool",
 		}, labels).With(labelsAndValues...),
-		TxSizeBytes: prometheus.NewHistogramFrom(stdprometheus.HistogramOpts{
+		TxSizeBytes: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "tx_size_bytes",
-			Help:      "Histogram of transaction sizes in bytes.",
-
-			Buckets: stdprometheus.ExponentialBuckets(1, 3, 7),
+			Help:      "Accumulated transaction sizes in bytes.",
+		}, labels).With(labelsAndValues...),
+		TotalTxsSizeBytes: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "total_txs_size_bytes",
+			Help:      "Total current mempool uncommitted txs bytes",
 		}, labels).With(labelsAndValues...),
 		FailedTxs: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
 			Namespace: namespace,
@@ -81,15 +85,16 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 
 func NopMetrics() *Metrics {
 	return &Metrics{
-		Size:         discard.NewGauge(),
-		PendingSize:  discard.NewGauge(),
-		TxSizeBytes:  discard.NewHistogram(),
-		FailedTxs:    discard.NewCounter(),
-		RejectedTxs:  discard.NewCounter(),
-		EvictedTxs:   discard.NewCounter(),
-		ExpiredTxs:   discard.NewCounter(),
-		RecheckTimes: discard.NewCounter(),
-		RemovedTxs:   discard.NewCounter(),
-		InsertedTxs:  discard.NewCounter(),
+		Size:              discard.NewGauge(),
+		PendingSize:       discard.NewGauge(),
+		TxSizeBytes:       discard.NewCounter(),
+		TotalTxsSizeBytes: discard.NewGauge(),
+		FailedTxs:         discard.NewCounter(),
+		RejectedTxs:       discard.NewCounter(),
+		EvictedTxs:        discard.NewCounter(),
+		ExpiredTxs:        discard.NewCounter(),
+		RecheckTimes:      discard.NewCounter(),
+		RemovedTxs:        discard.NewCounter(),
+		InsertedTxs:       discard.NewCounter(),
 	}
 }

--- a/internal/mempool/metrics.go
+++ b/internal/mempool/metrics.go
@@ -21,8 +21,11 @@ type Metrics struct {
 	// Number of pending transactions in mempool
 	PendingSize metrics.Gauge
 
-	// Histogram of transaction sizes in bytes.
-	TxSizeBytes metrics.Histogram `metrics_buckettype:"exp" metrics_bucketsizes:"1,3,7"`
+	// Accumulated transaction sizes in bytes.
+	TxSizeBytes metrics.Counter
+
+	// Total current mempool uncommitted txs bytes
+	TotalTxsSizeBytes metrics.Gauge
 
 	// Number of failed transactions.
 	FailedTxs metrics.Counter


### PR DESCRIPTION
## Describe your changes and provide context
The current problem is that we are blind about what's the daily mempool total txs size in bytes, and we are not sure what would be a safe config value to set to limit the size of txs in mempool.

This PR address this concern by adding visibility to monitor total txs size in bytes in mempool.

## Testing performed to validate your change

