### PR TITLE
fix: nil check before WrappedExtendedCommit in gossipVotesRoutine

### DIFF
--- a/internal/consensus/reactor.go
+++ b/internal/consensus/reactor.go
@@ -799,7 +799,10 @@ func (r *Reactor) gossipVotesRoutine(ctx context.Context, ps *PeerState, voteCh 
 			if r.state.state.ConsensusParams.ABCI.VoteExtensionsEnabled(prs.Height) {
 				ec = r.state.blockStore.LoadBlockExtendedCommit(prs.Height)
 			} else {
-				ec = r.state.blockStore.LoadBlockCommit(prs.Height).WrappedExtendedCommit()
+				commit := r.state.blockStore.LoadBlockCommit(prs.Height)
+				if commit != nil {
+					ec = commit.WrappedExtendedCommit()
+				}
 			}
 			r.state.mtx.RUnlock()
 			if ec == nil {

--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -431,10 +431,7 @@ func (cs *State) OnStart(ctx context.Context) error {
 
 	// we need the timeoutRoutine for replay so
 	// we don't block on the tick chan.
-	// NOTE: we will get a build up of garbage go routines
-	// firing on the tockChan until the receiveRoutine is started
-	// to deal with them (by that point, at most one will be valid)
-	cs.Spawn("timeoutTicker", cs.timeoutTicker.Run)
+	cs.SpawnCritical("timeoutTicker", cs.timeoutTicker.Run)
 
 	// We may have lost some votes if the process crashed reload from consensus
 	// log to catchup.

--- a/internal/consensus/ticker_test.go
+++ b/internal/consensus/ticker_test.go
@@ -1,0 +1,62 @@
+package consensus
+
+import (
+	"context"
+	"fmt"
+	"github.com/tendermint/tendermint/libs/log"
+	"github.com/tendermint/tendermint/libs/utils"
+	"github.com/tendermint/tendermint/libs/utils/scope"
+	"testing"
+	"time"
+)
+
+func TestTicker(t *testing.T) {
+	err := scope.Run(t.Context(), func(ctx context.Context, s scope.Scope) error {
+		logger, _ := log.NewDefaultLogger("plain", "debug")
+		ticker := NewTimeoutTicker(logger)
+		ch := ticker.Chan()
+		s.SpawnBg(func() error {
+			err := ticker.Run(ctx)
+			if ctx.Err() == nil {
+				return fmt.Errorf("ticker terminated with %v, before the test ended", err)
+			}
+			return utils.IgnoreCancel(err)
+		})
+		if got := len(ch); got > 0 {
+			return fmt.Errorf("expected empty, got len=%v", got)
+		}
+
+		t.Log("Fill the channel.")
+		h := int64(0)
+		for h < int64(cap(ch)) {
+			h += 1
+			ticker.ScheduleTimeout(timeoutInfo{Height: h, Duration: 0})
+			for len(ch) < int(h) {
+				if err := utils.Sleep(ctx, 10*time.Millisecond); err != nil {
+					return err
+				}
+			}
+		}
+		t.Log("Add a bunch of timeouts blindly.")
+		for range 3 {
+			h += 1
+			ticker.ScheduleTimeout(timeoutInfo{Height: h, Duration: 0})
+			if err := utils.Sleep(ctx, 100*time.Millisecond); err != nil {
+				return err
+			}
+		}
+		t.Log("Await the latest timeout")
+		for {
+			got, err := utils.Recv(ctx, ch)
+			if err != nil {
+				return err
+			}
+			if got.Height == h {
+				return nil
+			}
+		}
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/p2p/router_test.go
+++ b/internal/p2p/router_test.go
@@ -338,6 +338,10 @@ func TestRouter_Channel_Error(t *testing.T) {
 	})
 }
 
+func waitUntilDone(args mock.Arguments) {
+	<-args.Get(0).(context.Context).Done()
+}
+
 func TestRouter_AcceptPeers(t *testing.T) {
 	testcases := map[string]struct {
 		peerInfo types.NodeInfo
@@ -380,7 +384,7 @@ func TestRouter_AcceptPeers(t *testing.T) {
 
 			mockTransport := &mocks.Transport{}
 			mockTransport.On("Accept", mock.Anything).Once().Return(mockConnection, nil)
-			mockTransport.On("Accept", mock.Anything).Maybe().Return(nil, context.Canceled)
+			mockTransport.On("Accept", mock.Anything).Maybe().Run(waitUntilDone).Return(nil, context.Canceled)
 			mockTransport.On("Run", mock.Anything).Return(nil)
 
 			// Set up and start the router.
@@ -436,7 +440,7 @@ func TestRouter_AcceptPeers_Errors(t *testing.T) {
 			// Set up a mock transport that returns io.EOF once, which should prevent
 			// the router from calling Accept again.
 			mockTransport := &mocks.Transport{}
-			mockTransport.On("Accept", mock.Anything).Once().Return(nil, context.Canceled)
+			mockTransport.On("Accept", mock.Anything).Once().Run(waitUntilDone).Return(nil, context.Canceled)
 			mockTransport.On("Run", mock.Anything).Return(nil)
 
 			// Set up and start the router.
@@ -488,7 +492,7 @@ func TestRouter_AcceptPeers_HeadOfLineBlocking(t *testing.T) {
 	mockTransport.On("Accept", mock.Anything).Times(3).Run(func(_ mock.Arguments) {
 		acceptCh <- true
 	}).Return(mockConnection, nil)
-	mockTransport.On("Accept", mock.Anything).Once().Return(nil, context.Canceled)
+	mockTransport.On("Accept", mock.Anything).Once().Run(waitUntilDone).Return(nil, context.Canceled)
 	mockTransport.On("Run", mock.Anything).Return(nil)
 
 	// Set up and start the router.
@@ -570,7 +574,7 @@ func TestRouter_DialPeers(t *testing.T) {
 
 			mockTransport := &mocks.Transport{}
 			mockTransport.On("Run", mock.Anything).Return(nil)
-			mockTransport.On("Accept", mock.Anything).Maybe().Return(nil, context.Canceled)
+			mockTransport.On("Accept", mock.Anything).Maybe().Run(waitUntilDone).Return(nil, context.Canceled)
 			if tc.dialErr == nil {
 				mockTransport.On("Dial", mock.Anything, endpoint).Once().Return(mockConnection, nil)
 				// This handles the retry when a dialed connection gets closed after ReceiveMessage
@@ -649,7 +653,7 @@ func TestRouter_DialPeers_Parallel(t *testing.T) {
 
 	mockTransport := &mocks.Transport{}
 	mockTransport.On("Run", mock.Anything).Return(nil)
-	mockTransport.On("Accept", mock.Anything).Once().Return(nil, context.Canceled)
+	mockTransport.On("Accept", mock.Anything).Once().Run(waitUntilDone).Return(nil, context.Canceled)
 	for _, address := range []p2p.NodeAddress{a, b, c} {
 		endpoint := p2p.Endpoint{Protocol: address.Protocol, Path: string(address.NodeID)}
 		mockTransport.On("Dial", mock.Anything, endpoint).Run(func(_ mock.Arguments) {
@@ -736,7 +740,7 @@ func TestRouter_EvictPeers(t *testing.T) {
 
 	mockTransport := &mocks.Transport{}
 	mockTransport.On("Accept", mock.Anything).Once().Return(mockConnection, nil)
-	mockTransport.On("Accept", mock.Anything).Maybe().Return(nil, context.Canceled)
+	mockTransport.On("Accept", mock.Anything).Maybe().Run(waitUntilDone).Return(nil, context.Canceled)
 	mockTransport.On("Run", mock.Anything).Return(nil)
 
 	// Set up and start the router.
@@ -798,7 +802,7 @@ func TestRouter_ChannelCompatability(t *testing.T) {
 	mockTransport := &mocks.Transport{}
 	mockTransport.On("Run", mock.Anything).Return(nil)
 	mockTransport.On("Accept", mock.Anything).Once().Return(mockConnection, nil)
-	mockTransport.On("Accept", mock.Anything).Once().Return(nil, context.Canceled)
+	mockTransport.On("Accept", mock.Anything).Once().Run(waitUntilDone).Return(nil, context.Canceled)
 
 	// Set up and start the router.
 	peerManager, err := p2p.NewPeerManager(log.NewNopLogger(), selfID, dbm.NewMemDB(), p2p.PeerManagerOptions{}, p2p.NopMetrics())
@@ -847,7 +851,7 @@ func TestRouter_DontSendOnInvalidChannel(t *testing.T) {
 	mockTransport := &mocks.Transport{}
 	mockTransport.On("AddChannelDescriptors", mock.Anything).Return()
 	mockTransport.On("Accept", mock.Anything).Once().Return(mockConnection, nil)
-	mockTransport.On("Accept", mock.Anything).Maybe().Return(nil, context.Canceled)
+	mockTransport.On("Accept", mock.Anything).Maybe().Run(waitUntilDone).Return(nil, context.Canceled)
 	mockTransport.On("Run", mock.Anything).Return(nil)
 
 	// Set up and start the router.
@@ -912,7 +916,7 @@ func TestRouter_Channel_FilterByID(t *testing.T) {
 	mockTransport.On("AddChannelDescriptors", mock.Anything).Return()
 	mockTransport.On("String").Maybe().Return("mock")
 	mockTransport.On("Accept", mock.Anything).Once().Return(mockConnection, nil)
-	mockTransport.On("Accept", mock.Anything).Maybe().Return(nil, context.Canceled)
+	mockTransport.On("Accept", mock.Anything).Maybe().Run(waitUntilDone).Return(nil, context.Canceled)
 	mockTransport.On("Run", mock.Anything).Return(nil)
 
 	peerManager, err := p2p.NewPeerManager(log.NewNopLogger(), selfID, dbm.NewMemDB(), p2p.PeerManagerOptions{}, p2p.NopMetrics())

--- a/internal/p2p/transport.go
+++ b/internal/p2p/transport.go
@@ -117,7 +117,7 @@ type Endpoint struct {
 
 // NewEndpoint constructs an Endpoint from a types.NetAddress structure.
 func NewEndpoint(addr string) (Endpoint, error) {
-	addrPort, err := types.ParseAddressString(addr)
+	addrPort, err := types.ResolveAddressString(addr)
 	if err != nil {
 		return Endpoint{}, err
 	}

--- a/types/node_info.go
+++ b/types/node_info.go
@@ -3,6 +3,7 @@ package types
 import (
 	"errors"
 	"fmt"
+	"net"
 	"net/netip"
 	"strings"
 
@@ -76,7 +77,7 @@ func (info NodeInfo) ID() NodeID {
 // url-encoding), and we just need to be careful with how we handle that in our
 // clients. (e.g. off by default).
 func (info NodeInfo) Validate() error {
-	if _, err := ParseAddressString(info.ID().AddressString(info.ListenAddr)); err != nil {
+	if _, err := ResolveAddressString(info.ID().AddressString(info.ListenAddr)); err != nil {
 		return err
 	}
 
@@ -232,10 +233,8 @@ func NodeInfoFromProto(pb *tmp2p.NodeInfo) (NodeInfo, error) {
 	return dni, nil
 }
 
-// ParseAddressString reads an address string, and returns the IP
-// address and port information, returning an error for any validation
-// errors.
-func ParseAddressString(addr string) (netip.AddrPort, error) {
+// ResolveAddressString resolves the TCP address from the node address string.
+func ResolveAddressString(addr string) (netip.AddrPort, error) {
 	addrWithoutProtocol := removeProtocolIfDefined(addr)
 	spl := strings.Split(addrWithoutProtocol, "@")
 	if len(spl) != 2 {
@@ -250,7 +249,12 @@ func ParseAddressString(addr string) (netip.AddrPort, error) {
 	if err := id.Validate(); err != nil {
 		return netip.AddrPort{}, err
 	}
-	return netip.ParseAddrPort(spl[1])
+
+	tcpAddr, err := net.ResolveTCPAddr("tcp", spl[1])
+	if err != nil {
+		return netip.AddrPort{}, err
+	}
+	return tcpAddr.AddrPort(), nil
 }
 
 func removeProtocolIfDefined(addr string) string {

--- a/types/node_info_test.go
+++ b/types/node_info_test.go
@@ -178,7 +178,7 @@ func TestNodeInfoAddChannel(t *testing.T) {
 	require.Contains(t, nodeInfo.Channels, byte(0x02))
 }
 
-func TestParseAddressString(t *testing.T) {
+func TestResolveAddressString(t *testing.T) {
 	testCases := []struct {
 		name     string
 		addr     string
@@ -242,7 +242,7 @@ func TestParseAddressString(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			addr, err := ParseAddressString(tc.addr)
+			addr, err := ResolveAddressString(tc.addr)
 			if tc.correct {
 				require.NoError(t, err, tc.addr)
 				assert.Contains(t, tc.expected, addr.String())


### PR DESCRIPTION
## Summary

Fixes nil pointer dereference panic in `gossipVotesRoutine` when `LoadBlockCommit` returns nil.

## Problem

In v0.6.7, `LoadBlockCommit(prs.Height).WrappedExtendedCommit()` panics when `LoadBlockCommit` returns nil (race condition during peer catchup).

```
panic: runtime error: invalid memory address or nil pointer dereference
github.com/tendermint/tendermint/types.(*Commit).WrappedExtendedCommit(...)
github.com/tendermint/tendermint/internal/consensus.(*Reactor).gossipVotesRoutine
```

## Fix

Add nil check before calling `WrappedExtendedCommit()`. The existing `ec == nil` check then handles it gracefully.