### PR TITLE
Make RPC timeout configurable

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -519,6 +519,9 @@ type RPCConfig struct {
 
 	// Lag threshold determines the threshold for whether the /lag_status endpoint returns OK or not
 	LagThreshold int64 `mapstructure:"lag-threshold"`
+
+	// Timeout for any read request
+	TimeoutRead time.Duration `mapstructure:"timeout-read"`
 }
 
 // DefaultRPCConfig returns a default configuration for the RPC server
@@ -547,6 +550,8 @@ func DefaultRPCConfig() *RPCConfig {
 		TLSCertFile:  "",
 		TLSKeyFile:   "",
 		LagThreshold: 300,
+
+		TimeoutRead: 10 * time.Second,
 	}
 }
 

--- a/config/toml.go
+++ b/config/toml.go
@@ -277,6 +277,9 @@ tls-key-file = "{{ .RPC.TLSKeyFile }}"
 # pprof listen address (https://golang.org/pkg/net/http/pprof)
 pprof-laddr = "{{ .RPC.PprofListenAddress }}"
 
+# timeout for any read request
+timeout-read = "{{ .RPC.TimeoutRead }}"
+
 #######################################################
 ###           P2P Configuration Options             ###
 #######################################################

--- a/internal/rpc/core/env.go
+++ b/internal/rpc/core/env.go
@@ -243,6 +243,10 @@ func (env *Environment) StartService(ctx context.Context, conf *config.Config) (
 		cfg.WriteTimeout = conf.RPC.TimeoutBroadcastTxCommit + 1*time.Second
 	}
 
+	if conf.RPC.TimeoutRead > 0 {
+		cfg.ReadTimeout = conf.RPC.TimeoutRead
+	}
+
 	// If the event log is enabled, subscribe to all events published to the
 	// event bus, and forward them to the event log.
 	if lg := env.EventLog; lg != nil {


### PR DESCRIPTION
## Describe your changes and provide context
Add a `TimeoutRead` config for RPC endpoints (read-only)

## Testing performed to validate your change


