### PR TITLE
Exclude nil tx from tx search results

### DIFF
--- a/internal/state/indexer/tx/kv/kv.go
+++ b/internal/state/indexer/tx/kv/kv.go
@@ -224,7 +224,9 @@ hashes:
 		if err != nil {
 			return nil, fmt.Errorf("failed to get Tx{%X}: %w", h, err)
 		}
-		results = append(results, res)
+		if res != nil {
+			results = append(results, res)
+		}
 
 		// Potentially exit early.
 		select {


### PR DESCRIPTION
## Describe your changes and provide context
For some unknown reason (still needs investigation) empty bytes can be returned from tx kv store. This would cause a nil pointer panic when returning for tx search endpoints.

## Testing performed to validate your change
tested on archive node

