### PR TITLE
Add a new config to speed up block sync

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -643,6 +643,9 @@ type P2PConfig struct { //nolint: maligned
 	// Comma separated list of nodes to keep persistent connections to
 	PersistentPeers string `mapstructure:"persistent-peers"`
 
+	// Comma separated list of nodes for block sync only
+	BlockSyncPeers string `mapstructure:"blocksync-peers"`
+
 	// UPNP port forwarding
 	UPNP bool `mapstructure:"upnp"`
 
@@ -712,7 +715,7 @@ func DefaultP2PConfig() *P2PConfig {
 		RecvRate:                5120000, // 5 mB/s
 		PexReactor:              true,
 		AllowDuplicateIP:        false,
-		HandshakeTimeout:        20 * time.Second,
+		HandshakeTimeout:        5 * time.Second,
 		DialTimeout:             3 * time.Second,
 		TestDialFail:            false,
 		QueueType:               "simple-priority",

--- a/config/toml.go
+++ b/config/toml.go
@@ -306,6 +306,9 @@ bootstrap-peers = "{{ .P2P.BootstrapPeers }}"
 # Comma separated list of nodes to keep persistent connections to
 persistent-peers = "{{ .P2P.PersistentPeers }}"
 
+# Comma separated list of nodes for block sync only
+blocksync-peers = "{{ .P2P.BlockSyncPeers }}"
+
 # UPNP port forwarding
 upnp = {{ .P2P.UPNP }}
 

--- a/internal/blocksync/pool.go
+++ b/internal/blocksync/pool.go
@@ -31,9 +31,8 @@ eg, L = latency = 0.1s
 */
 
 const (
-	requestInterval           = 10 * time.Millisecond
-	inactiveSleepInterval     = 1 * time.Second
-	maxTotalRequesters        = 600
+	requestInterval           = 100 * time.Millisecond
+	maxTotalRequesters        = 50
 	maxPeerErrBuffer          = 1000
 	maxPendingRequests        = maxTotalRequesters
 	maxPendingRequestsPerPeer = 20
@@ -54,7 +53,7 @@ const (
 	BadBlock    RetryReason = "BadBlock"
 )
 
-var peerTimeout = 10 * time.Second // not const so we can override with tests
+var peerTimeout = 2 * time.Second // not const so we can override with tests
 
 /*
 	Peers self report their heights when we join the block pool.
@@ -356,6 +355,12 @@ func (pool *BlockPool) SetPeerRange(peerID types.NodeID, base int64, height int6
 	pool.mtx.Lock()
 	defer pool.mtx.Unlock()
 
+	blockSyncPeers := pool.peerManager.GetBlockSyncPeers()
+	if len(blockSyncPeers) > 0 && !blockSyncPeers[peerID] {
+		pool.logger.Info(fmt.Sprintf("Skip adding peer %s for blocksync based on config, current num of blocksync peers: %d", peerID, len(blockSyncPeers)))
+		return
+	}
+
 	peer := pool.peers[peerID]
 	if peer != nil {
 		peer.base = base
@@ -431,6 +436,7 @@ func (pool *BlockPool) getSortedPeers(peers map[types.NodeID]*bpPeer) []types.No
 	for peer := range peers {
 		sortedPeers = append(sortedPeers, peer)
 	}
+
 	// Sort from high to low score
 	sort.Slice(sortedPeers, func(i, j int) bool {
 		return pool.peerManager.Score(sortedPeers[i]) > pool.peerManager.Score(sortedPeers[j])

--- a/internal/blocksync/pool.go
+++ b/internal/blocksync/pool.go
@@ -357,7 +357,7 @@ func (pool *BlockPool) SetPeerRange(peerID types.NodeID, base int64, height int6
 
 	blockSyncPeers := pool.peerManager.GetBlockSyncPeers()
 	if len(blockSyncPeers) > 0 && !blockSyncPeers[peerID] {
-		pool.logger.Info(fmt.Sprintf("Skip adding peer %s for blocksync based on config, current num of blocksync peers: %d", peerID, len(blockSyncPeers)))
+		pool.logger.Info(fmt.Sprintf("Skip adding peer %s for blocksync, num of blocksync peers: %d, num of pool peers: %d", peerID, len(blockSyncPeers), len(pool.peers)))
 		return
 	}
 
@@ -375,7 +375,7 @@ func (pool *BlockPool) SetPeerRange(peerID types.NodeID, base int64, height int6
 			logger:     pool.logger.With("peer", peerID),
 			startAt:    time.Now(),
 		}
-
+		pool.logger.Info(fmt.Sprintf("Adding peer %s to blocksync pool", peerID))
 		pool.peers[peerID] = peer
 	}
 

--- a/internal/blocksync/reactor.go
+++ b/internal/blocksync/reactor.go
@@ -612,8 +612,7 @@ func (r *Reactor) poolRoutine(ctx context.Context, stateSynced bool, blockSyncCh
 				// See https://github.com/tendermint/tendermint/pull/8433#discussion_r866790631
 				panic(fmt.Errorf("peeked first block without extended commit at height %d - possible node store corruption", first.Height))
 			} else if first == nil || second == nil {
-				// we need to have fetched two consecutive blocks in order to
-				// perform blocksync verification
+				// we need to have fetched two consecutive blocks in order to perform blocksync verification
 				continue
 			}
 

--- a/internal/blocksync/reactor.go
+++ b/internal/blocksync/reactor.go
@@ -560,10 +560,11 @@ func (r *Reactor) poolRoutine(ctx context.Context, stateSynced bool, blockSyncCh
 				continue
 
 			case r.pool.IsCaughtUp() && r.previousMaxPeerHeight <= r.pool.MaxPeerHeight():
-				r.logger.Info("switching to consensus reactor", "height", height)
+				r.logger.Info("switching to consensus reactor after caught up", "height", height)
 
 			case time.Since(lastAdvance) > syncTimeout:
 				r.logger.Error("no progress since last advance", "last_advance", lastAdvance)
+				continue
 
 			default:
 				r.logger.Info(

--- a/node/setup.go
+++ b/node/setup.go
@@ -255,6 +255,16 @@ func createPeerManager(
 		peers = append(peers, address)
 	}
 
+	for _, p := range tmstrings.SplitAndTrimEmpty(cfg.P2P.BlockSyncPeers, ",", " ") {
+		address, err := p2p.ParseNodeAddress(p)
+		if err != nil {
+			return nil, func() error { return nil }, fmt.Errorf("invalid peer address %q: %w", p, err)
+		}
+
+		peers = append(peers, address)
+		options.BlockSyncPeers = append(options.PersistentPeers, address.NodeID)
+	}
+
 	for _, p := range tmstrings.SplitAndTrimEmpty(cfg.P2P.UnconditionalPeerIDs, ",", " ") {
 		options.UnconditionalPeers = append(options.UnconditionalPeers, types.NodeID(p))
 	}

--- a/node/setup.go
+++ b/node/setup.go
@@ -262,7 +262,7 @@ func createPeerManager(
 		}
 
 		peers = append(peers, address)
-		options.BlockSyncPeers = append(options.PersistentPeers, address.NodeID)
+		options.BlockSyncPeers = append(options.BlockSyncPeers, address.NodeID)
 	}
 
 	for _, p := range tmstrings.SplitAndTrimEmpty(cfg.P2P.UnconditionalPeerIDs, ",", " ") {


### PR DESCRIPTION
## Describe your changes and provide context
This PR speed up block sync and fix a few issues:
1. The bpr pending request number is too high, leading to overuse of network and possible gaps
2. The peer pickup logic is not great, so that it would have a high chance to pick a slow peer or not responding peer, leading to constant timeout
3. We should never switch to consensus mode if we are behind, we should stick to the catch up mode
## Testing performed to validate your change

