### PR TITLE
Make missing txs check atomic

### DIFF
--- a/internal/consensus/replay_stubs.go
+++ b/internal/consensus/replay_stubs.go
@@ -24,6 +24,10 @@ func (m emptyMempool) GetTxsForKeys(txKeys []types.TxKey) types.Txs {
 	return types.Txs{}
 }
 
+func (m emptyMempool) SafeGetTxsForKeys(txKeys []types.TxKey) (types.Txs, []types.TxKey) {
+	return types.Txs{}, []types.TxKey{}
+}
+
 var _ mempool.Mempool = emptyMempool{}
 
 func (emptyMempool) TxStore() *mempool.TxStore { return nil }

--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -2502,13 +2502,12 @@ func (cs *State) tryCreateProposalBlock(ctx context.Context, height int64, round
 // Build a proposal block from mempool txs. If cs.config.GossipTransactionKeyOnly=true
 // proposals only contain txKeys so we rebuild the block using mempool txs
 func (cs *State) buildProposalBlock(height int64, header types.Header, lastCommit *types.Commit, evidence []types.Evidence, proposerAddress types.Address, txKeys []types.TxKey) *types.Block {
-	missingTxs := cs.blockExec.GetMissingTxs(txKeys)
+	txs, missingTxs := cs.blockExec.SafeGetTxsByKeys(txKeys)
 	if len(missingTxs) > 0 {
 		cs.metrics.ProposalMissingTxs.Set(float64(len(missingTxs)))
 		cs.logger.Debug("Missing txs when trying to build block", "missing_txs", cs.blockExec.GetMissingTxs(txKeys))
 		return nil
 	}
-	txs := cs.blockExec.GetTxsForKeys(txKeys)
 	block := cs.state.MakeBlock(height, cs.blockExec.GetTxsForKeys(txKeys), lastCommit, evidence, proposerAddress)
 	block.Version = header.Version
 	block.Data.Txs = txs

--- a/internal/mempool/mempool.go
+++ b/internal/mempool/mempool.go
@@ -405,6 +405,23 @@ func (txmp *TxMempool) GetTxsForKeys(txKeys []types.TxKey) types.Txs {
 	return txs
 }
 
+func (txmp *TxMempool) SafeGetTxsForKeys(txKeys []types.TxKey) (types.Txs, []types.TxKey) {
+	txmp.mtx.RLock()
+	defer txmp.mtx.RUnlock()
+
+	txs := make([]types.Tx, 0, len(txKeys))
+	missing := []types.TxKey{}
+	for _, txKey := range txKeys {
+		wtx := txmp.txStore.GetTxByHash(txKey)
+		if wtx == nil {
+			missing = append(missing, txKey)
+			continue
+		}
+		txs = append(txs, wtx.tx)
+	}
+	return txs, missing
+}
+
 // Flush empties the mempool. It acquires a read-lock, fetches all the
 // transactions currently in the transaction store and removes each transaction
 // from the store and all indexes and finally resets the cache.

--- a/internal/mempool/mocks/mempool.go
+++ b/internal/mempool/mocks/mempool.go
@@ -108,13 +108,17 @@ func (_m *Mempool) Lock() {
 	_m.Called()
 }
 
-// ReapMaxBytesMaxGas provides a mock function with given fields: maxBytes, maxGas
-func (_m *Mempool) ReapMaxBytesMaxGas(maxBytes int64, maxGasWanted int64, maxGas int64, minTxsInBlock int64) types.Txs {
-	ret := _m.Called(maxBytes, maxGas)
+// ReapMaxBytesMaxGas provides a mock function with given fields: maxBytes, maxGas, maxGasEstimated, minTxsInBlock
+func (_m *Mempool) ReapMaxBytesMaxGas(maxBytes int64, maxGas int64, maxGasEstimated int64, minTxsInBlock int64) types.Txs {
+	ret := _m.Called(maxBytes, maxGas, maxGasEstimated, minTxsInBlock)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ReapMaxBytesMaxGas")
+	}
 
 	var r0 types.Txs
-	if rf, ok := ret.Get(0).(func(int64, int64, int64) types.Txs); ok {
-		r0 = rf(maxBytes, maxGas, minTxsInBlock)
+	if rf, ok := ret.Get(0).(func(int64, int64, int64, int64) types.Txs); ok {
+		r0 = rf(maxBytes, maxGas, maxGasEstimated, minTxsInBlock)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(types.Txs)

--- a/internal/mempool/mocks/mempool.go
+++ b/internal/mempool/mocks/mempool.go
@@ -23,6 +23,10 @@ type Mempool struct {
 func (_m *Mempool) CheckTx(ctx context.Context, tx types.Tx, callback func(*abcitypes.ResponseCheckTx), txInfo mempool.TxInfo) error {
 	ret := _m.Called(ctx, tx, callback, txInfo)
 
+	if len(ret) == 0 {
+		panic("no return value specified for CheckTx")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, types.Tx, func(*abcitypes.ResponseCheckTx), mempool.TxInfo) error); ok {
 		r0 = rf(ctx, tx, callback, txInfo)
@@ -33,12 +37,12 @@ func (_m *Mempool) CheckTx(ctx context.Context, tx types.Tx, callback func(*abci
 	return r0
 }
 
-// EnableTxsAvailable provides a mock function with given fields:
+// EnableTxsAvailable provides a mock function with no fields
 func (_m *Mempool) EnableTxsAvailable() {
 	_m.Called()
 }
 
-// Flush provides a mock function with given fields:
+// Flush provides a mock function with no fields
 func (_m *Mempool) Flush() {
 	_m.Called()
 }
@@ -46,6 +50,10 @@ func (_m *Mempool) Flush() {
 // FlushAppConn provides a mock function with given fields: _a0
 func (_m *Mempool) FlushAppConn(_a0 context.Context) error {
 	ret := _m.Called(_a0)
+
+	if len(ret) == 0 {
+		panic("no return value specified for FlushAppConn")
+	}
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context) error); ok {
@@ -60,6 +68,10 @@ func (_m *Mempool) FlushAppConn(_a0 context.Context) error {
 // GetTxsForKeys provides a mock function with given fields: txKeys
 func (_m *Mempool) GetTxsForKeys(txKeys []types.TxKey) types.Txs {
 	ret := _m.Called(txKeys)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetTxsForKeys")
+	}
 
 	var r0 types.Txs
 	if rf, ok := ret.Get(0).(func([]types.TxKey) types.Txs); ok {
@@ -77,6 +89,10 @@ func (_m *Mempool) GetTxsForKeys(txKeys []types.TxKey) types.Txs {
 func (_m *Mempool) HasTx(txKey types.TxKey) bool {
 	ret := _m.Called(txKey)
 
+	if len(ret) == 0 {
+		panic("no return value specified for HasTx")
+	}
+
 	var r0 bool
 	if rf, ok := ret.Get(0).(func(types.TxKey) bool); ok {
 		r0 = rf(txKey)
@@ -87,7 +103,7 @@ func (_m *Mempool) HasTx(txKey types.TxKey) bool {
 	return r0
 }
 
-// Lock provides a mock function with given fields:
+// Lock provides a mock function with no fields
 func (_m *Mempool) Lock() {
 	_m.Called()
 }
@@ -97,8 +113,8 @@ func (_m *Mempool) ReapMaxBytesMaxGas(maxBytes int64, maxGasWanted int64, maxGas
 	ret := _m.Called(maxBytes, maxGas)
 
 	var r0 types.Txs
-	if rf, ok := ret.Get(0).(func(int64, int64) types.Txs); ok {
-		r0 = rf(maxBytes, maxGas)
+	if rf, ok := ret.Get(0).(func(int64, int64, int64) types.Txs); ok {
+		r0 = rf(maxBytes, maxGas, minTxsInBlock)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(types.Txs)
@@ -111,6 +127,10 @@ func (_m *Mempool) ReapMaxBytesMaxGas(maxBytes int64, maxGasWanted int64, maxGas
 // ReapMaxTxs provides a mock function with given fields: max
 func (_m *Mempool) ReapMaxTxs(max int) types.Txs {
 	ret := _m.Called(max)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ReapMaxTxs")
+	}
 
 	var r0 types.Txs
 	if rf, ok := ret.Get(0).(func(int) types.Txs); ok {
@@ -128,6 +148,10 @@ func (_m *Mempool) ReapMaxTxs(max int) types.Txs {
 func (_m *Mempool) RemoveTxByKey(txKey types.TxKey) error {
 	ret := _m.Called(txKey)
 
+	if len(ret) == 0 {
+		panic("no return value specified for RemoveTxByKey")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(types.TxKey) error); ok {
 		r0 = rf(txKey)
@@ -138,9 +162,45 @@ func (_m *Mempool) RemoveTxByKey(txKey types.TxKey) error {
 	return r0
 }
 
-// Size provides a mock function with given fields:
+// SafeGetTxsForKeys provides a mock function with given fields: txKeys
+func (_m *Mempool) SafeGetTxsForKeys(txKeys []types.TxKey) (types.Txs, []types.TxKey) {
+	ret := _m.Called(txKeys)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SafeGetTxsForKeys")
+	}
+
+	var r0 types.Txs
+	var r1 []types.TxKey
+	if rf, ok := ret.Get(0).(func([]types.TxKey) (types.Txs, []types.TxKey)); ok {
+		return rf(txKeys)
+	}
+	if rf, ok := ret.Get(0).(func([]types.TxKey) types.Txs); ok {
+		r0 = rf(txKeys)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(types.Txs)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func([]types.TxKey) []types.TxKey); ok {
+		r1 = rf(txKeys)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).([]types.TxKey)
+		}
+	}
+
+	return r0, r1
+}
+
+// Size provides a mock function with no fields
 func (_m *Mempool) Size() int {
 	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for Size")
+	}
 
 	var r0 int
 	if rf, ok := ret.Get(0).(func() int); ok {
@@ -152,9 +212,13 @@ func (_m *Mempool) Size() int {
 	return r0
 }
 
-// SizeBytes provides a mock function with given fields:
+// SizeBytes provides a mock function with no fields
 func (_m *Mempool) SizeBytes() int64 {
 	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for SizeBytes")
+	}
 
 	var r0 int64
 	if rf, ok := ret.Get(0).(func() int64); ok {
@@ -166,9 +230,13 @@ func (_m *Mempool) SizeBytes() int64 {
 	return r0
 }
 
-// TxStore provides a mock function with given fields:
+// TxStore provides a mock function with no fields
 func (_m *Mempool) TxStore() *mempool.TxStore {
 	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for TxStore")
+	}
 
 	var r0 *mempool.TxStore
 	if rf, ok := ret.Get(0).(func() *mempool.TxStore); ok {
@@ -182,9 +250,13 @@ func (_m *Mempool) TxStore() *mempool.TxStore {
 	return r0
 }
 
-// TxsAvailable provides a mock function with given fields:
+// TxsAvailable provides a mock function with no fields
 func (_m *Mempool) TxsAvailable() <-chan struct{} {
 	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for TxsAvailable")
+	}
 
 	var r0 <-chan struct{}
 	if rf, ok := ret.Get(0).(func() <-chan struct{}); ok {
@@ -198,7 +270,7 @@ func (_m *Mempool) TxsAvailable() <-chan struct{} {
 	return r0
 }
 
-// Unlock provides a mock function with given fields:
+// Unlock provides a mock function with no fields
 func (_m *Mempool) Unlock() {
 	_m.Called()
 }
@@ -206,6 +278,10 @@ func (_m *Mempool) Unlock() {
 // Update provides a mock function with given fields: ctx, blockHeight, blockTxs, txResults, newPreFn, newPostFn, recheck
 func (_m *Mempool) Update(ctx context.Context, blockHeight int64, blockTxs types.Txs, txResults []*abcitypes.ExecTxResult, newPreFn mempool.PreCheckFunc, newPostFn mempool.PostCheckFunc, recheck bool) error {
 	ret := _m.Called(ctx, blockHeight, blockTxs, txResults, newPreFn, newPostFn, recheck)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Update")
+	}
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, int64, types.Txs, []*abcitypes.ExecTxResult, mempool.PreCheckFunc, mempool.PostCheckFunc, bool) error); ok {
@@ -217,13 +293,12 @@ func (_m *Mempool) Update(ctx context.Context, blockHeight int64, blockTxs types
 	return r0
 }
 
-type mockConstructorTestingTNewMempool interface {
+// NewMempool creates a new instance of Mempool. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
+// The first argument is typically a *testing.T value.
+func NewMempool(t interface {
 	mock.TestingT
 	Cleanup(func())
-}
-
-// NewMempool creates a new instance of Mempool. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewMempool(t mockConstructorTestingTNewMempool) *Mempool {
+}) *Mempool {
 	mock := &Mempool{}
 	mock.Mock.Test(t)
 

--- a/internal/mempool/types.go
+++ b/internal/mempool/types.go
@@ -42,6 +42,10 @@ type Mempool interface {
 
 	GetTxsForKeys(txKeys []types.TxKey) types.Txs
 
+	// Similar to GetTxsForKeys except that it would return a list
+	// indicating missing keys.
+	SafeGetTxsForKeys(txKeys []types.TxKey) (types.Txs, []types.TxKey)
+
 	// ReapMaxBytesMaxGas reaps transactions from the mempool up to maxBytes
 	// bytes total with the condition that the total gasWanted must be less than
 	// maxGas and that the total estimated gas used is less than maxGasEstimated.

--- a/internal/state/execution.go
+++ b/internal/state/execution.go
@@ -477,6 +477,10 @@ func (blockExec *BlockExecutor) GetMissingTxs(txKeys []types.TxKey) []types.TxKe
 	return missingTxKeys
 }
 
+func (blockExec *BlockExecutor) SafeGetTxsByKeys(txKeys []types.TxKey) (types.Txs, []types.TxKey) {
+	return blockExec.mempool.SafeGetTxsForKeys(txKeys)
+}
+
 func (blockExec *BlockExecutor) CheckTxFromPeerProposal(ctx context.Context, tx types.Tx) {
 	// Ignore errors from CheckTx because there could be benign errors due to the same tx being
 	// inserted into the mempool from gossiping. Since such simultaneous insertion could result in

--- a/internal/state/execution_test.go
+++ b/internal/state/execution_test.go
@@ -531,7 +531,7 @@ func TestFinalizeBlockValidatorUpdates(t *testing.T) {
 		mock.Anything,
 		mock.Anything,
 		mock.Anything).Return(nil)
-	mp.On("ReapMaxBytesMaxGas", mock.Anything, mock.Anything).Return(types.Txs{})
+	mp.On("ReapMaxBytesMaxGas", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(types.Txs{})
 	mp.On("TxStore").Return(nil)
 
 	eventBus := eventbus.NewDefault(logger)
@@ -669,7 +669,7 @@ func TestEmptyPrepareProposal(t *testing.T) {
 		mock.Anything,
 		mock.Anything,
 		mock.Anything).Return(nil)
-	mp.On("ReapMaxBytesMaxGas", mock.Anything, mock.Anything).Return(types.Txs{})
+	mp.On("ReapMaxBytesMaxGas", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(types.Txs{})
 	mp.On("TxStore").Return(nil)
 
 	blockExec := sm.NewBlockExecutor(
@@ -708,7 +708,7 @@ func TestPrepareProposalErrorOnNonExistingRemoved(t *testing.T) {
 	evpool.On("PendingEvidence", mock.Anything).Return([]types.Evidence{}, int64(0))
 
 	mp := &mpmocks.Mempool{}
-	mp.On("ReapMaxBytesMaxGas", mock.Anything, mock.Anything).Return(types.Txs{})
+	mp.On("ReapMaxBytesMaxGas", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(types.Txs{})
 
 	app := abcimocks.NewApplication(t)
 
@@ -766,7 +766,7 @@ func TestPrepareProposalReorderTxs(t *testing.T) {
 
 	txs := factory.MakeNTxs(height, 10)
 	mp := &mpmocks.Mempool{}
-	mp.On("ReapMaxBytesMaxGas", mock.Anything, mock.Anything).Return(types.Txs(txs))
+	mp.On("ReapMaxBytesMaxGas", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(types.Txs(txs))
 
 	trs := txsToTxRecords(types.Txs(txs))
 	trs = trs[2:]
@@ -828,7 +828,7 @@ func TestPrepareProposalErrorOnTooManyTxs(t *testing.T) {
 	maxDataBytes := types.MaxDataBytes(state.ConsensusParams.Block.MaxBytes, 0, nValidators)
 	txs := factory.MakeNTxs(height, maxDataBytes/bytesPerTx+2) // +2 so that tx don't fit
 	mp := &mpmocks.Mempool{}
-	mp.On("ReapMaxBytesMaxGas", mock.Anything, mock.Anything).Return(types.Txs(txs))
+	mp.On("ReapMaxBytesMaxGas", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(types.Txs(txs))
 
 	trs := txsToTxRecords(types.Txs(txs))
 
@@ -880,7 +880,7 @@ func TestPrepareProposalErrorOnPrepareProposalError(t *testing.T) {
 
 	txs := factory.MakeNTxs(height, 10)
 	mp := &mpmocks.Mempool{}
-	mp.On("ReapMaxBytesMaxGas", mock.Anything, mock.Anything).Return(types.Txs(txs))
+	mp.On("ReapMaxBytesMaxGas", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(types.Txs(txs))
 
 	cm := &abciclientmocks.Client{}
 	cm.On("IsRunning").Return(true)
@@ -984,7 +984,7 @@ func TestCreateProposalAbsentVoteExtensions(t *testing.T) {
 				mock.Anything,
 				mock.Anything,
 				mock.Anything).Return(nil)
-			mp.On("ReapMaxBytesMaxGas", mock.Anything, mock.Anything).Return(types.Txs{})
+			mp.On("ReapMaxBytesMaxGas", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(types.Txs{})
 
 			blockExec := sm.NewBlockExecutor(
 				stateStore,


### PR DESCRIPTION
## Describe your changes and provide context
Previously it's possible for txs in mempool to be evicted during the window between missing txs check and txs retrieval. This PR makes missing txs check and txs retrieval happening under the same mutex section.

## Testing performed to validate your change
no functional change. existing unit test

