### PR TITLE
Rollback should not cause missing validatorset

### DIFF
--- a/cmd/tendermint/commands/rollback.go
+++ b/cmd/tendermint/commands/rollback.go
@@ -51,15 +51,6 @@ func RollbackState(config *config.Config, removeBlock bool) (int64, []byte, erro
 	if err != nil {
 		return -1, nil, err
 	}
-	currentHeight := blockStore.Height()
-	currentState, _ := stateStore.Load()
-	fmt.Printf("Current blockStore height=%d statestore height=%d hash=%X\n", currentHeight, currentState.LastBlockHeight, blockStore.LoadSeenCommit().Hash())
-	lastValSet, err := stateStore.LoadValidators(currentHeight - 1)
-	if err != nil {
-		panic(fmt.Errorf("[Debug] Not able to load validator set at height %d: %v", currentHeight-1, err))
-	} else {
-		fmt.Printf("Validator set for height=%d has size of %d\n", currentHeight-1, len(lastValSet.Validators))
-	}
 
 	defer func() {
 		_ = blockStore.Close()

--- a/cmd/tendermint/commands/rollback.go
+++ b/cmd/tendermint/commands/rollback.go
@@ -2,11 +2,11 @@ package commands
 
 import (
 	"fmt"
-	"github.com/tendermint/tendermint/internal/state"
 
 	"github.com/spf13/cobra"
 
 	"github.com/tendermint/tendermint/config"
+	"github.com/tendermint/tendermint/internal/state"
 )
 
 var removeBlock bool = false

--- a/cmd/tendermint/commands/rollback.go
+++ b/cmd/tendermint/commands/rollback.go
@@ -48,9 +48,16 @@ application.
 func RollbackState(config *config.Config, removeBlock bool) (int64, []byte, error) {
 	// use the parsed config to load the block and state store
 	blockStore, stateStore, err := loadStateAndBlockStore(config)
-	fmt.Printf("Current blockStore height=%d hash=%X\n", blockStore.Height(), blockStore.LoadSeenCommit().Hash())
 	if err != nil {
 		return -1, nil, err
+	}
+	currentHeight := blockStore.Height()
+	fmt.Printf("Current blockStore height=%d hash=%X\n", currentHeight, blockStore.LoadSeenCommit().Hash())
+	lastValSet, err := stateStore.LoadValidators(currentHeight - 1)
+	if err != nil {
+		panic(fmt.Errorf("[Debug] Not able to load validator set at height %d: %w", currentHeight-1, err))
+	} else {
+		fmt.Printf("Validator set for height=%d has size of %d\n", currentHeight-1, len(lastValSet.Validators))
 	}
 
 	defer func() {

--- a/cmd/tendermint/commands/rollback.go
+++ b/cmd/tendermint/commands/rollback.go
@@ -2,11 +2,11 @@ package commands
 
 import (
 	"fmt"
+	"github.com/tendermint/tendermint/internal/state"
 
 	"github.com/spf13/cobra"
 
 	"github.com/tendermint/tendermint/config"
-	"github.com/tendermint/tendermint/internal/state"
 )
 
 var removeBlock bool = false
@@ -52,10 +52,11 @@ func RollbackState(config *config.Config, removeBlock bool) (int64, []byte, erro
 		return -1, nil, err
 	}
 	currentHeight := blockStore.Height()
-	fmt.Printf("Current blockStore height=%d hash=%X\n", currentHeight, blockStore.LoadSeenCommit().Hash())
+	currentState, _ := stateStore.Load()
+	fmt.Printf("Current blockStore height=%d statestore height=%d hash=%X\n", currentHeight, currentState.LastBlockHeight, blockStore.LoadSeenCommit().Hash())
 	lastValSet, err := stateStore.LoadValidators(currentHeight - 1)
 	if err != nil {
-		panic(fmt.Errorf("[Debug] Not able to load validator set at height %d: %w", currentHeight-1, err))
+		panic(fmt.Errorf("[Debug] Not able to load validator set at height %d: %v", currentHeight-1, err))
 	} else {
 		fmt.Printf("Validator set for height=%d has size of %d\n", currentHeight-1, len(lastValSet.Validators))
 	}

--- a/internal/state/rollback.go
+++ b/internal/state/rollback.go
@@ -77,6 +77,7 @@ func Rollback(bs BlockStore, ss Store, removeBlock bool, privValidatorConfig *co
 	}
 
 	valChangeHeight := latestState.LastHeightValidatorsChanged
+	fmt.Printf("valChangeHeight is %d, rollbackHeight is %d\n", valChangeHeight, rollbackHeight)
 	// this can only happen if the validator set changed since the last block
 	if valChangeHeight > rollbackHeight {
 		valChangeHeight = rollbackHeight + 1

--- a/internal/state/rollback.go
+++ b/internal/state/rollback.go
@@ -71,13 +71,6 @@ func Rollback(bs BlockStore, ss Store, removeBlock bool, privValidatorConfig *co
 		return -1, nil, fmt.Errorf("block at height %d not found", latestState.LastBlockHeight)
 	}
 
-	previousLastValidatorSet, err := ss.LoadValidators(rollbackHeight)
-	if err != nil {
-		return -1, nil, err
-	} else {
-		fmt.Printf("Validatorset for height=%d has size of %d\n", rollbackHeight, len(previousLastValidatorSet.Validators))
-	}
-
 	previousParams, err := ss.LoadConsensusParams(rollbackHeight + 1)
 	if err != nil {
 		return -1, nil, err
@@ -87,6 +80,20 @@ func Rollback(bs BlockStore, ss Store, removeBlock bool, privValidatorConfig *co
 	// this can only happen if the validator set changed since the last block
 	if valChangeHeight > rollbackHeight {
 		valChangeHeight = rollbackHeight + 1
+	}
+
+	// Verify it has validator set data
+	previousLastValidatorSet, err := ss.LoadValidators(rollbackHeight)
+	if err != nil {
+		return -1, nil, err
+	}
+	previousLastValidatorSet, err = ss.LoadValidators(rollbackHeight - 1)
+	if err != nil {
+		return -1, nil, err
+	}
+	previousLastValidatorSet, err = ss.LoadValidators(rollbackHeight + 1)
+	if err != nil {
+		return -1, nil, err
 	}
 
 	paramsChangeHeight := latestState.LastHeightConsensusParamsChanged

--- a/internal/state/rollback.go
+++ b/internal/state/rollback.go
@@ -45,10 +45,8 @@ func Rollback(bs BlockStore, ss Store, removeBlock bool, privValidatorConfig *co
 	// pending block before continuing.
 	if latestBlockHeight == latestStateHeight+1 {
 		fmt.Printf("Invalid state in the latest block height=%d, removing it first \n", latestBlockHeight)
-		if removeBlock {
-			if err := bs.DeleteLatestBlock(); err != nil {
-				return -1, nil, fmt.Errorf("failed to remove final block from blockstore: %w", err)
-			}
+		if err := bs.DeleteLatestBlock(); err != nil {
+			return -1, nil, fmt.Errorf("failed to remove final block from blockstore: %w", err)
 		}
 		return latestState.LastBlockHeight, latestState.AppHash, nil
 	}

--- a/internal/state/rollback.go
+++ b/internal/state/rollback.go
@@ -38,7 +38,7 @@ func Rollback(bs BlockStore, ss Store, removeBlock bool, privValidatorConfig *co
 
 	latestBlockHeight := bs.Height()
 	latestStateHeight := latestState.LastBlockHeight
-	fmt.Printf("Current blockStore height=%d tendermint state height=%d blockHash=%X appHash=%X lastResultHash=%X\n", latestBlockHeight, latestStateHeight, bs.LoadSeenCommit().Hash(), latestState.AppHash, latestState.LastResultsHash)
+	fmt.Printf("Current blockStore height=%d tendermint state height=%d appHash=%X lastResultHash=%X\n", latestBlockHeight, latestStateHeight, latestState.AppHash, latestState.LastResultsHash)
 
 	// NOTE: persistence of state and blocks don't happen atomically. Therefore it is possible that
 	// when the user stopped the node the state wasn't updated but the blockstore was. Discard the

--- a/internal/state/rollback.go
+++ b/internal/state/rollback.go
@@ -77,11 +77,14 @@ func Rollback(bs BlockStore, ss Store, removeBlock bool, privValidatorConfig *co
 	}
 
 	valChangeHeight := latestState.LastHeightValidatorsChanged
-	fmt.Printf("valChangeHeight is %d, rollbackHeight is %d\n", valChangeHeight, rollbackHeight)
-	// this can only happen if the validator set changed since the last block
 	if valChangeHeight > rollbackHeight {
-		valChangeHeight = rollbackHeight + 1
+		valInfo, err := ss.(dbStore).LoadValidatorsInfo(rollbackHeight)
+		if err != nil {
+			return -1, nil, err
+		}
+		valChangeHeight = valInfo.LastHeightChanged
 	}
+	fmt.Printf("valChangeHeight is %d, rollbackHeight is %d\n", valChangeHeight, rollbackHeight)
 
 	// Verify it has validator set data
 	previousLastValidatorSet, err := ss.LoadValidators(rollbackHeight)

--- a/internal/state/rollback.go
+++ b/internal/state/rollback.go
@@ -84,14 +84,9 @@ func Rollback(bs BlockStore, ss Store, removeBlock bool, privValidatorConfig *co
 		}
 		valChangeHeight = valInfo.LastHeightChanged
 	}
-	fmt.Printf("valChangeHeight is %d, rollbackHeight is %d\n", valChangeHeight, rollbackHeight)
 
 	// Verify it has validator set data
 	previousLastValidatorSet, err := ss.LoadValidators(rollbackHeight)
-	if err != nil {
-		return -1, nil, err
-	}
-	previousLastValidatorSet, err = ss.LoadValidators(rollbackHeight - 1)
 	if err != nil {
 		return -1, nil, err
 	}

--- a/internal/state/rollback.go
+++ b/internal/state/rollback.go
@@ -85,7 +85,6 @@ func Rollback(bs BlockStore, ss Store, removeBlock bool, privValidatorConfig *co
 		valChangeHeight = valInfo.LastHeightChanged
 	}
 
-	// Verify it has validator set data
 	previousLastValidatorSet, err := ss.LoadValidators(rollbackHeight)
 	if err != nil {
 		return -1, nil, err

--- a/internal/state/rollback.go
+++ b/internal/state/rollback.go
@@ -92,10 +92,6 @@ func Rollback(bs BlockStore, ss Store, removeBlock bool, privValidatorConfig *co
 	if err != nil {
 		return -1, nil, err
 	}
-	previousLastValidatorSet, err = ss.LoadValidators(rollbackHeight + 1)
-	if err != nil {
-		return -1, nil, err
-	}
 
 	paramsChangeHeight := latestState.LastHeightConsensusParamsChanged
 	// this can only happen if params changed from the last block

--- a/internal/state/rollback_test.go
+++ b/internal/state/rollback_test.go
@@ -149,7 +149,7 @@ func setupStateStore(t *testing.T, height int64) state.Store {
 		LastValidators:                   valSet,
 		Validators:                       valSet.CopyIncrementProposerPriority(1),
 		NextValidators:                   valSet.CopyIncrementProposerPriority(2),
-		LastHeightValidatorsChanged:      height + 1,
+		LastHeightValidatorsChanged:      height,
 		ConsensusParams:                  *params,
 		LastHeightConsensusParamsChanged: height + 1,
 	}

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -173,6 +173,7 @@ func (store dbStore) save(state State, key []byte) error {
 		}
 	}
 	// Save next validators.
+	fmt.Printf("[Debug] saveValidatorsInfo nextHeight+1=%d, LastHeightValidatorsChanged=%d, NextValidatorsSize=%d\n", nextHeight+1, state.LastHeightValidatorsChanged, len(state.NextValidators.Validators))
 	err := store.saveValidatorsInfo(nextHeight+1, state.LastHeightValidatorsChanged, state.NextValidators, batch)
 	if err != nil {
 		return err

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -173,7 +173,6 @@ func (store dbStore) save(state State, key []byte) error {
 		}
 	}
 	// Save next validators.
-	fmt.Printf("[Debug] saveValidatorsInfo nextHeight+1=%d, LastHeightValidatorsChanged=%d, NextValidatorsSize=%d\n", nextHeight+1, state.LastHeightValidatorsChanged, len(state.NextValidators.Validators))
 	err := store.saveValidatorsInfo(nextHeight+1, state.LastHeightValidatorsChanged, state.NextValidators, batch)
 	if err != nil {
 		return err
@@ -512,7 +511,6 @@ func (store dbStore) LoadValidators(height int64) (*types.ValidatorSet, error) {
 	if err != nil {
 		return nil, ErrNoValSetForHeight{Height: height, Err: err}
 	}
-	fmt.Printf("[Debug] LoadValidators for height %d with LastHeightChanged %d\n", height, valInfo.LastHeightChanged)
 	if valInfo.ValidatorSet == nil {
 		lastStoredHeight := lastStoredHeightFor(height, valInfo.LastHeightChanged)
 		valInfo2, err := loadValidatorsInfo(store.db, lastStoredHeight)

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -508,11 +508,11 @@ func (store dbStore) SaveValidatorSets(lowerHeight, upperHeight int64, vals *typ
 // LoadValidators loads the ValidatorSet for a given height.
 // Returns ErrNoValSetForHeight if the validator set can't be found for this height.
 func (store dbStore) LoadValidators(height int64) (*types.ValidatorSet, error) {
-
 	valInfo, err := loadValidatorsInfo(store.db, height)
 	if err != nil {
 		return nil, ErrNoValSetForHeight{Height: height, Err: err}
 	}
+	fmt.Printf("[Debug] LoadValidators for height %d with LastHeightChanged %d\n", height, valInfo.LastHeightChanged)
 	if valInfo.ValidatorSet == nil {
 		lastStoredHeight := lastStoredHeightFor(height, valInfo.LastHeightChanged)
 		valInfo2, err := loadValidatorsInfo(store.db, lastStoredHeight)

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -557,6 +557,14 @@ func lastStoredHeightFor(height, lastHeightChanged int64) int64 {
 	return tmmath.MaxInt64(checkpointHeight, lastHeightChanged)
 }
 
+func (store dbStore) LoadValidatorsInfo(height int64) (*tmstate.ValidatorsInfo, error) {
+	valInfo, err := loadValidatorsInfo(store.db, height)
+	if err != nil {
+		return nil, ErrNoValSetForHeight{Height: height, Err: err}
+	}
+	return valInfo, nil
+}
+
 // CONTRACT: Returned ValidatorsInfo can be mutated.
 func loadValidatorsInfo(db dbm.DB, height int64) (*tmstate.ValidatorsInfo, error) {
 	buf, err := db.Get(validatorsKey(height))


### PR DESCRIPTION
## Describe your changes and provide context
Problem:
Currently there's a bug in rollback logic, where after rollback, the node could sometimes run into this error:
```
Dec 04 15:54:59 ip-172-31-26-246 seid[234375]: panic: failed to load validator set at height 118546578: couldn't find validators at height 118546577 (height 118546578 was originally requested): %!w(<nil>)
Dec 04 15:54:59 ip-172-31-26-246 seid[234375]: goroutine 967 [running]:
Dec 04 15:54:59 ip-172-31-26-246 seid[234375]: github.com/tendermint/tendermint/internal/state.buildLastCommitInfo(0xc0683e21c0, {0x3824a58?, 0xc01f8f2ff0?}, 0x11?)
Dec 04 15:54:59 ip-172-31-26-246 seid[234375]:         /root/go/pkg/mod/github.com/sei-protocol/sei-tendermint@v0.4.3/internal/state/execution.go:500 +0x44e
Dec 04 15:54:59 ip-172-31-26-246 seid[234375]: github.com/tendermint/tendermint/internal/state.(*BlockExecutor).ApplyBlock(_, {_, _}, {{{0xb, 0x0}, {0xc019faff98, 0x11}}, {0xc05de3f4a0, 0x9}, 0x1, ...}, ...)
Dec 04 15:54:59 ip-172-31-26-246 seid[234375]:         /root/go/pkg/mod/github.com/sei-protocol/sei-tendermint@v0.4.3/internal/state/execution.go:257 +0x4e5
Dec 04 15:54:59 ip-172-31-26-246 seid[234375]: github.com/tendermint/tendermint/internal/blocksync.(*Reactor).poolRoutine(0xc05c9cd080, {0x3811f68?, 0xc000053770}, 0x0, 0xc05de5e600?)
Dec 04 15:54:59 ip-172-31-26-246 seid[234375]:         /root/go/pkg/mod/github.com/sei-protocol/sei-tendermint@v0.4.3/internal/blocksync/reactor.go:705 +0x16f8
Dec 04 15:54:59 ip-172-31-26-246 seid[234375]: created by github.com/tendermint/tendermint/internal/blocksync.(*Reactor).OnStart in goroutine 1
Dec 04 15:54:59 ip-172-31-26-246 seid[234375]:         /root/go/pkg/mod/github.com/sei-protocol/sei-tendermint@v0.4.3/internal/blocksync/reactor.go:181 +0x5fd
```

Root cause:
ValidatorSet data are not stored on every height, it was stored only when things get changed, or every interval (100k). So the root cause is that the rollback could sometimes fill LastHeightValidatorsChanged with the wrong value. The correct logic should be to use the previous block's value of LastHeightValidatorsChanged, however in some cases it will simply just set it to be rollbackHeight + 1, which could lead to not able to find the correct validator set data. 

Solution:
In order to fix it, the correct way is when rollback, we need to query previous block's LastHeightValidatorsChanged and assign that as the rolled back state.

## Testing performed to validate your change
Tested in archive node