### PR TITLE
Consider non-existing PartSet as incomplete

### DIFF
--- a/types/part_set.go
+++ b/types/part_set.go
@@ -319,6 +319,9 @@ func (ps *PartSet) GetPart(index int) *Part {
 }
 
 func (ps *PartSet) IsComplete() bool {
+	if ps == nil {
+		return false
+	}
 	return ps.count == ps.total
 }
 

--- a/types/part_set_test.go
+++ b/types/part_set_test.go
@@ -16,6 +16,8 @@ const (
 )
 
 func TestBasicPartSet(t *testing.T) {
+
+	assert.False(t, (*PartSet)(nil).IsComplete())
 	// Construct random data of size partSize * 100
 	nParts := 100
 	data := tmrand.Bytes(testPartSize * nParts)


### PR DESCRIPTION
Add checks to assert that a non-existing PartSet is considered to be incomplete.
