### PR TITLE
reverted semantics of ParseAddressString

### DIFF
--- a/internal/p2p/transport.go
+++ b/internal/p2p/transport.go
@@ -117,7 +117,7 @@ type Endpoint struct {
 
 // NewEndpoint constructs an Endpoint from a types.NetAddress structure.
 func NewEndpoint(addr string) (Endpoint, error) {
-	addrPort, err := types.ParseAddressString(addr)
+	addrPort, err := types.ResolveAddressString(addr)
 	if err != nil {
 		return Endpoint{}, err
 	}

--- a/types/node_info.go
+++ b/types/node_info.go
@@ -250,8 +250,8 @@ func ResolveAddressString(addr string) (netip.AddrPort, error) {
 		return netip.AddrPort{}, err
 	}
 
-	tcpAddr,err := net.ResolveTCPAddr("tcp", spl[1])
-	if err!=nil {
+	tcpAddr, err := net.ResolveTCPAddr("tcp", spl[1])
+	if err != nil {
 		return netip.AddrPort{}, err
 	}
 	return tcpAddr.AddrPort(), nil

--- a/types/node_info.go
+++ b/types/node_info.go
@@ -3,6 +3,7 @@ package types
 import (
 	"errors"
 	"fmt"
+	"net"
 	"net/netip"
 	"strings"
 
@@ -76,7 +77,7 @@ func (info NodeInfo) ID() NodeID {
 // url-encoding), and we just need to be careful with how we handle that in our
 // clients. (e.g. off by default).
 func (info NodeInfo) Validate() error {
-	if _, err := ParseAddressString(info.ID().AddressString(info.ListenAddr)); err != nil {
+	if _, err := ResolveAddressString(info.ID().AddressString(info.ListenAddr)); err != nil {
 		return err
 	}
 
@@ -232,10 +233,8 @@ func NodeInfoFromProto(pb *tmp2p.NodeInfo) (NodeInfo, error) {
 	return dni, nil
 }
 
-// ParseAddressString reads an address string, and returns the IP
-// address and port information, returning an error for any validation
-// errors.
-func ParseAddressString(addr string) (netip.AddrPort, error) {
+// ResolveAddressString resolves the TCP address from the node address string.
+func ResolveAddressString(addr string) (netip.AddrPort, error) {
 	addrWithoutProtocol := removeProtocolIfDefined(addr)
 	spl := strings.Split(addrWithoutProtocol, "@")
 	if len(spl) != 2 {
@@ -250,7 +249,12 @@ func ParseAddressString(addr string) (netip.AddrPort, error) {
 	if err := id.Validate(); err != nil {
 		return netip.AddrPort{}, err
 	}
-	return netip.ParseAddrPort(spl[1])
+
+	tcpAddr,err := net.ResolveTCPAddr("tcp", spl[1])
+	if err!=nil {
+		return netip.AddrPort{}, err
+	}
+	return tcpAddr.AddrPort(), nil
 }
 
 func removeProtocolIfDefined(addr string) string {

--- a/types/node_info_test.go
+++ b/types/node_info_test.go
@@ -178,7 +178,7 @@ func TestNodeInfoAddChannel(t *testing.T) {
 	require.Contains(t, nodeInfo.Channels, byte(0x02))
 }
 
-func TestParseAddressString(t *testing.T) {
+func TestResolveAddressString(t *testing.T) {
 	testCases := []struct {
 		name     string
 		addr     string
@@ -242,7 +242,7 @@ func TestParseAddressString(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			addr, err := ParseAddressString(tc.addr)
+			addr, err := ResolveAddressString(tc.addr)
 			if tc.correct {
 				require.NoError(t, err, tc.addr)
 				assert.Contains(t, tc.expected, addr.String())


### PR DESCRIPTION
https://github.com/sei-protocol/sei-tendermint/pull/308 has accidentally changed the semantics of ParseAddressString from resolving the tcp address to parsing tcp address. As a side effect, support for DNS names in the config has been removed.

This PR reverts to the original semantics to support DNS names again. Also renamed the functions to better describe what they do.
