### PR TITLE
[CON-89] Increase tm event buffer to reduce critical path backpressure

### DIFF
--- a/internal/eventbus/event_bus.go
+++ b/internal/eventbus/event_bus.go
@@ -13,7 +13,7 @@ import (
 	"github.com/tendermint/tendermint/types"
 )
 
-var DefaultBufferCapacity = 100
+var DefaultBufferCapacity = 10000
 
 // Subscription is a proxy interface for a pubsub Subscription.
 type Subscription interface {

--- a/internal/pubsub/pubsub.go
+++ b/internal/pubsub/pubsub.go
@@ -315,7 +315,7 @@ func (s *Server) publish(data types.EventData, events []abci.Event) error {
 	select {
 	case <-s.done:
 		return ErrServerStopped
-	case s.queue <- item{
+	case s.queue <- item{ //TODO: This function is dogshit and causes so much blocking in the critical path fml
 		Data:   data,
 		Events: events,
 	}:

--- a/internal/pubsub/pubsub.go
+++ b/internal/pubsub/pubsub.go
@@ -38,7 +38,6 @@ import (
 	"errors"
 	"fmt"
 	"sync"
-	"time"
 
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/internal/pubsub/query"
@@ -337,20 +336,6 @@ func (s *Server) run(ctx context.Context) {
 		defer s.pubs.Unlock()
 		close(s.queue)
 		s.queue = nil
-	}()
-
-	go func() {
-		ticker := time.NewTicker(1 * time.Second)
-		defer ticker.Stop()
-
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				s.logger.Info("pubsub queue depth", "depth", len(s.queue))
-			}
-		}
 	}()
 
 	s.exited = make(chan struct{})


### PR DESCRIPTION
## Describe your changes and provide context
Currently, the buffer for tendermint events is too small to properly handle large amounts of traffic, since filling the buffer up will slow down the critical path for execution, resulting in potentially longer block times or at least node falling behind.

## Testing performed to validate your change
Tested in loadtest cluster and detacehd pacific-1 RPC
