### PR TITLE
more granular buckets for consensus histograms

### DIFF
--- a/abci/client/doc.go
+++ b/abci/client/doc.go
@@ -1,9 +1,9 @@
 // Package abciclient provides an ABCI implementation in Go.
 //
 // There are 3 clients available:
-//		1. socket (unix or TCP)
-//		2. local (in memory)
-//		3. gRPC
+//  1. socket (unix or TCP)
+//  2. local (in memory)
+//  3. gRPC
 //
 // ## Socket client
 //
@@ -12,7 +12,7 @@
 //
 // ## Local client
 //
-// The global mutex is locked during each call
+// # The global mutex is locked during each call
 //
 // ## gRPC client
 //

--- a/abci/server/server.go
+++ b/abci/server/server.go
@@ -2,9 +2,8 @@
 Package server is used to start a new ABCI server.
 
 It contains two server implementation:
- * gRPC server
- * socket server
-
+  - gRPC server
+  - socket server
 */
 package server
 

--- a/crypto/doc.go
+++ b/crypto/doc.go
@@ -33,7 +33,6 @@
 
 // We also provide hashing wrappers around algorithms:
 
-
 package crypto
 
 // TODO: Add more docs in here

--- a/crypto/merkle/doc.go
+++ b/crypto/merkle/doc.go
@@ -12,20 +12,19 @@ second pre-image attacks. Hence, use this library with caution.
 Otherwise you might run into similar issues as, e.g., in early Bitcoin:
 https://bitcointalk.org/?topic=102395
 
-                        *
-                       / \
-                     /     \
-                   /         \
-                 /             \
-                *               *
-               / \             / \
-              /   \           /   \
-             /     \         /     \
-            *       *       *       h6
-           / \     / \     / \
-          h0  h1  h2  h3  h4  h5
+	              *
+	             / \
+	           /     \
+	         /         \
+	       /             \
+	      *               *
+	     / \             / \
+	    /   \           /   \
+	   /     \         /     \
+	  *       *       *       h6
+	 / \     / \     / \
+	h0  h1  h2  h3  h4  h5
 
 TODO(ismail): add 2nd pre-image protection or clarify further on how we use this and why this secure.
-
 */
 package merkle

--- a/crypto/merkle/tree.go
+++ b/crypto/merkle/tree.go
@@ -53,10 +53,10 @@ func hashFromByteSlices(sha hash.Hash, items [][]byte) []byte {
 //
 // These preliminary results suggest:
 //
-// 1. The performance of the HashFromByteSlice is pretty good
-// 2. Go has low overhead for recursive functions
-// 3. The performance of the HashFromByteSlice routine is dominated
-//    by the actual hashing of data
+//  1. The performance of the HashFromByteSlice is pretty good
+//  2. Go has low overhead for recursive functions
+//  3. The performance of the HashFromByteSlice routine is dominated
+//     by the actual hashing of data
 //
 // Although this work is in no way exhaustive, point #3 suggests that
 // optimization of this routine would need to take an alternative

--- a/internal/consensus/metrics.gen.go
+++ b/internal/consensus/metrics.gen.go
@@ -107,6 +107,8 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 			Subsystem: MetricsSubsystem,
 			Name:      "block_size_bytes",
 			Help:      "Size of the block.",
+
+			Buckets: stdprometheus.ExponentialBuckets(1000, 1.5, 25),
 		}, labels).With(labelsAndValues...),
 		TotalTxs: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
 			Namespace: namespace,
@@ -263,12 +265,16 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 			Subsystem: MetricsSubsystem,
 			Name:      "consensus_time",
 			Help:      "Number of seconds spent on consensus",
+
+			Buckets: stdprometheus.ExponentialBuckets(0.01, 1.3, 25),
 		}, labels).With(labelsAndValues...),
 		CompleteProposalTime: prometheus.NewHistogramFrom(stdprometheus.HistogramOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
 			Name:      "complete_proposal_time",
 			Help:      "CompleteProposalTime measures how long it takes between receiving a proposal and finishing processing all of its parts. Note that this means it also includes network latency from block parts gossip",
+
+			Buckets: stdprometheus.ExponentialBuckets(0.01, 1.3, 25),
 		}, labels).With(labelsAndValues...),
 		ApplyBlockLatency: prometheus.NewHistogramFrom(stdprometheus.HistogramOpts{
 			Namespace: namespace,
@@ -276,7 +282,7 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 			Name:      "apply_block_latency",
 			Help:      "ApplyBlockLatency measures how long it takes to execute ApplyBlock in finalize commit step",
 
-			Buckets: stdprometheus.ExponentialBucketsRange(0.01, 10, 10),
+			Buckets: stdprometheus.ExponentialBuckets(0.01, 1.3, 25),
 		}, labels).With(labelsAndValues...),
 		StepLatency: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
 			Namespace: namespace,

--- a/internal/consensus/metrics.go
+++ b/internal/consensus/metrics.go
@@ -56,7 +56,7 @@ type Metrics struct {
 	// Number of transactions.
 	NumTxs metrics.Gauge
 	// Size of the block.
-	BlockSizeBytes metrics.Histogram
+	BlockSizeBytes metrics.Histogram `metrics_buckettype:"exp" metrics_bucketsizes:"1000, 1.5, 25"`
 	// Total number of transactions.
 	TotalTxs metrics.Gauge
 	// The latest block height.
@@ -164,15 +164,15 @@ type Metrics struct {
 
 	// ConsensusTime the metric to track how long the consensus takes in each block
 	//metrics: Number of seconds spent on consensus
-	ConsensusTime metrics.Histogram
+	ConsensusTime metrics.Histogram `metrics_buckettype:"exp" metrics_bucketsizes:"0.01, 1.3, 25"`
 
 	// CompleteProposalTime measures how long it takes between receiving a proposal and finishing
 	// processing all of its parts. Note that this means it also includes network latency from
 	// block parts gossip
-	CompleteProposalTime metrics.Histogram
+	CompleteProposalTime metrics.Histogram `metrics_buckettype:"exp" metrics_bucketsizes:"0.01, 1.3, 25"`
 
 	// ApplyBlockLatency measures how long it takes to execute ApplyBlock in finalize commit step
-	ApplyBlockLatency metrics.Histogram `metrics_buckettype:"exprange" metrics_bucketsizes:"0.01, 10, 10"`
+	ApplyBlockLatency metrics.Histogram `metrics_buckettype:"exp" metrics_bucketsizes:"0.01, 1.3, 25"`
 
 	StepLatency                 metrics.Gauge `metrics_labels:"step"`
 	lastRecordedStepLatencyNano int64
@@ -240,12 +240,24 @@ func (m *Metrics) MarkFinalRound(round int32, proposer string) {
 	m.FinalRound.With("proposer_address", proposer).Observe(float64(round))
 }
 
-func (m *Metrics) MarkProposeLatency(proposer string, seconds float64) {
-	m.ProposeLatency.With("proposer_address", proposer).Observe(seconds)
+func (m *Metrics) MarkProposeLatency(proposer string, latency time.Duration) {
+	m.ProposeLatency.With("proposer_address", proposer).Observe(latency.Seconds())
 }
 
-func (m *Metrics) MarkPrevoteLatency(validator string, seconds float64) {
-	m.PrevoteLatency.With("validator_address", validator).Observe(seconds)
+func (m *Metrics) MarkPrevoteLatency(validator string, latency time.Duration) {
+	m.PrevoteLatency.With("validator_address", validator).Observe(latency.Seconds())
+}
+
+func (m *Metrics) MarkCompleteProposalTime(latency time.Duration) {
+	m.CompleteProposalTime.Observe(latency.Seconds())
+}
+
+func (m *Metrics) MarkConsensusTime(latency time.Duration) {
+	m.ConsensusTime.Observe(latency.Seconds())
+}
+
+func (m *Metrics) MarkApplyBlockLatency(latency time.Duration) {
+	m.ApplyBlockLatency.Observe(latency.Seconds())
 }
 
 func (m *Metrics) MarkStep(s cstypes.RoundStepType) {

--- a/internal/evidence/doc.go
+++ b/internal/evidence/doc.go
@@ -3,7 +3,7 @@ Package evidence handles all evidence storage and gossiping from detection to bl
 For the different types of evidence refer to the `evidence.go` file in the types package
 or https://github.com/tendermint/tendermint/blob/master/spec/consensus/light-client/accountability.md.
 
-Gossiping
+# Gossiping
 
 The core functionality begins with the evidence reactor (see reactor.
 go) which operates both the sending and receiving of evidence.
@@ -29,7 +29,7 @@ There are two buckets that evidence can be stored in: Pending & Committed.
 
 All evidence is proto encoded to disk.
 
-Proposing
+# Proposing
 
 When a new block is being proposed (in state/execution.go#CreateProposalBlock),
 `PendingEvidence(maxBytes)` is called to send up to the maxBytes of uncommitted evidence, from the evidence store,
@@ -42,12 +42,11 @@ Once the proposed evidence is submitted,
 the evidence is marked as committed and is moved from the broadcasted set to the committed set.
 As a result it is also removed from the concurrent list so that it is no longer gossiped.
 
-Minor Functionality
+# Minor Functionality
 
 As all evidence (including POLC's) are bounded by an expiration date, those that exceed this are no longer needed
 and hence pruned. Currently, only committed evidence in which a marker to the height that the evidence was committed
 and hence very small is saved. All updates are made from the `Update(block, state)` function which should be called
 when a new block is committed.
-
 */
 package evidence

--- a/internal/evidence/pool.go
+++ b/internal/evidence/pool.go
@@ -102,11 +102,11 @@ func (evpool *Pool) PendingEvidence(maxBytes int64) ([]types.Evidence, int64) {
 
 // Update takes both the new state and the evidence committed at that height and performs
 // the following operations:
-// 1. Take any conflicting votes from consensus and use the state's LastBlockTime to form
-//    DuplicateVoteEvidence and add it to the pool.
-// 2. Update the pool's state which contains evidence params relating to expiry.
-// 3. Moves pending evidence that has now been committed into the committed pool.
-// 4. Removes any expired evidence based on both height and time.
+//  1. Take any conflicting votes from consensus and use the state's LastBlockTime to form
+//     DuplicateVoteEvidence and add it to the pool.
+//  2. Update the pool's state which contains evidence params relating to expiry.
+//  3. Moves pending evidence that has now been committed into the committed pool.
+//  4. Removes any expired evidence based on both height and time.
 func (evpool *Pool) Update(ctx context.Context, state sm.State, ev types.EvidenceList) {
 	// sanity check
 	if state.LastBlockHeight <= evpool.state.LastBlockHeight {

--- a/internal/evidence/verify.go
+++ b/internal/evidence/verify.go
@@ -150,13 +150,14 @@ func (evpool *Pool) verify(ctx context.Context, evidence types.Evidence) error {
 
 // VerifyLightClientAttack verifies LightClientAttackEvidence against the state of the full node. This involves
 // the following checks:
-//     - the common header from the full node has at least 1/3 voting power which is also present in
-//       the conflicting header's commit
-//     - 2/3+ of the conflicting validator set correctly signed the conflicting block
-//     - the nodes trusted header at the same height as the conflicting header has a different hash
+//   - the common header from the full node has at least 1/3 voting power which is also present in
+//     the conflicting header's commit
+//   - 2/3+ of the conflicting validator set correctly signed the conflicting block
+//   - the nodes trusted header at the same height as the conflicting header has a different hash
 //
 // CONTRACT: must run ValidateBasic() on the evidence before verifying
-//           must check that the evidence has not expired (i.e. is outside the maximum age threshold)
+//
+//	must check that the evidence has not expired (i.e. is outside the maximum age threshold)
 func VerifyLightClientAttack(e *types.LightClientAttackEvidence, commonHeader, trustedHeader *types.SignedHeader,
 	commonVals *types.ValidatorSet, now time.Time, trustPeriod time.Duration) error {
 	// In the case of lunatic attack there will be a different commonHeader height. Therefore the node perform a single
@@ -196,10 +197,10 @@ func VerifyLightClientAttack(e *types.LightClientAttackEvidence, commonHeader, t
 
 // VerifyDuplicateVote verifies DuplicateVoteEvidence against the state of full node. This involves the
 // following checks:
-//      - the validator is in the validator set at the height of the evidence
-//      - the height, round, type and validator address of the votes must be the same
-//      - the block ID's must be different
-//      - The signatures must both be valid
+//   - the validator is in the validator set at the height of the evidence
+//   - the height, round, type and validator address of the votes must be the same
+//   - the block ID's must be different
+//   - The signatures must both be valid
 func VerifyDuplicateVote(e *types.DuplicateVoteEvidence, chainID string, valSet *types.ValidatorSet) error {
 	_, val := valSet.GetByAddress(e.VoteA.ValidatorAddress)
 	if val == nil {

--- a/internal/inspect/doc.go
+++ b/internal/inspect/doc.go
@@ -12,23 +12,23 @@ inconsistent state so the node will not be able to start up again.
 The RPC endpoints provided by the Inspector type allow for a node operator to inspect
 the block store and state store to better understand what may have caused the inconsistent state.
 
-
 The Inspector type's lifecycle is controlled by a context.Context
-  ins := inspect.NewFromConfig(rpcConfig)
-  ctx, cancelFunc:= context.WithCancel(context.Background())
 
-  // Run blocks until the Inspector server is shut down.
-  go ins.Run(ctx)
-  ...
+	ins := inspect.NewFromConfig(rpcConfig)
+	ctx, cancelFunc:= context.WithCancel(context.Background())
 
-  // calling the cancel function will stop the running inspect server
-  cancelFunc()
+	// Run blocks until the Inspector server is shut down.
+	go ins.Run(ctx)
+	...
+
+	// calling the cancel function will stop the running inspect server
+	cancelFunc()
 
 Inspector serves its RPC endpoints on the address configured in the RPC configuration
 
-  rpcConfig.ListenAddress = "tcp://127.0.0.1:26657"
-  ins := inspect.NewFromConfig(rpcConfig)
-  go ins.Run(ctx)
+	rpcConfig.ListenAddress = "tcp://127.0.0.1:26657"
+	ins := inspect.NewFromConfig(rpcConfig)
+	go ins.Run(ctx)
 
 The list of available RPC endpoints can then be viewed by navigating to
 http://127.0.0.1:26657/ in the web browser.

--- a/internal/jsontypes/jsontypes.go
+++ b/internal/jsontypes/jsontypes.go
@@ -2,10 +2,10 @@
 // implementations need to be stored as JSON. To do this, concrete values are
 // packaged in wrapper objects having the form:
 //
-//   {
-//     "type": "<type-tag>",
-//     "value": <json-encoding-of-value>
-//   }
+//	{
+//	  "type": "<type-tag>",
+//	  "value": <json-encoding-of-value>
+//	}
 //
 // This package provides a registry for type tag strings and functions to
 // encode and decode wrapper objects.

--- a/internal/libs/clist/clist.go
+++ b/internal/libs/clist/clist.go
@@ -22,7 +22,6 @@ import (
 const MaxLength = int(^uint(0) >> 1)
 
 /*
-
 CElement is an element of a linked-list
 Traversal from a CElement is goroutine-safe.
 
@@ -39,7 +38,6 @@ the for-loop. Use sync.Cond when you need serial access to the
 "condition". In our case our condition is if `next != nil || removed`,
 and there's no reason to serialize that condition for goroutines
 waiting on NextWait() (since it's just a read operation).
-
 */
 type CElement struct {
 	mtx        sync.RWMutex

--- a/internal/libs/flowrate/flowrate.go
+++ b/internal/libs/flowrate/flowrate.go
@@ -39,10 +39,10 @@ type Monitor struct {
 // weight of each sample in the exponential moving average (EMA) calculation.
 // The exact formulas are:
 //
-// 	sampleTime = currentTime - prevSampleTime
-// 	sampleRate = byteCount / sampleTime
-// 	weight     = 1 - exp(-sampleTime/windowSize)
-// 	newRate    = weight*sampleRate + (1-weight)*oldRate
+//	sampleTime = currentTime - prevSampleTime
+//	sampleRate = byteCount / sampleTime
+//	weight     = 1 - exp(-sampleTime/windowSize)
+//	newRate    = weight*sampleRate + (1-weight)*oldRate
 //
 // The default values for sampleRate and windowSize (if <= 0) are 100ms and 1s,
 // respectively.

--- a/internal/pubsub/pubsub.go
+++ b/internal/pubsub/pubsub.go
@@ -10,28 +10,27 @@
 //
 // Example:
 //
-//     q, err := query.New(`account.name='John'`)
-//     if err != nil {
-//         return err
-//     }
-//     sub, err := pubsub.SubscribeWithArgs(ctx, pubsub.SubscribeArgs{
-//         ClientID: "johns-transactions",
-//         Query:    q,
-//     })
-//     if err != nil {
-//         return err
-//     }
+//	q, err := query.New(`account.name='John'`)
+//	if err != nil {
+//	    return err
+//	}
+//	sub, err := pubsub.SubscribeWithArgs(ctx, pubsub.SubscribeArgs{
+//	    ClientID: "johns-transactions",
+//	    Query:    q,
+//	})
+//	if err != nil {
+//	    return err
+//	}
 //
-//     for {
-//         next, err := sub.Next(ctx)
-//         if err == pubsub.ErrTerminated {
-//            return err // terminated by publisher
-//         } else if err != nil {
-//            return err // timed out, client unsubscribed, etc.
-//         }
-//         process(next)
-//     }
-//
+//	for {
+//	    next, err := sub.Next(ctx)
+//	    if err == pubsub.ErrTerminated {
+//	       return err // terminated by publisher
+//	    } else if err != nil {
+//	       return err // timed out, client unsubscribed, etc.
+//	    }
+//	    process(next)
+//	}
 package pubsub
 
 import (

--- a/internal/pubsub/query/syntax/doc.go
+++ b/internal/pubsub/query/syntax/doc.go
@@ -1,34 +1,33 @@
 // Package syntax defines a scanner and parser for the Tendermint event filter
 // query language. A query selects events by their types and attribute values.
 //
-// Grammar
+// # Grammar
 //
 // The grammar of the query language is defined by the following EBNF:
 //
-//   query      = conditions EOF
-//   conditions = condition {"AND" condition}
-//   condition  = tag comparison
-//   comparison = equal / order / contains / "EXISTS"
-//   equal      = "=" (date / number / time / value)
-//   order      = cmp (date / number / time)
-//   contains   = "CONTAINS" value
-//   cmp        = "<" / "<=" / ">" / ">="
+//	query      = conditions EOF
+//	conditions = condition {"AND" condition}
+//	condition  = tag comparison
+//	comparison = equal / order / contains / "EXISTS"
+//	equal      = "=" (date / number / time / value)
+//	order      = cmp (date / number / time)
+//	contains   = "CONTAINS" value
+//	cmp        = "<" / "<=" / ">" / ">="
 //
 // The lexical terms are defined here using RE2 regular expression notation:
 //
-//   // The name of an event attribute (type.value)
-//   tag    = #'\w+(\.\w+)*'
+//	// The name of an event attribute (type.value)
+//	tag    = #'\w+(\.\w+)*'
 //
-//   // A datestamp (YYYY-MM-DD)
-//   date   = #'DATE \d{4}-\d{2}-\d{2}'
+//	// A datestamp (YYYY-MM-DD)
+//	date   = #'DATE \d{4}-\d{2}-\d{2}'
 //
-//   // A number with optional fractional parts (0, 10, 3.25)
-//   number = #'\d+(\.\d+)?'
+//	// A number with optional fractional parts (0, 10, 3.25)
+//	number = #'\d+(\.\d+)?'
 //
-//   // An RFC3339 timestamp (2021-11-23T22:04:19-09:00)
-//   time   = #'TIME \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}([-+]\d{2}:\d{2}|Z)'
+//	// An RFC3339 timestamp (2021-11-23T22:04:19-09:00)
+//	time   = #'TIME \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}([-+]\d{2}:\d{2}|Z)'
 //
-//   // A quoted literal string value ('a b c')
-//   value  = #'\'[^\']*\''
-//
+//	// A quoted literal string value ('a b c')
+//	value  = #'\'[^\']*\''
 package syntax

--- a/internal/state/indexer/doc.go
+++ b/internal/state/indexer/doc.go
@@ -8,7 +8,7 @@ Tendermint supports two primary means of block and transaction event indexing:
 
 An ABCI application can emit events during block and transaction execution in the form
 
-   <abci.Event.Type>.<abci.EventAttributeKey>=<abci.EventAttributeValue>
+	<abci.Event.Type>.<abci.EventAttributeKey>=<abci.EventAttributeValue>
 
 for example "transfer.amount=10000".
 

--- a/internal/state/mocks/block_store.go
+++ b/internal/state/mocks/block_store.go
@@ -185,7 +185,6 @@ func (_m *BlockStore) LoadSeenCommit() *types.Commit {
 	return r0
 }
 
-
 // PruneBlocks provides a mock function with given fields: height
 func (_m *BlockStore) PruneBlocks(height int64) (uint64, error) {
 	ret := _m.Called(height)

--- a/libs/json/doc.go
+++ b/libs/json/doc.go
@@ -13,12 +13,12 @@
 // compatibility with e.g. Javascript (which uses 64-bit floats for numbers, having 53-bit
 // precision):
 //
-// 	int32(32)  // Output: 32
-// 	uint32(32) // Output: 32
-// 	int64(64)  // Output: "64"
-// 	uint64(64) // Output: "64"
-// 	int(64)    // Output: "64"
-// 	uint(64)   // Output: "64"
+//	int32(32)  // Output: 32
+//	uint32(32) // Output: 32
+//	int64(64)  // Output: "64"
+//	uint64(64) // Output: "64"
+//	int(64)    // Output: "64"
+//	uint(64)   // Output: "64"
 //
 // Encoding of other scalars follows encoding/json:
 //
@@ -50,7 +50,7 @@
 // Times are encoded as encoding/json, in RFC3339Nano format, but requiring UTC time zone (with zero
 // times emitted as "0001-01-01T00:00:00Z" as with encoding/json):
 //
-// 	time.Date(2020, 6, 8, 16, 21, 28, 123, time.FixedZone("UTC+2", 2*60*60))
+//	time.Date(2020, 6, 8, 16, 21, 28, 123, time.FixedZone("UTC+2", 2*60*60))
 //	// Output: "2020-06-08T14:21:28.000000123Z"
 //	time.Time{}       // Output: "0001-01-01T00:00:00Z"
 //	(*time.Time)(nil) // Output: null
@@ -95,5 +95,4 @@
 //
 //	Struct{Car: &Car{Wheels: 4}, Vehicle: &Car{Wheels: 4}}
 //	// Output: {"Car": {"Wheels: 4"}, "Vehicle": {"type":"vehicle/car","value":{"Wheels":4}}}
-//
 package json

--- a/libs/log/filter.go
+++ b/libs/log/filter.go
@@ -69,18 +69,19 @@ func (l *filter) Error(msg string, keyvals ...interface{}) {
 // Allow*With methods, it is used as the logger's level.
 //
 // Examples:
-//     logger = log.NewFilter(logger, log.AllowError(), log.AllowInfoWith("module", "crypto"))
-//		 logger.With("module", "crypto").Info("Hello") # produces "I... Hello module=crypto"
 //
-//     logger = log.NewFilter(logger, log.AllowError(),
-//				log.AllowInfoWith("module", "crypto"),
-// 				log.AllowNoneWith("user", "Sam"))
-//		 logger.With("module", "crypto", "user", "Sam").Info("Hello") # returns nil
+//	    logger = log.NewFilter(logger, log.AllowError(), log.AllowInfoWith("module", "crypto"))
+//			 logger.With("module", "crypto").Info("Hello") # produces "I... Hello module=crypto"
 //
-//     logger = log.NewFilter(logger,
-// 				log.AllowError(),
-// 				log.AllowInfoWith("module", "crypto"), log.AllowNoneWith("user", "Sam"))
-//		 logger.With("user", "Sam").With("module", "crypto").Info("Hello") # produces "I... Hello module=crypto user=Sam"
+//	    logger = log.NewFilter(logger, log.AllowError(),
+//					log.AllowInfoWith("module", "crypto"),
+//					log.AllowNoneWith("user", "Sam"))
+//			 logger.With("module", "crypto", "user", "Sam").Info("Hello") # returns nil
+//
+//	    logger = log.NewFilter(logger,
+//					log.AllowError(),
+//					log.AllowInfoWith("module", "crypto"), log.AllowNoneWith("user", "Sam"))
+//			 logger.With("user", "Sam").With("module", "crypto").Info("Hello") # produces "I... Hello module=crypto user=Sam"
 func (l *filter) With(keyvals ...interface{}) Logger {
 	keyInAllowedKeyvals := false
 

--- a/light/doc.go
+++ b/light/doc.go
@@ -63,31 +63,31 @@ This package provides three major things:
 
 Example usage:
 
-		db, err := dbm.NewGoLevelDB("light-client-db", dbDir)
-		if err != nil {
-			// handle error
-		}
+	db, err := dbm.NewGoLevelDB("light-client-db", dbDir)
+	if err != nil {
+		// handle error
+	}
 
-		c, err := NewHTTPClient(
-			chainID,
-			TrustOptions{
-				Period: 504 * time.Hour, // 21 days
-				Height: 100,
-				Hash:   header.Hash(),
-			},
-			"http://localhost:26657",
-			[]string{"http://witness1:26657"},
-			dbs.New(db, ""),
-		)
-		if err != nil {
-			// handle error
-		}
+	c, err := NewHTTPClient(
+		chainID,
+		TrustOptions{
+			Period: 504 * time.Hour, // 21 days
+			Height: 100,
+			Hash:   header.Hash(),
+		},
+		"http://localhost:26657",
+		[]string{"http://witness1:26657"},
+		dbs.New(db, ""),
+	)
+	if err != nil {
+		// handle error
+	}
 
-		h, err := c.TrustedHeader(100)
-		if err != nil {
-			// handle error
-		}
-		fmt.Println("header", h)
+	h, err := c.TrustedHeader(100)
+	if err != nil {
+		// handle error
+	}
+	fmt.Println("header", h)
 
 Check out other examples in example_test.go
 

--- a/light/verifier.go
+++ b/light/verifier.go
@@ -19,13 +19,13 @@ var (
 // VerifyNonAdjacent verifies non-adjacent untrustedHeader against
 // trustedHeader. It ensures that:
 //
-//	a) trustedHeader can still be trusted (if not, ErrOldHeaderExpired is returned)
-//	b) untrustedHeader is valid (if not, ErrInvalidHeader is returned)
-//	c) trustLevel ([1/3, 1]) of trustedHeaderVals (or trustedHeaderNextVals)
-//  signed correctly (if not, ErrNewValSetCantBeTrusted is returned)
-//	d) more than 2/3 of untrustedVals have signed h2
-//    (otherwise, ErrInvalidHeader is returned)
-//  e) headers are non-adjacent.
+//		a) trustedHeader can still be trusted (if not, ErrOldHeaderExpired is returned)
+//		b) untrustedHeader is valid (if not, ErrInvalidHeader is returned)
+//		c) trustLevel ([1/3, 1]) of trustedHeaderVals (or trustedHeaderNextVals)
+//	 signed correctly (if not, ErrNewValSetCantBeTrusted is returned)
+//		d) more than 2/3 of untrustedVals have signed h2
+//	   (otherwise, ErrInvalidHeader is returned)
+//	 e) headers are non-adjacent.
 //
 // maxClockDrift defines how much untrustedHeader.Time can drift into the
 // future.
@@ -93,12 +93,12 @@ func VerifyNonAdjacent(
 // VerifyAdjacent verifies directly adjacent untrustedHeader against
 // trustedHeader. It ensures that:
 //
-//  a) trustedHeader can still be trusted (if not, ErrOldHeaderExpired is returned)
-//  b) untrustedHeader is valid (if not, ErrInvalidHeader is returned)
-//  c) untrustedHeader.ValidatorsHash equals trustedHeader.NextValidatorsHash
-//  d) more than 2/3 of new validators (untrustedVals) have signed h2
-//    (otherwise, ErrInvalidHeader is returned)
-//  e) headers are adjacent.
+//	a) trustedHeader can still be trusted (if not, ErrOldHeaderExpired is returned)
+//	b) untrustedHeader is valid (if not, ErrInvalidHeader is returned)
+//	c) untrustedHeader.ValidatorsHash equals trustedHeader.NextValidatorsHash
+//	d) more than 2/3 of new validators (untrustedVals) have signed h2
+//	  (otherwise, ErrInvalidHeader is returned)
+//	e) headers are adjacent.
 //
 // maxClockDrift defines how much untrustedHeader.Time can drift into the
 // future.
@@ -194,10 +194,10 @@ func HeaderExpired(h *types.SignedHeader, trustingPeriod time.Duration, now time
 // VerifyBackwards verifies an untrusted header with a height one less than
 // that of an adjacent trusted header. It ensures that:
 //
-// 	a) untrusted header is valid
-//  b) untrusted header has a time before the trusted header
-//  c) that the LastBlockID hash of the trusted header is the same as the hash
-//  of the trusted header
+//		a) untrusted header is valid
+//	 b) untrusted header has a time before the trusted header
+//	 c) that the LastBlockID hash of the trusted header is the same as the hash
+//	 of the trusted header
 //
 // For any of these cases ErrInvalidHeader is returned.
 // NOTE: This does not check whether the trusted or untrusted header has expired

--- a/privval/doc.go
+++ b/privval/doc.go
@@ -1,13 +1,12 @@
 /*
-
 Package privval provides different implementations of the types.PrivValidator.
 
-FilePV
+# FilePV
 
 FilePV is the simplest implementation and developer default.
 It uses one file for the private key and another to store state.
 
-SignerListenerEndpoint
+# SignerListenerEndpoint
 
 SignerListenerEndpoint establishes a connection to an external process,
 like a Key Management Server (KMS), using a socket.
@@ -15,15 +14,14 @@ SignerListenerEndpoint listens for the external KMS process to dial in.
 SignerListenerEndpoint takes a listener, which determines the type of connection
 (ie. encrypted over tcp, or unencrypted over unix).
 
-SignerDialerEndpoint
+# SignerDialerEndpoint
 
 SignerDialerEndpoint is a simple wrapper around a net.Conn. It's used by both IPCVal and TCPVal.
 
-SignerClient
+# SignerClient
 
 SignerClient handles remote validator connections that provide signing services.
 In production, it's recommended to wrap it with RetrySignerClient to avoid
 termination in case of temporary errors.
-
 */
 package privval

--- a/rpc/jsonrpc/doc.go
+++ b/rpc/jsonrpc/doc.go
@@ -1,7 +1,7 @@
 // HTTP RPC server supporting calls via uri params, jsonrpc over HTTP, and jsonrpc over
 // websockets
 //
-// Client Requests
+// # Client Requests
 //
 // Suppose we want to expose the rpc function `HelloWorld(name string, num int)`.
 //
@@ -9,12 +9,12 @@
 //
 // As a GET request, it would have URI encoded parameters, and look like:
 //
-//   curl 'http://localhost:8008/hello_world?name="my_world"&num=5'
+//	curl 'http://localhost:8008/hello_world?name="my_world"&num=5'
 //
 // Note the `'` around the url, which is just so bash doesn't ignore the quotes in `"my_world"`.
 // This should also work:
 //
-//   curl http://localhost:8008/hello_world?name=\"my_world\"&num=5
+//	curl http://localhost:8008/hello_world?name=\"my_world\"&num=5
 //
 // A GET request to `/` returns a list of available endpoints.
 // For those which take arguments, the arguments will be listed in order, with `_` where the actual value should be.
@@ -23,20 +23,19 @@
 //
 // As a POST request, we use JSONRPC. For instance, the same request would have this as the body:
 //
-//   {
-//     "jsonrpc": "2.0",
-//     "id": "anything",
-//     "method": "hello_world",
-//     "params": {
-//       "name": "my_world",
-//       "num": 5
-//     }
-//   }
+//	{
+//	  "jsonrpc": "2.0",
+//	  "id": "anything",
+//	  "method": "hello_world",
+//	  "params": {
+//	    "name": "my_world",
+//	    "num": 5
+//	  }
+//	}
 //
 // With the above saved in file `data.json`, we can make the request with
 //
-//   curl --data @data.json http://localhost:8008
-//
+//	curl --data @data.json http://localhost:8008
 //
 // WebSocket (JSONRPC)
 //
@@ -44,42 +43,42 @@
 // Websocket connections are available at their own endpoint, typically `/websocket`,
 // though this is configurable when starting the server.
 //
-// Server Definition
+// # Server Definition
 //
 // Define some types and routes:
 //
-//    type ResultStatus struct {
-//    	    Value string
-//    }
+//	type ResultStatus struct {
+//		    Value string
+//	}
 //
 // Define some routes
 //
-//   var Routes = map[string]*rpcserver.RPCFunc{
-//	    "status": rpcserver.NewRPCFunc(Status),
-//   }
+//	  var Routes = map[string]*rpcserver.RPCFunc{
+//		    "status": rpcserver.NewRPCFunc(Status),
+//	  }
 //
 // An rpc function:
 //
-//   func Status(v string) (*ResultStatus, error) {
-//	    return &ResultStatus{v}, nil
-//   }
+//	  func Status(v string) (*ResultStatus, error) {
+//		    return &ResultStatus{v}, nil
+//	  }
 //
 // Now start the server:
 //
-//   mux := http.NewServeMux()
-//   rpcserver.RegisterRPCFuncs(mux, Routes)
-//   wm := rpcserver.NewWebsocketManager(Routes)
-//   mux.HandleFunc("/websocket", wm.WebsocketHandler)
-//   logger := log.NewTMLogger(log.NewSyncWriter(os.Stdout))
-//   listener, err := rpc.Listen("0.0.0.0:8080", rpcserver.Config{})
-//   if err != nil { panic(err) }
-//   go rpcserver.Serve(listener, mux, logger)
+//	mux := http.NewServeMux()
+//	rpcserver.RegisterRPCFuncs(mux, Routes)
+//	wm := rpcserver.NewWebsocketManager(Routes)
+//	mux.HandleFunc("/websocket", wm.WebsocketHandler)
+//	logger := log.NewTMLogger(log.NewSyncWriter(os.Stdout))
+//	listener, err := rpc.Listen("0.0.0.0:8080", rpcserver.Config{})
+//	if err != nil { panic(err) }
+//	go rpcserver.Serve(listener, mux, logger)
 //
 // Note that unix sockets are supported as well (eg. `/path/to/socket` instead of `0.0.0.0:8008`)
 // Now see all available endpoints by sending a GET request to `0.0.0.0:8008`.
 // Each route is available as a GET request, as a JSONRPCv2 POST request, and via JSONRPCv2 over websockets.
 //
-// Examples
+// # Examples
 //
 // - [Tendermint](https://github.com/tendermint/tendermint/blob/master/rpc/core/routes.go)
 package jsonrpc

--- a/scripts/keymigrate/migrate.go
+++ b/scripts/keymigrate/migrate.go
@@ -352,7 +352,7 @@ func convertEvidence(key keyID, newPrefix int64) ([]byte, error) {
 // so checking the one-byte prefix alone is not enough to distinguish them.
 // Legacy evidence keys are suffixed with a string of the format:
 //
-//     "%0.16X/%X"
+//	"%0.16X/%X"
 //
 // where the first element is the height and the second is the hash.  Thus, we
 // check

--- a/test/e2e/app/state.go
+++ b/test/e2e/app/state.go
@@ -1,4 +1,4 @@
-//nolint: gosec
+// nolint: gosec
 package app
 
 import (

--- a/test/e2e/generator/main.go
+++ b/test/e2e/generator/main.go
@@ -1,4 +1,4 @@
-//nolint: gosec
+// nolint: gosec
 package main
 
 import (

--- a/test/e2e/node/config.go
+++ b/test/e2e/node/config.go
@@ -1,4 +1,4 @@
-//nolint: goconst
+// nolint: goconst
 package main
 
 import (

--- a/test/e2e/pkg/testnet.go
+++ b/test/e2e/pkg/testnet.go
@@ -1,4 +1,4 @@
-//nolint: gosec
+// nolint: gosec
 package e2e
 
 import (

--- a/test/e2e/runner/exec.go
+++ b/test/e2e/runner/exec.go
@@ -1,4 +1,4 @@
-//nolint: gosec
+// nolint: gosec
 package main
 
 import (

--- a/types/utils.go
+++ b/types/utils.go
@@ -4,9 +4,9 @@ import "reflect"
 
 // Go lacks a simple and safe way to see if something is a typed nil.
 // See:
-//  - https://dave.cheney.net/2017/08/09/typed-nils-in-go-2
-//  - https://groups.google.com/forum/#!topic/golang-nuts/wnH302gBa4I/discussion
-//  - https://github.com/golang/go/issues/21538
+//   - https://dave.cheney.net/2017/08/09/typed-nils-in-go-2
+//   - https://groups.google.com/forum/#!topic/golang-nuts/wnH302gBa4I/discussion
+//   - https://github.com/golang/go/issues/21538
 func isTypedNil(o interface{}) bool {
 	rv := reflect.ValueOf(o)
 	switch rv.Kind() {

--- a/types/validator.go
+++ b/types/validator.go
@@ -212,7 +212,6 @@ func ValidatorFromProto(vp *tmproto.Validator) (*Validator, error) {
 	return v, nil
 }
 
-
 //----------------------------------------
 // RandValidator
 

--- a/types/vote_set.go
+++ b/types/vote_set.go
@@ -20,38 +20,38 @@ const (
 )
 
 /*
-	VoteSet helps collect signatures from validators at each height+round for a
-	predefined vote type.
+VoteSet helps collect signatures from validators at each height+round for a
+predefined vote type.
 
-	We need VoteSet to be able to keep track of conflicting votes when validators
-	double-sign.  Yet, we can't keep track of *all* the votes seen, as that could
-	be a DoS attack vector.
+We need VoteSet to be able to keep track of conflicting votes when validators
+double-sign.  Yet, we can't keep track of *all* the votes seen, as that could
+be a DoS attack vector.
 
-	There are two storage areas for votes.
-	1. voteSet.votes
-	2. voteSet.votesByBlock
+There are two storage areas for votes.
+1. voteSet.votes
+2. voteSet.votesByBlock
 
-	`.votes` is the "canonical" list of votes.  It always has at least one vote,
-	if a vote from a validator had been seen at all.  Usually it keeps track of
-	the first vote seen, but when a 2/3 majority is found, votes for that get
-	priority and are copied over from `.votesByBlock`.
+`.votes` is the "canonical" list of votes.  It always has at least one vote,
+if a vote from a validator had been seen at all.  Usually it keeps track of
+the first vote seen, but when a 2/3 majority is found, votes for that get
+priority and are copied over from `.votesByBlock`.
 
-	`.votesByBlock` keeps track of a list of votes for a particular block.  There
-	are two ways a &blockVotes{} gets created in `.votesByBlock`.
-	1. the first vote seen by a validator was for the particular block.
-	2. a peer claims to have seen 2/3 majority for the particular block.
+`.votesByBlock` keeps track of a list of votes for a particular block.  There
+are two ways a &blockVotes{} gets created in `.votesByBlock`.
+1. the first vote seen by a validator was for the particular block.
+2. a peer claims to have seen 2/3 majority for the particular block.
 
-	Since the first vote from a validator will always get added in `.votesByBlock`
-	, all votes in `.votes` will have a corresponding entry in `.votesByBlock`.
+Since the first vote from a validator will always get added in `.votesByBlock`
+, all votes in `.votes` will have a corresponding entry in `.votesByBlock`.
 
-	When a &blockVotes{} in `.votesByBlock` reaches a 2/3 majority quorum, its
-	votes are copied into `.votes`.
+When a &blockVotes{} in `.votesByBlock` reaches a 2/3 majority quorum, its
+votes are copied into `.votes`.
 
-	All this is memory bounded because conflicting votes only get added if a peer
-	told us to track that block, each peer only gets to tell us 1 such block, and,
-	there's only a limited number of peers.
+All this is memory bounded because conflicting votes only get added if a peer
+told us to track that block, each peer only gets to tell us 1 such block, and,
+there's only a limited number of peers.
 
-	NOTE: Assumes that the sum total of voting power does not exceed MaxUInt64.
+NOTE: Assumes that the sum total of voting power does not exceed MaxUInt64.
 */
 type VoteSet struct {
 	chainID           string
@@ -140,8 +140,10 @@ func (voteSet *VoteSet) Size() int {
 
 // Returns added=true if vote is valid and new.
 // Otherwise returns err=ErrVote[
-//		UnexpectedStep | InvalidIndex | InvalidAddress |
-//		InvalidSignature | InvalidBlockHash | ConflictingVotes ]
+//
+//	UnexpectedStep | InvalidIndex | InvalidAddress |
+//	InvalidSignature | InvalidBlockHash | ConflictingVotes ]
+//
 // Duplicate votes return added=false, err=nil.
 // Conflicting votes return added=*, err=ErrVoteConflictingVotes.
 // NOTE: vote should not be mutated after adding.
@@ -661,10 +663,10 @@ func (voteSet *VoteSet) MakeExtendedCommit() *ExtendedCommit {
 //--------------------------------------------------------------------------------
 
 /*
-	Votes for a particular block
-	There are two ways a *blockVotes gets created for a blockKey.
-	1. first (non-conflicting) vote of a validator w/ blockKey (peerMaj23=false)
-	2. A peer claims to have a 2/3 majority w/ blockKey (peerMaj23=true)
+Votes for a particular block
+There are two ways a *blockVotes gets created for a blockKey.
+1. first (non-conflicting) vote of a validator w/ blockKey (peerMaj23=false)
+2. A peer claims to have a 2/3 majority w/ blockKey (peerMaj23=true)
 */
 type blockVotes struct {
 	peerMaj23 bool           // peer claims to have maj23


### PR DESCRIPTION
New buckets cover range 0.1-20s with 30% measurement error, which should be good enough.
IMO the metrics collected with the current buckets might have been misleading.

Adjusted other bucket ranges accordingly (factor=1.3, various initial values, depending on the expected order of magnitude). The latency metrics were measured with various units (ns, ms, s), I've normalized it to seconds. What is being measured is also not very uniform/useful, but I'll need to dig deeper to fix it.

I've run "go fmt" against the repo, which had some side effects in other files.