### PR TITLE
Fix handshake and dial timeout

### DIFF
--- a/internal/blocksync/pool.go
+++ b/internal/blocksync/pool.go
@@ -328,7 +328,7 @@ func (pool *BlockPool) AddBlock(peerID types.NodeID, block *types.Block, extComm
 			peer.decrPending(blockSize)
 		}
 	} else if setBlockResult < 0 {
-		err := errors.New("brp requester peer is different from original peer")
+		err := errors.New("bpr requester peer is different from original peer")
 		pool.sendError(err, peerID)
 		return fmt.Errorf("%w (peer: %s, requester: %s, block height: %d)", err, peerID, requester.getPeerID(), block.Height)
 	}
@@ -677,23 +677,20 @@ func (*bpRequester) OnStop() {}
 // Return 1 if block exist and peer matches.
 func (bpr *bpRequester) setBlock(block *types.Block, extCommit *types.ExtendedCommit, peerID types.NodeID) int {
 	bpr.mtx.Lock()
+	defer bpr.mtx.Unlock()
 	if bpr.block == nil {
 		bpr.block = block
 		if extCommit != nil {
 			bpr.extCommit = extCommit
 		}
-		bpr.mtx.Unlock()
-
 		select {
 		case bpr.gotBlockCh <- struct{}{}:
 		default:
 		}
 		return 0
 	} else if bpr.peerID == peerID {
-		bpr.mtx.Unlock()
 		return 1
 	}
-	bpr.mtx.Unlock()
 	return -1
 }
 

--- a/internal/blocksync/pool.go
+++ b/internal/blocksync/pool.go
@@ -320,14 +320,15 @@ func (pool *BlockPool) AddBlock(peerID types.NodeID, block *types.Block, extComm
 		return fmt.Errorf("peer sent us a block we didn't expect (peer: %s, current height: %d, block height: %d)", peerID, pool.height, block.Height)
 	}
 
-	if requester.setBlock(block, extCommit, peerID) {
+	setBlockResult := requester.setBlock(block, extCommit, peerID)
+	if setBlockResult == 0 {
 		atomic.AddInt32(&pool.numPending, -1)
 		peer := pool.peers[peerID]
 		if peer != nil {
 			peer.decrPending(blockSize)
 		}
-	} else {
-		err := errors.New("requester is different or block already exists")
+	} else if setBlockResult < 0 {
+		err := errors.New("brp requester peer is different from original peer")
 		pool.sendError(err, peerID)
 		return fmt.Errorf("%w (peer: %s, requester: %s, block height: %d)", err, peerID, requester.getPeerID(), block.Height)
 	}
@@ -671,24 +672,29 @@ func (bpr *bpRequester) OnStart(ctx context.Context) error {
 
 func (*bpRequester) OnStop() {}
 
-// Returns true if the peer matches and block doesn't already exist.
-func (bpr *bpRequester) setBlock(block *types.Block, extCommit *types.ExtendedCommit, peerID types.NodeID) bool {
+// Returns 0 if block doesn't already exist.
+// Returns -1 if block exist but peers doesn't match.
+// Return 1 if block exist and peer matches.
+func (bpr *bpRequester) setBlock(block *types.Block, extCommit *types.ExtendedCommit, peerID types.NodeID) int {
 	bpr.mtx.Lock()
-	if bpr.block != nil || bpr.peerID != peerID {
+	if bpr.block == nil {
+		bpr.block = block
+		if extCommit != nil {
+			bpr.extCommit = extCommit
+		}
 		bpr.mtx.Unlock()
-		return false
-	}
-	bpr.block = block
-	if extCommit != nil {
-		bpr.extCommit = extCommit
+
+		select {
+		case bpr.gotBlockCh <- struct{}{}:
+		default:
+		}
+		return 0
+	} else if bpr.peerID == peerID {
+		bpr.mtx.Unlock()
+		return 1
 	}
 	bpr.mtx.Unlock()
-
-	select {
-	case bpr.gotBlockCh <- struct{}{}:
-	default:
-	}
-	return true
+	return -1
 }
 
 func (bpr *bpRequester) getBlock() *types.Block {

--- a/internal/p2p/peermanager.go
+++ b/internal/p2p/peermanager.go
@@ -553,7 +553,7 @@ func (m *PeerManager) TryDialNext() (NodeAddress, error) {
 
 			// We now have an eligible address to dial. If we're full but have
 			// upgrade capacity (as checked above), we find a lower-scored peer
-			// we can replace and mark it as upgrading so noone else claims it.
+			// we can replace and mark it as upgrading so no one else claims it.
 			//
 			// If we don't find one, there is no point in trying additional
 			// peers, since they will all have the same or lower score than this
@@ -567,6 +567,7 @@ func (m *PeerManager) TryDialNext() (NodeAddress, error) {
 			}
 
 			m.dialing[peer.ID] = true
+			m.logger.Info(fmt.Sprintf("Going to dial peer %s with address %s", peer.ID, addressInfo.Address))
 			return addressInfo.Address, nil
 		}
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -808,7 +808,10 @@ func loadStateFromDBOrGenesisDocProvider(stateStore sm.Store, genDoc *types.Gene
 
 func getRouterConfig(conf *config.Config, appClient abciclient.Client) p2p.RouterOptions {
 	opts := p2p.RouterOptions{
-		QueueType: conf.P2P.QueueType,
+		QueueType:        conf.P2P.QueueType,
+		DialTimeout:      conf.P2P.DialTimeout,
+		HandshakeTimeout: conf.P2P.HandshakeTimeout,
+		ResolveTimeout:   conf.P2P.HandshakeTimeout,
 	}
 
 	if conf.FilterPeers && appClient != nil {


### PR DESCRIPTION
## Describe your changes and provide context
Sometimes a peer could end up having multiple different IP addresses in the network, some IP are stale, this will cause dial always fail and got stuck. Currently the dial and handshake timeout is not passed in correctly, leading to the fact that the timeout is infinite. So we should enable dial timeout to fix this issue.

## Testing performed to validate your change

