### PR TITLE
Fixed timeoutTicker

### DIFF
--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -1650,6 +1650,15 @@ func (cs *State) defaultDoPrevote(ctx context.Context, height int64, round int32
 
 	if cs.roundState.Proposal() == nil {
 		logger.Info("prevote step: did not receive proposal; prevoting nil")
+		done := make(chan struct{})
+		defer close(done)
+		go func() {
+			select {
+			case <-time.After(time.Second * 10):
+				logger.Error("signAddVote(prevote) takes over 10s")
+			case <-done:
+			}
+		}()
 		cs.signAddVote(ctx, tmproto.PrevoteType, nil, types.PartSetHeader{})
 		return
 	}
@@ -2861,6 +2870,7 @@ func (cs *State) signVote(
 	if err := cs.wal.FlushAndSync(); err != nil {
 		return nil, err
 	}
+	cs.logger.Info("FlushAndSync() done")
 
 	if cs.privValidatorPubKey == nil {
 		return nil, errPubKeyIsNotSet

--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -431,10 +431,7 @@ func (cs *State) OnStart(ctx context.Context) error {
 
 	// we need the timeoutRoutine for replay so
 	// we don't block on the tick chan.
-	// NOTE: we will get a build up of garbage go routines
-	// firing on the tockChan until the receiveRoutine is started
-	// to deal with them (by that point, at most one will be valid)
-	cs.Spawn("timeoutTicker", cs.timeoutTicker.Run)
+	cs.SpawnCritical("timeoutTicker", cs.timeoutTicker.Run)
 
 	// We may have lost some votes if the process crashed reload from consensus
 	// log to catchup.
@@ -1650,15 +1647,6 @@ func (cs *State) defaultDoPrevote(ctx context.Context, height int64, round int32
 
 	if cs.roundState.Proposal() == nil {
 		logger.Info("prevote step: did not receive proposal; prevoting nil")
-		done := make(chan struct{})
-		defer close(done)
-		go func() {
-			select {
-			case <-time.After(time.Second * 10):
-				logger.Error("signAddVote(prevote) takes over 10s")
-			case <-done:
-			}
-		}()
 		cs.signAddVote(ctx, tmproto.PrevoteType, nil, types.PartSetHeader{})
 		return
 	}
@@ -2870,7 +2858,6 @@ func (cs *State) signVote(
 	if err := cs.wal.FlushAndSync(); err != nil {
 		return nil, err
 	}
-	cs.logger.Info("FlushAndSync() done")
 
 	if cs.privValidatorPubKey == nil {
 		return nil, errPubKeyIsNotSet

--- a/internal/consensus/ticker.go
+++ b/internal/consensus/ticker.go
@@ -7,10 +7,6 @@ import (
 	"github.com/tendermint/tendermint/libs/utils/scope"
 )
 
-var (
-	tickTockBufferSize = 10
-)
-
 // TimeoutTicker is a timer that schedules timeouts
 // conditional on the height/round/step in the timeoutInfo.
 // The timeoutInfo.Duration may be non-positive.
@@ -28,7 +24,6 @@ type TimeoutTicker interface {
 type timeoutTicker struct {
 	logger   log.Logger
 	tick     utils.AtomicWatch[utils.Option[timeoutInfo]] // for scheduling timeouts
-	tock     utils.AtomicWatch[utils.Option[timeoutInfo]] // last fired timeout
 	tockChan chan timeoutInfo                             // for notifying about them
 }
 
@@ -37,8 +32,7 @@ func NewTimeoutTicker(logger log.Logger) TimeoutTicker {
 	tt := &timeoutTicker{
 		logger:   logger,
 		tick:     utils.NewAtomicWatch(utils.None[timeoutInfo]()),
-		tock: 	  utils.NewAtomicWatch(utils.None[timeoutInfo]()),
-		tockChan: make(chan timeoutInfo, tickTockBufferSize),
+		tockChan: make(chan timeoutInfo),
 	}
 	return tt
 }
@@ -62,6 +56,7 @@ func (t *timeoutTicker) ScheduleTimeout(newti timeoutInfo) {
 // timers are interupted and replaced by new ticks from later steps
 // timeouts of 0 on the tickChan will be immediately relayed to the tockChan
 func (t *timeoutTicker) Run(ctx context.Context) error {
+	tock := utils.NewAtomicWatch(utils.None[timeoutInfo]()) // last fired timeout
 	return scope.Run(ctx, func(ctx context.Context, s scope.Scope) error {
 		s.Spawn(func() error {
 			// Task measuring timeouts.
@@ -75,14 +70,14 @@ func (t *timeoutTicker) Run(ctx context.Context) error {
 					return err
 				}
 				t.logger.Debug("Internal state machine timeout elapsed ", "duration", ti.Duration, "height", ti.Height, "round", ti.Round, "step", ti.Step)
-				t.tock.Store(utils.Some(ti))
+				tock.Store(utils.Some(ti))
 				return nil
 			})
 		})
 		// Task reporting timeouts via channel.
 		// TODO(gprusak): it would be better to expose t.tock directly,
 		// however the receiving task doesn't support receiving from AtomicWatch yet.
-		return t.tock.Iter(ctx, func(ctx context.Context, mto utils.Option[timeoutInfo]) error {
+		return tock.Iter(ctx, func(ctx context.Context, mto utils.Option[timeoutInfo]) error {
 			to, ok := mto.Get()
 			if !ok {
 				return nil

--- a/internal/consensus/ticker.go
+++ b/internal/consensus/ticker.go
@@ -28,6 +28,7 @@ type TimeoutTicker interface {
 type timeoutTicker struct {
 	logger   log.Logger
 	tick     utils.AtomicWatch[utils.Option[timeoutInfo]] // for scheduling timeouts
+	tock     utils.AtomicWatch[utils.Option[timeoutInfo]] // last fired timeout
 	tockChan chan timeoutInfo                             // for notifying about them
 }
 
@@ -61,18 +62,31 @@ func (t *timeoutTicker) ScheduleTimeout(newti timeoutInfo) {
 // timeouts of 0 on the tickChan will be immediately relayed to the tockChan
 func (t *timeoutTicker) Run(ctx context.Context) error {
 	return scope.Run(ctx, func(ctx context.Context, s scope.Scope) error {
-		return t.tick.Iter(ctx, func(ctx context.Context, mti utils.Option[timeoutInfo]) error {
-			ti, ok := mti.Get()
+		s.Spawn(func() error {
+			// Task measuring timeouts.
+			return t.tick.Iter(ctx, func(ctx context.Context, mti utils.Option[timeoutInfo]) error {
+				ti, ok := mti.Get()
+				if !ok {
+					return nil
+				}
+				t.logger.Debug("Internal state machine timeout scheduled", "duration", ti.Duration, "height", ti.Height, "round", ti.Round, "step", ti.Step)
+				if err := utils.Sleep(ctx, ti.Duration); err != nil {
+					return err
+				}
+				t.logger.Debug("Internal state machine timeout elapsed ", "duration", ti.Duration, "height", ti.Height, "round", ti.Round, "step", ti.Step)
+				t.tock.Store(utils.Some(ti))
+				return nil
+			})
+		})
+		// Task reporting timeouts via channel.
+		// TODO(gprusak): it would be better to expose t.tock directly,
+		// however the receiving task doesn't support receiving from AtomicWatch yet.
+		return t.tick.Iter(ctx, func(ctx context.Context, mto utils.Option[timeoutInfo]) error {
+			to, ok := mto.Get()
 			if !ok {
 				return nil
 			}
-			t.logger.Debug("Internal state machine timeout scheduled", "duration", ti.Duration, "height", ti.Height, "round", ti.Round, "step", ti.Step)
-			if err := utils.Sleep(ctx, ti.Duration); err != nil {
-				return err
-			}
-			t.logger.Debug("Internal state machine timeout elapsed ", "duration", ti.Duration, "height", ti.Height, "round", ti.Round, "step", ti.Step)
-			s.Spawn(func() error { return utils.Send(ctx, t.tockChan, ti) })
-			return nil
+			return utils.Send(ctx, t.tockChan, to)
 		})
 	})
 }

--- a/internal/consensus/ticker.go
+++ b/internal/consensus/ticker.go
@@ -37,6 +37,7 @@ func NewTimeoutTicker(logger log.Logger) TimeoutTicker {
 	tt := &timeoutTicker{
 		logger:   logger,
 		tick:     utils.NewAtomicWatch(utils.None[timeoutInfo]()),
+		tock: 	  utils.NewAtomicWatch(utils.None[timeoutInfo]()),
 		tockChan: make(chan timeoutInfo, tickTockBufferSize),
 	}
 	return tt
@@ -81,7 +82,7 @@ func (t *timeoutTicker) Run(ctx context.Context) error {
 		// Task reporting timeouts via channel.
 		// TODO(gprusak): it would be better to expose t.tock directly,
 		// however the receiving task doesn't support receiving from AtomicWatch yet.
-		return t.tick.Iter(ctx, func(ctx context.Context, mto utils.Option[timeoutInfo]) error {
+		return t.tock.Iter(ctx, func(ctx context.Context, mto utils.Option[timeoutInfo]) error {
 			to, ok := mto.Get()
 			if !ok {
 				return nil

--- a/internal/consensus/ticker_test.go
+++ b/internal/consensus/ticker_test.go
@@ -1,0 +1,62 @@
+package consensus
+
+import (
+	"context"
+	"fmt"
+	"github.com/tendermint/tendermint/libs/log"
+	"github.com/tendermint/tendermint/libs/utils"
+	"github.com/tendermint/tendermint/libs/utils/scope"
+	"testing"
+	"time"
+)
+
+func TestTicker(t *testing.T) {
+	err := scope.Run(t.Context(), func(ctx context.Context, s scope.Scope) error {
+		logger, _ := log.NewDefaultLogger("plain", "debug")
+		ticker := NewTimeoutTicker(logger)
+		ch := ticker.Chan()
+		s.SpawnBg(func() error {
+			err := ticker.Run(ctx)
+			if ctx.Err() == nil {
+				return fmt.Errorf("ticker terminated with %v, before the test ended", err)
+			}
+			return utils.IgnoreCancel(err)
+		})
+		if got := len(ch); got > 0 {
+			return fmt.Errorf("expected empty, got len=%v", got)
+		}
+
+		t.Log("Fill the channel.")
+		h := int64(0)
+		for h < int64(cap(ch)) {
+			h += 1
+			ticker.ScheduleTimeout(timeoutInfo{Height: h, Duration: 0})
+			for len(ch) <= int(h) {
+				if err := utils.Sleep(ctx, 10*time.Millisecond); err != nil {
+					return err
+				}
+			}
+		}
+		t.Log("Add a bunch of timeouts blindly.")
+		for range 3 {
+			h += 1
+			ticker.ScheduleTimeout(timeoutInfo{Height: h, Duration: 0})
+			if err := utils.Sleep(ctx, 100*time.Millisecond); err != nil {
+				return err
+			}
+		}
+		t.Log("Await the latest timeout")
+		for {
+			got, err := utils.Recv(ctx, ch)
+			if err != nil {
+				return err
+			}
+			if got.Height == h {
+				return nil
+			}
+		}
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/consensus/ticker_test.go
+++ b/internal/consensus/ticker_test.go
@@ -31,7 +31,7 @@ func TestTicker(t *testing.T) {
 		for h < int64(cap(ch)) {
 			h += 1
 			ticker.ScheduleTimeout(timeoutInfo{Height: h, Duration: 0})
-			for len(ch) <= int(h) {
+			for len(ch) < int(h) {
 				if err := utils.Sleep(ctx, 10*time.Millisecond); err != nil {
 					return err
 				}

--- a/internal/p2p/router_test.go
+++ b/internal/p2p/router_test.go
@@ -338,6 +338,10 @@ func TestRouter_Channel_Error(t *testing.T) {
 	})
 }
 
+func waitUntilDone(args mock.Arguments) {
+	<-args.Get(0).(context.Context).Done()
+}
+
 func TestRouter_AcceptPeers(t *testing.T) {
 	testcases := map[string]struct {
 		peerInfo types.NodeInfo
@@ -380,7 +384,7 @@ func TestRouter_AcceptPeers(t *testing.T) {
 
 			mockTransport := &mocks.Transport{}
 			mockTransport.On("Accept", mock.Anything).Once().Return(mockConnection, nil)
-			mockTransport.On("Accept", mock.Anything).Maybe().Return(nil, context.Canceled)
+			mockTransport.On("Accept", mock.Anything).Maybe().Run(waitUntilDone).Return(nil, context.Canceled)
 			mockTransport.On("Run", mock.Anything).Return(nil)
 
 			// Set up and start the router.
@@ -436,7 +440,7 @@ func TestRouter_AcceptPeers_Errors(t *testing.T) {
 			// Set up a mock transport that returns io.EOF once, which should prevent
 			// the router from calling Accept again.
 			mockTransport := &mocks.Transport{}
-			mockTransport.On("Accept", mock.Anything).Once().Return(nil, context.Canceled)
+			mockTransport.On("Accept", mock.Anything).Once().Run(waitUntilDone).Return(nil, context.Canceled)
 			mockTransport.On("Run", mock.Anything).Return(nil)
 
 			// Set up and start the router.
@@ -488,7 +492,7 @@ func TestRouter_AcceptPeers_HeadOfLineBlocking(t *testing.T) {
 	mockTransport.On("Accept", mock.Anything).Times(3).Run(func(_ mock.Arguments) {
 		acceptCh <- true
 	}).Return(mockConnection, nil)
-	mockTransport.On("Accept", mock.Anything).Once().Return(nil, context.Canceled)
+	mockTransport.On("Accept", mock.Anything).Once().Run(waitUntilDone).Return(nil, context.Canceled)
 	mockTransport.On("Run", mock.Anything).Return(nil)
 
 	// Set up and start the router.
@@ -570,7 +574,7 @@ func TestRouter_DialPeers(t *testing.T) {
 
 			mockTransport := &mocks.Transport{}
 			mockTransport.On("Run", mock.Anything).Return(nil)
-			mockTransport.On("Accept", mock.Anything).Maybe().Return(nil, context.Canceled)
+			mockTransport.On("Accept", mock.Anything).Maybe().Run(waitUntilDone).Return(nil, context.Canceled)
 			if tc.dialErr == nil {
 				mockTransport.On("Dial", mock.Anything, endpoint).Once().Return(mockConnection, nil)
 				// This handles the retry when a dialed connection gets closed after ReceiveMessage
@@ -649,7 +653,7 @@ func TestRouter_DialPeers_Parallel(t *testing.T) {
 
 	mockTransport := &mocks.Transport{}
 	mockTransport.On("Run", mock.Anything).Return(nil)
-	mockTransport.On("Accept", mock.Anything).Once().Return(nil, context.Canceled)
+	mockTransport.On("Accept", mock.Anything).Once().Run(waitUntilDone).Return(nil, context.Canceled)
 	for _, address := range []p2p.NodeAddress{a, b, c} {
 		endpoint := p2p.Endpoint{Protocol: address.Protocol, Path: string(address.NodeID)}
 		mockTransport.On("Dial", mock.Anything, endpoint).Run(func(_ mock.Arguments) {
@@ -736,7 +740,7 @@ func TestRouter_EvictPeers(t *testing.T) {
 
 	mockTransport := &mocks.Transport{}
 	mockTransport.On("Accept", mock.Anything).Once().Return(mockConnection, nil)
-	mockTransport.On("Accept", mock.Anything).Maybe().Return(nil, context.Canceled)
+	mockTransport.On("Accept", mock.Anything).Maybe().Run(waitUntilDone).Return(nil, context.Canceled)
 	mockTransport.On("Run", mock.Anything).Return(nil)
 
 	// Set up and start the router.
@@ -798,7 +802,7 @@ func TestRouter_ChannelCompatability(t *testing.T) {
 	mockTransport := &mocks.Transport{}
 	mockTransport.On("Run", mock.Anything).Return(nil)
 	mockTransport.On("Accept", mock.Anything).Once().Return(mockConnection, nil)
-	mockTransport.On("Accept", mock.Anything).Once().Return(nil, context.Canceled)
+	mockTransport.On("Accept", mock.Anything).Once().Run(waitUntilDone).Return(nil, context.Canceled)
 
 	// Set up and start the router.
 	peerManager, err := p2p.NewPeerManager(log.NewNopLogger(), selfID, dbm.NewMemDB(), p2p.PeerManagerOptions{}, p2p.NopMetrics())
@@ -847,7 +851,7 @@ func TestRouter_DontSendOnInvalidChannel(t *testing.T) {
 	mockTransport := &mocks.Transport{}
 	mockTransport.On("AddChannelDescriptors", mock.Anything).Return()
 	mockTransport.On("Accept", mock.Anything).Once().Return(mockConnection, nil)
-	mockTransport.On("Accept", mock.Anything).Maybe().Return(nil, context.Canceled)
+	mockTransport.On("Accept", mock.Anything).Maybe().Run(waitUntilDone).Return(nil, context.Canceled)
 	mockTransport.On("Run", mock.Anything).Return(nil)
 
 	// Set up and start the router.
@@ -912,7 +916,7 @@ func TestRouter_Channel_FilterByID(t *testing.T) {
 	mockTransport.On("AddChannelDescriptors", mock.Anything).Return()
 	mockTransport.On("String").Maybe().Return("mock")
 	mockTransport.On("Accept", mock.Anything).Once().Return(mockConnection, nil)
-	mockTransport.On("Accept", mock.Anything).Maybe().Return(nil, context.Canceled)
+	mockTransport.On("Accept", mock.Anything).Maybe().Run(waitUntilDone).Return(nil, context.Canceled)
 	mockTransport.On("Run", mock.Anything).Return(nil)
 
 	peerManager, err := p2p.NewPeerManager(log.NewNopLogger(), selfID, dbm.NewMemDB(), p2p.PeerManagerOptions{}, p2p.NopMetrics())

--- a/libs/service/service.go
+++ b/libs/service/service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"github.com/tendermint/tendermint/libs/log"
 	"github.com/tendermint/tendermint/libs/utils"
@@ -165,9 +166,9 @@ func (bs *BaseService) Spawn(name string, task func(ctx context.Context) error) 
 	}()
 }
 
-// Spawns a critical task which should run as long as the service is running.
+// Spawns a critical task which should run until success OR as long as the service is running.
 // It panics in any of the following cases:
-// * task returns BEFORE the service is canceled (even if it returns no error)
+// * task returns context.Canceled BEFORE the service is canceled.
 // * task returns an error other than context.Canceled.
 func (bs *BaseService) SpawnCritical(name string, task func(ctx context.Context) error) {
 	inner := bs.inner.Load()
@@ -178,8 +179,10 @@ func (bs *BaseService) SpawnCritical(name string, task func(ctx context.Context)
 	inner.wg.Add(1)
 	go func() {
 		defer inner.wg.Done()
-		if err := task(inner.ctx); utils.IgnoreCancel(err) != nil || inner.ctx.Err() == nil {
-			panic(fmt.Sprintf("critical task failed: name=%v, service=%v: %v", name, bs.name, err))
+		if err := task(inner.ctx); err != nil {
+			if !errors.Is(err, context.Canceled) || inner.ctx.Err() == nil {
+				panic(fmt.Sprintf("critical task failed: name=%v, service=%v: %v", name, bs.name, err))
+			}
 		}
 	}()
 }

--- a/libs/service/service.go
+++ b/libs/service/service.go
@@ -165,6 +165,10 @@ func (bs *BaseService) Spawn(name string, task func(ctx context.Context) error) 
 	}()
 }
 
+// Spawns a critical task which should run as long as the service is running.
+// It panics in any of the following cases:
+// * task returns BEFORE the service is canceled (even if it returns no error)
+// * task returns an error other than context.Canceled.
 func (bs *BaseService) SpawnCritical(name string, task func(ctx context.Context) error) {
 	inner := bs.inner.Load()
 	if inner == nil {
@@ -174,7 +178,7 @@ func (bs *BaseService) SpawnCritical(name string, task func(ctx context.Context)
 	inner.wg.Add(1)
 	go func() {
 		defer inner.wg.Done()
-		if err := utils.IgnoreCancel(task(inner.ctx)); err != nil {
+		if err := task(inner.ctx); utils.IgnoreCancel(err) != nil || inner.ctx.Err() == nil {
 			panic(fmt.Sprintf("critical task failed: name=%v, service=%v: %v", name, bs.name, err))
 		}
 	}()


### PR DESCRIPTION
timeoutTicker should be a long running task. Due to a bug (context shadowing), the task was terminating early if all the following conditions occurred at the same time:
* timeout happened
* output channel is full (task reporting the timeout is blocked)
* new timeout arrived on the input channel


Fix simplifies the timeout management by spawning 2 long running tasks (instead of task per timeout). Additionally:
* A test was added specifically to detect early exit of the ticker task.
* timeoutTicker task is now spawned via Service.SpawnCritical (instead of Service.Spawn), which panics in case the task fails instead of just logging an error.
* Service.SpawnCritical now panics in case the spawned task terminates with context.Canceled before the service is canceled (it used to be silently ignored, equivalent to a task success). This is a temporary measure until the Service is replaced by structured concurrency altogether.