### PR TITLE
prevent peers from spamming block parts

### DIFF
--- a/internal/consensus/reactor.go
+++ b/internal/consensus/reactor.go
@@ -502,7 +502,9 @@ func (r *Reactor) gossipDataForCatchup(ctx context.Context, rs *cstypes.RoundSta
 		if err != nil {
 			// sleep to avoid retrying too fast
 			time.Sleep(r.state.config.PeerGossipSleepDuration)
+			return
 		}
+		ps.SetHasProposalBlockPart(prs.Height, prs.Round, index)
 		return
 	}
 


### PR DESCRIPTION
If a node is even just 1 block behind, his peers will start to spam random block parts at him which
* saturates the network
* kicks out other msgs from the outbound queue (because block parts are the highest priority messages)
* OOMs the node - it is unable to process all the incoming parts and the parts are large.
All this behavior was observed on a 50-node 1-region cluster with 1000txs/s (with lifted limits on the block size).

Fix boils down to properly marking the block parts as sent, so that they are not retransmitted indefinitely.