### PR TITLE
Return error if any in mempool `CheckTx` and fix callback

### DIFF
--- a/internal/mempool/mempool.go
+++ b/internal/mempool/mempool.go
@@ -363,6 +363,7 @@ func (txmp *TxMempool) CheckTx(
 	if err != nil {
 		removeHandler(true)
 		res.Log = txmp.AppendCheckTxErr(res.Log, err.Error())
+		return err
 	}
 
 	wtx := &WrappedTx{
@@ -377,27 +378,25 @@ func (txmp *TxMempool) CheckTx(
 		estimatedGas:  res.GasEstimated,
 	}
 
-	if err == nil {
-		// only add new transaction if checkTx passes and is not pending
-		if !res.IsPendingTransaction {
-			err = txmp.addNewTransaction(wtx, res.ResponseCheckTx, txInfo)
-			if err != nil {
-				return err
-			}
-		} else {
-			// otherwise add to pending txs store
-			if res.Checker == nil {
-				return errors.New("no checker available for pending transaction")
-			}
-			if err := txmp.canAddPendingTx(wtx); err != nil {
-				// TODO: eviction strategy for pending transactions
-				removeHandler(true)
-				return err
-			}
-			atomic.AddInt64(&txmp.pendingSizeBytes, int64(wtx.Size()))
-			if err := txmp.pendingTxs.Insert(wtx, res, txInfo); err != nil {
-				return err
-			}
+	// only add new transaction if checkTx passes and is not pending
+	if !res.IsPendingTransaction {
+		err = txmp.addNewTransaction(wtx, res.ResponseCheckTx, txInfo)
+		if err != nil {
+			return err
+		}
+	} else {
+		// otherwise add to pending txs store
+		if res.Checker == nil {
+			return errors.New("no checker available for pending transaction")
+		}
+		if err := txmp.canAddPendingTx(wtx); err != nil {
+			// TODO: eviction strategy for pending transactions
+			removeHandler(true)
+			return err
+		}
+		atomic.AddInt64(&txmp.pendingSizeBytes, int64(wtx.Size()))
+		if err := txmp.pendingTxs.Insert(wtx, res, txInfo); err != nil {
+			return err
 		}
 	}
 


### PR DESCRIPTION
When call to the underlying (cosmos) `CheckTx` fails make sure that the error is returned from mempool `CheckTx`.

Fix check for callback to assure result is non-nil before callback function is executed.
