### PR TITLE
Use txs from SafeGetTxsByKeys

### DIFF
--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -2508,7 +2508,7 @@ func (cs *State) buildProposalBlock(height int64, header types.Header, lastCommi
 		cs.logger.Debug("Missing txs when trying to build block", "missing_txs", cs.blockExec.GetMissingTxs(txKeys))
 		return nil
 	}
-	block := cs.state.MakeBlock(height, cs.blockExec.GetTxsForKeys(txKeys), lastCommit, evidence, proposerAddress)
+	block := cs.state.MakeBlock(height, txs, lastCommit, evidence, proposerAddress)
 	block.Version = header.Version
 	block.Data.Txs = txs
 	block.DataHash = block.Data.Hash(true)


### PR DESCRIPTION
## Describe your changes and provide context
This is a patch to https://github.com/sei-protocol/sei-tendermint/pull/269 which made missing txs check atomic with tx retrieval but didn't use the atomically retrieved txs to make blocks.

## Testing performed to validate your change
unit test
