### PR TITLE
Allow `-` in event query

### DIFF
--- a/internal/pubsub/query/syntax/scanner.go
+++ b/internal/pubsub/query/syntax/scanner.go
@@ -306,7 +306,7 @@ func (s *Scanner) invalid(ch rune) error {
 func isDigit(r rune) bool { return '0' <= r && r <= '9' }
 
 func isTagRune(r rune) bool {
-	return r == '.' || r == '_' || unicode.IsLetter(r) || unicode.IsDigit(r)
+	return r == '.' || r == '_' || r == '-' || unicode.IsLetter(r) || unicode.IsDigit(r)
 }
 
 func isTimeRune(r rune) bool {

--- a/internal/pubsub/query/syntax/syntax_test.go
+++ b/internal/pubsub/query/syntax/syntax_test.go
@@ -71,7 +71,6 @@ func TestScannerErrors(t *testing.T) {
 		input string
 	}{
 		{`'incomplete string`},
-		{`-23`},
 		{`&`},
 		{`DATE xyz-pdq`},
 		{`DATE xyzp-dq-zv`},
@@ -169,6 +168,8 @@ func TestParseValid(t *testing.T) {
 
 		{"hash='136E18F7E4C348B780CF873A0BF43922E5BAFA63'", true},
 		{"hash=136E18F7E4C348B780CF873A0BF43922E5BAFA63", false},
+
+		{"wasm-buy_now.collection_address='sei1y4ktds0hrkrwx86pmdpvy0nxxlycqzdhg5mh9vpsk4ra8f5sjxvsfkpzmu27'", true},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## Describe your changes and provide context
Some contracts define there event topic with `-` which is currently not queryable. This PR allows such keys to be queried.

## Testing performed to validate your change
local sei

