### PR TITLE
Add utils to get RequestBeginBlock

### DIFF
--- a/utils/slice.go
+++ b/utils/slice.go
@@ -1,0 +1,9 @@
+package utils
+
+func Map[I any, O any](input []I, lambda func(i I) O) []O {
+	res := []O{}
+	for _, i := range input {
+		res = append(res, lambda(i))
+	}
+	return res
+}


### PR DESCRIPTION
## Describe your changes and provide context
Add helper function to turn a `types.Block` into an `abci.RequestBeginBlock`

## Testing performed to validate your change
unit test

