### PR TITLE
Deprecate MinTxsPerBlock

### DIFF
--- a/internal/consensus/mempool_test.go
+++ b/internal/consensus/mempool_test.go
@@ -230,7 +230,7 @@ func TestMempoolRmBadTx(t *testing.T) {
 
 		// check for the tx
 		for {
-			txs := assertMempool(t, cs.txNotifier).ReapMaxBytesMaxGas(int64(len(txBytes)), -1, -1, 0)
+			txs := assertMempool(t, cs.txNotifier).ReapMaxBytesMaxGas(int64(len(txBytes)), -1, -1)
 			if len(txs) == 0 {
 				emptyMempoolCh <- struct{}{}
 				return

--- a/internal/consensus/replay_stubs.go
+++ b/internal/consensus/replay_stubs.go
@@ -37,9 +37,9 @@ func (emptyMempool) Size() int                 { return 0 }
 func (emptyMempool) CheckTx(context.Context, types.Tx, func(*abci.ResponseCheckTx), mempool.TxInfo) error {
 	return nil
 }
-func (emptyMempool) RemoveTxByKey(txKey types.TxKey) error         { return nil }
-func (emptyMempool) ReapMaxBytesMaxGas(_, _, _, _ int64) types.Txs { return types.Txs{} }
-func (emptyMempool) ReapMaxTxs(n int) types.Txs                    { return types.Txs{} }
+func (emptyMempool) RemoveTxByKey(txKey types.TxKey) error      { return nil }
+func (emptyMempool) ReapMaxBytesMaxGas(_, _, _ int64) types.Txs { return types.Txs{} }
+func (emptyMempool) ReapMaxTxs(n int) types.Txs                 { return types.Txs{} }
 func (emptyMempool) Update(
 	_ context.Context,
 	_ int64,

--- a/internal/mempool/mempool.go
+++ b/internal/mempool/mempool.go
@@ -491,6 +491,10 @@ func (txmp *TxMempool) ReapMaxBytesMaxGas(maxBytes, maxGasWanted, maxGasEstimate
 		gasEstimated := totalGasEstimated + txGasEstimate
 		maxGasWantedExceeded := maxGasWanted > -1 && gasWanted > maxGasWanted
 		maxGasEstimatedExceeded := maxGasEstimated > -1 && gasEstimated > maxGasEstimated
+		if wtx.gasWanted > 0 {
+			nonzeroGasTxCnt++
+		}
+
 		if nonzeroGasTxCnt >= minTxsInBlock && (maxGasWantedExceeded || maxGasEstimatedExceeded) {
 			return false
 		}
@@ -499,9 +503,6 @@ func (txmp *TxMempool) ReapMaxBytesMaxGas(maxBytes, maxGasWanted, maxGasEstimate
 		totalGasEstimated = gasEstimated
 
 		txs = append(txs, wtx.tx)
-		if wtx.gasWanted > 0 {
-			nonzeroGasTxCnt++
-		}
 		return true
 	})
 

--- a/internal/mempool/mempool.go
+++ b/internal/mempool/mempool.go
@@ -455,7 +455,7 @@ func (txmp *TxMempool) Flush() {
 // NOTE:
 //   - Transactions returned are not removed from the mempool transaction
 //     store or indexes.
-func (txmp *TxMempool) ReapMaxBytesMaxGas(maxBytes, maxGasWanted, maxGasEstimated, minTxsInBlock int64) types.Txs {
+func (txmp *TxMempool) ReapMaxBytesMaxGas(maxBytes, maxGasWanted, maxGasEstimated int64) types.Txs {
 	txmp.mtx.Lock()
 	defer txmp.mtx.Unlock()
 
@@ -463,7 +463,6 @@ func (txmp *TxMempool) ReapMaxBytesMaxGas(maxBytes, maxGasWanted, maxGasEstimate
 		totalGasWanted    int64
 		totalGasEstimated int64
 		totalSize         int64
-		nonzeroGasTxCnt   int64
 	)
 
 	var txs []types.Tx
@@ -491,11 +490,8 @@ func (txmp *TxMempool) ReapMaxBytesMaxGas(maxBytes, maxGasWanted, maxGasEstimate
 		gasEstimated := totalGasEstimated + txGasEstimate
 		maxGasWantedExceeded := maxGasWanted > -1 && gasWanted > maxGasWanted
 		maxGasEstimatedExceeded := maxGasEstimated > -1 && gasEstimated > maxGasEstimated
-		if wtx.gasWanted > 0 {
-			nonzeroGasTxCnt++
-		}
 
-		if nonzeroGasTxCnt >= minTxsInBlock && (maxGasWantedExceeded || maxGasEstimatedExceeded) {
+		if maxGasWantedExceeded || maxGasEstimatedExceeded {
 			return false
 		}
 

--- a/internal/mempool/mempool_test.go
+++ b/internal/mempool/mempool_test.go
@@ -406,7 +406,7 @@ func TestTxMempool_ReapMaxBytesMaxGas(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		reapedTxs := txmp.ReapMaxBytesMaxGas(-1, 50, -1, 0)
+		reapedTxs := txmp.ReapMaxBytesMaxGas(-1, 50, -1)
 		ensurePrioritized(reapedTxs)
 		require.Equal(t, len(tTxs), txmp.Size())
 		require.Equal(t, int64(5690), txmp.SizeBytes())
@@ -417,7 +417,7 @@ func TestTxMempool_ReapMaxBytesMaxGas(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		reapedTxs := txmp.ReapMaxBytesMaxGas(1000, -1, -1, 0)
+		reapedTxs := txmp.ReapMaxBytesMaxGas(1000, -1, -1)
 		ensurePrioritized(reapedTxs)
 		require.Equal(t, len(tTxs), txmp.Size())
 		require.Equal(t, int64(5690), txmp.SizeBytes())
@@ -429,7 +429,7 @@ func TestTxMempool_ReapMaxBytesMaxGas(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		reapedTxs := txmp.ReapMaxBytesMaxGas(1500, 30, -1, 0)
+		reapedTxs := txmp.ReapMaxBytesMaxGas(1500, 30, -1)
 		ensurePrioritized(reapedTxs)
 		require.Equal(t, len(tTxs), txmp.Size())
 		require.Equal(t, int64(5690), txmp.SizeBytes())
@@ -440,7 +440,7 @@ func TestTxMempool_ReapMaxBytesMaxGas(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		reapedTxs := txmp.ReapMaxBytesMaxGas(-1, 2, -1, 2)
+		reapedTxs := txmp.ReapMaxBytesMaxGas(-1, 2, -1)
 		ensurePrioritized(reapedTxs)
 		require.Equal(t, len(tTxs), txmp.Size())
 		require.Len(t, reapedTxs, 2)
@@ -450,29 +450,7 @@ func TestTxMempool_ReapMaxBytesMaxGas(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		reapedTxs := txmp.ReapMaxBytesMaxGas(-1, -1, 50, 0)
-		ensurePrioritized(reapedTxs)
-		require.Equal(t, len(tTxs), txmp.Size())
-		require.Len(t, reapedTxs, 50)
-	}()
-
-	// Test that minTxsPerBlock is still used even when max gas esimated is exceeded
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		// pull minTxsPerBlock even though max gas wanted is hit
-		reapedTxs := txmp.ReapMaxBytesMaxGas(-1, -1, 50, 50)
-		ensurePrioritized(reapedTxs)
-		require.Equal(t, len(tTxs), txmp.Size())
-		require.Len(t, reapedTxs, 50)
-	}()
-
-	// Test that minTxsPerBlock is still used even when max gas wanted is exceeded
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		// pull minTxsPerBlock even though max gas wanted is hit
-		reapedTxs := txmp.ReapMaxBytesMaxGas(-1, 50, -1, 50)
+		reapedTxs := txmp.ReapMaxBytesMaxGas(-1, -1, 50)
 		ensurePrioritized(reapedTxs)
 		require.Equal(t, len(tTxs), txmp.Size())
 		require.Len(t, reapedTxs, 50)
@@ -521,7 +499,7 @@ func TestTxMempool_ReapMaxBytesMaxGas_FallbackToGasWanted(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		reapedTxs := txmp.ReapMaxBytesMaxGas(-1, -1, 50, 0)
+		reapedTxs := txmp.ReapMaxBytesMaxGas(-1, -1, 50)
 		ensurePrioritized(reapedTxs)
 		require.Equal(t, len(tTxs), txmp.Size())
 		require.Len(t, reapedTxs, 50)

--- a/internal/mempool/mempool_test.go
+++ b/internal/mempool/mempool_test.go
@@ -440,7 +440,7 @@ func TestTxMempool_ReapMaxBytesMaxGas(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		reapedTxs := txmp.ReapMaxBytesMaxGas(-1, 1, -1, 2)
+		reapedTxs := txmp.ReapMaxBytesMaxGas(-1, 2, -1, 2)
 		ensurePrioritized(reapedTxs)
 		require.Equal(t, len(tTxs), txmp.Size())
 		require.Len(t, reapedTxs, 2)
@@ -461,10 +461,10 @@ func TestTxMempool_ReapMaxBytesMaxGas(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		// pull minTxsPerBlock even though max gas wanted is hit
-		reapedTxs := txmp.ReapMaxBytesMaxGas(-1, -1, 50, 51)
+		reapedTxs := txmp.ReapMaxBytesMaxGas(-1, -1, 50, 50)
 		ensurePrioritized(reapedTxs)
 		require.Equal(t, len(tTxs), txmp.Size())
-		require.Len(t, reapedTxs, 51)
+		require.Len(t, reapedTxs, 50)
 	}()
 
 	// Test that minTxsPerBlock is still used even when max gas wanted is exceeded
@@ -472,10 +472,10 @@ func TestTxMempool_ReapMaxBytesMaxGas(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		// pull minTxsPerBlock even though max gas wanted is hit
-		reapedTxs := txmp.ReapMaxBytesMaxGas(-1, 50, -1, 51)
+		reapedTxs := txmp.ReapMaxBytesMaxGas(-1, 50, -1, 50)
 		ensurePrioritized(reapedTxs)
 		require.Equal(t, len(tTxs), txmp.Size())
-		require.Len(t, reapedTxs, 51)
+		require.Len(t, reapedTxs, 50)
 	}()
 
 	wg.Wait()

--- a/internal/mempool/mocks/mempool.go
+++ b/internal/mempool/mocks/mempool.go
@@ -108,17 +108,17 @@ func (_m *Mempool) Lock() {
 	_m.Called()
 }
 
-// ReapMaxBytesMaxGas provides a mock function with given fields: maxBytes, maxGas, maxGasEstimated, minTxsInBlock
-func (_m *Mempool) ReapMaxBytesMaxGas(maxBytes int64, maxGas int64, maxGasEstimated int64, minTxsInBlock int64) types.Txs {
-	ret := _m.Called(maxBytes, maxGas, maxGasEstimated, minTxsInBlock)
+// ReapMaxBytesMaxGas provides a mock function with given fields: maxBytes, maxGas, maxGasEstimated
+func (_m *Mempool) ReapMaxBytesMaxGas(maxBytes int64, maxGas int64, maxGasEstimated int64) types.Txs {
+	ret := _m.Called(maxBytes, maxGas, maxGasEstimated)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ReapMaxBytesMaxGas")
 	}
 
 	var r0 types.Txs
-	if rf, ok := ret.Get(0).(func(int64, int64, int64, int64) types.Txs); ok {
-		r0 = rf(maxBytes, maxGas, maxGasEstimated, minTxsInBlock)
+	if rf, ok := ret.Get(0).(func(int64, int64, int64) types.Txs); ok {
+		r0 = rf(maxBytes, maxGas, maxGasEstimated)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(types.Txs)

--- a/internal/mempool/types.go
+++ b/internal/mempool/types.go
@@ -52,7 +52,7 @@ type Mempool interface {
 	//
 	// If all 3 maxes are negative, there is no cap on the size of all returned
 	// transactions (~ all available transactions).
-	ReapMaxBytesMaxGas(maxBytes, maxGas, maxGasEstimated, minTxsInBlock int64) types.Txs
+	ReapMaxBytesMaxGas(maxBytes, maxGas, maxGasEstimated int64) types.Txs
 
 	// ReapMaxTxs reaps up to max transactions from the mempool. If max is
 	// negative, there is no cap on the size of all returned transactions

--- a/internal/state/execution.go
+++ b/internal/state/execution.go
@@ -102,7 +102,7 @@ func (blockExec *BlockExecutor) CreateProposalBlock(
 	// Fetch a limited amount of valid txs
 	maxDataBytes := types.MaxDataBytes(maxBytes, evSize, state.Validators.Size())
 
-	txs := blockExec.mempool.ReapMaxBytesMaxGas(maxDataBytes, maxGasWanted, maxGas, state.ConsensusParams.Block.MinTxsInBlock)
+	txs := blockExec.mempool.ReapMaxBytesMaxGas(maxDataBytes, maxGasWanted, maxGas)
 	commit := lastExtCommit.ToCommit()
 	block := state.MakeBlock(height, txs, commit, evidence, proposerAddr)
 	rpp, err := blockExec.appClient.PrepareProposal(

--- a/types/params.go
+++ b/types/params.go
@@ -59,7 +59,7 @@ type HashedParams struct {
 type BlockParams struct {
 	MaxBytes      int64 `json:"max_bytes,string"`
 	MaxGas        int64 `json:"max_gas,string"`
-	MinTxsInBlock int64 `json:"min_txs_in_block,string"`
+	MinTxsInBlock int64 `json:"min_txs_in_block,string"` // deprecated
 	MaxGasWanted  int64 `json:"max_gas_wanted,string"`
 }
 


### PR DESCRIPTION
## Describe your changes and provide context

We will rely on EVM tx simulation for estimated gas used as well as the hard block gas limit. If we want to use MinTxsPerBlock, we also need to account for it in `checkTotalBlockGas`. 

## Testing performed to validate your change
existing tests

