### PR TITLE
only allow 1 tx per envelope

### DIFF
--- a/internal/mempool/reactor.go
+++ b/internal/mempool/reactor.go
@@ -128,10 +128,10 @@ func (r *Reactor) handleMempoolMessage(ctx context.Context, envelope *p2p.Envelo
 
 	switch msg := envelope.Message.(type) {
 	case *protomem.Txs:
-		protoTxs := msg.GetTxs()
-		if len(protoTxs) == 0 {
-			return errors.New("empty txs received from peer")
+		if err := msg.Validate(); err != nil {
+			return err
 		}
+		protoTxs := msg.GetTxs()
 
 		txInfo := TxInfo{SenderID: r.ids.GetForPeer(envelope.From)}
 		if len(envelope.From) != 0 {

--- a/proto/tendermint/mempool/txs.go
+++ b/proto/tendermint/mempool/txs.go
@@ -1,0 +1,14 @@
+package mempool
+
+import "errors"
+
+func (txs *Txs) Validate() error {
+	protoTxs := txs.GetTxs()
+	if len(protoTxs) == 0 {
+		return errors.New("empty txs received from peer")
+	}
+	if len(protoTxs) > 1 {
+		return errors.New("right now we only allow 1 tx per envelope")
+	}
+	return nil
+}

--- a/proto/tendermint/mempool/txs_test.go
+++ b/proto/tendermint/mempool/txs_test.go
@@ -1,0 +1,16 @@
+package mempool
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidate(t *testing.T) {
+	txs := Txs{Txs: [][]byte{}}
+	require.Contains(t, txs.Validate().Error(), "empty txs received from peer")
+	txs.Txs = [][]byte{{0}, {0}}
+	require.Contains(t, txs.Validate().Error(), "right now we only allow 1 tx per envelope")
+	txs.Txs = [][]byte{{0}}
+	require.Nil(t, txs.Validate())
+}


### PR DESCRIPTION
## Describe your changes and provide context
there is currently no use case for multiple txs in a single envelope, and allowing that might expose us to unwanted effects. Eventually we should change the proto definition from a list to a single item

## Testing performed to validate your change
unit test

