### PR TITLE
Purge expired txs from mempool cleanly

### DIFF
--- a/internal/mempool/mempool.go
+++ b/internal/mempool/mempool.go
@@ -1059,7 +1059,7 @@ func (txmp *TxMempool) purgeExpiredTxs(blockHeight int64) {
 	}
 
 	for _, wtx := range expiredTxs {
-		txmp.expire(blockHeight, wtx)
+		txmp.removeTx(wtx, !txmp.config.KeepInvalidTxsInCache, false, true)
 	}
 
 	// remove pending txs that have expired

--- a/internal/mempool/mempool_test.go
+++ b/internal/mempool/mempool_test.go
@@ -1073,3 +1073,28 @@ func TestAppendCheckTxErr(t *testing.T) {
 
 	require.Equal(t, newLogData, actualResult)
 }
+
+func TestMempoolExpiration(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	client := abciclient.NewLocalClient(log.NewNopLogger(), &application{Application: kvstore.NewApplication()})
+	if err := client.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(client.Wait)
+
+	txmp := setup(t, client, 0)
+	txmp.config.TTLDuration = time.Nanosecond // we want tx to expire immediately
+	txs := checkTxs(ctx, t, txmp, 100, 0)
+	require.Equal(t, len(txs), txmp.priorityIndex.Len())
+	require.Equal(t, len(txs), txmp.heightIndex.Size())
+	require.Equal(t, len(txs), txmp.timestampIndex.Size())
+	require.Equal(t, len(txs), txmp.txStore.Size())
+	time.Sleep(time.Millisecond)
+	txmp.purgeExpiredTxs(txmp.height)
+	require.Equal(t, 0, txmp.priorityIndex.Len())
+	require.Equal(t, 0, txmp.heightIndex.Size())
+	require.Equal(t, 0, txmp.timestampIndex.Size())
+	require.Equal(t, 0, txmp.txStore.Size())
+}


### PR DESCRIPTION
## Describe your changes and provide context
The purge logic appears to be accidentally removed in https://github.com/sei-protocol/sei-tendermint/pull/198/files#diff-9598ef5393ed91774956377627a7b21bc52184e435f287d67b80a9075dbad2b6R931

## Testing performed to validate your change
unit test

